### PR TITLE
Add trusted npm publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,38 @@
+name: Publish npm package
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    if: github.repository == 'sgateway/s-gw'
+    runs-on: ubuntu-latest
+    environment: npm
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      SGW_E2E_CHROME: /usr/bin/google-chrome
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+
+      - run: rustup toolchain install 1.96.1 --profile minimal --component rustfmt,clippy
+      - run: npm ci --ignore-scripts
+      - run: npm run verify
+
+      - name: Verify release version
+        run: |
+          package_version="$(node -p "require('./package.json').version")"
+          test "v${package_version}" = "${GITHUB_REF_NAME}"
+
+      - run: npm publish --access public


### PR DESCRIPTION
Adds an OIDC-based npm publish workflow for @s-gw/s-gw. Publishes only from GitHub releases after verification and does not use a stored npm token.