### PR TITLE
Add official MCP Registry metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ Notable changes to s-gw are documented here. The project follows [Semantic Versi
 
 ## Unreleased
 
+## 0.1.1 - 2026-07-10
+
+### Added
+
+- Official MCP Registry metadata for discovery and one-command launch through npm.
+- `s-gw mcp` as a primary CLI entry point for the stdio MCP server.
+
+### Changed
+
+- MCP server version reporting now stays aligned with the package version.
+
 ## 0.1.0 - 2026-07-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The agent never needs the unlock passphrase or raw credential. Approval is scope
 | Surface | Purpose |
 | --- | --- |
 | `s-gw` CLI | Setup, credential enrollment, approvals, policies, agent snippets, guard mode, and diagnostics. |
-| `s-gw-mcp` | Stdio MCP server for agent-facing handle discovery and request creation. |
+| `s-gw-mcp` / `s-gw mcp` | Stdio MCP server for agent-facing handle discovery and request creation. |
 | Native macOS app | Approval queue, credential inventory, policy rules, usage flow, activity, and audit review. |
 | Menu-bar helper | Fast visibility into pending approvals and local daemon status. |
 | Local web console | Browser-accessible fallback UI bound to `127.0.0.1`. |

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -40,10 +40,11 @@ Do not describe the macOS DMG as a production download until the application, he
 1. Create an annotated `vX.Y.Z` tag from a green `main` commit.
 2. Publish the public scoped package with `npm publish --access public`.
 3. Verify `npm view @s-gw/s-gw@X.Y.Z version` and install it in a clean npm prefix.
-4. Create a GitHub release using the matching changelog entry.
-5. Attach signed platform artifacts, the npm tarball, and `SHA256SUMS.txt`.
-6. Verify checksums from a clean download.
-7. Install the release on clean macOS and Windows test accounts.
-8. Confirm the update checker sees the release and opens the correct notes.
+4. Validate `server.json`, then publish it with `mcp-publisher publish` after the npm version is live.
+5. Create a GitHub release using the matching changelog entry.
+6. Attach signed platform artifacts, the npm tarball, and `SHA256SUMS.txt`.
+7. Verify checksums from a clean download.
+8. Install the release on clean macOS and Windows test accounts.
+9. Confirm the update checker sees the release and opens the correct notes.
 
 If signing is not available, label installers as preview artifacts and state the signing and notarization limitations in the release notes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@s-gw/s-gw",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@s-gw/s-gw",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@s-gw/s-gw",
-  "version": "0.1.0",
+  "version": "0.1.1",
+  "mcpName": "io.github.sgateway/s-gw",
   "description": "Local credential control for AI coding agents.",
   "type": "module",
   "repository": {
@@ -28,6 +29,7 @@
     "LICENSE",
     "NOTICE",
     "TRADEMARKS.md",
+    "server.json",
     ".codex-plugin",
     ".mcp.json",
     "skills",
@@ -65,8 +67,12 @@
   },
   "keywords": [
     "mcp",
+    "mcp-server",
+    "model-context-protocol",
     "secrets",
+    "secrets-management",
     "credential-security",
+    "agent-security",
     "local-first",
     "ai-agents",
     "codex",

--- a/server.json
+++ b/server.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.sgateway/s-gw",
+  "title": "s-gw",
+  "description": "Keep credentials out of AI coding agents with local approvals, scoped injection, and audit trails.",
+  "websiteUrl": "https://s-gw.com",
+  "icons": [
+    {
+      "src": "https://raw.githubusercontent.com/sgateway/s-gw/main/assets/icons/s-gw-128.png",
+      "mimeType": "image/png",
+      "sizes": ["128x128"]
+    }
+  ],
+  "repository": {
+    "url": "https://github.com/sgateway/s-gw",
+    "source": "github"
+  },
+  "version": "0.1.1",
+  "packages": [
+    {
+      "registryType": "npm",
+      "registryBaseUrl": "https://registry.npmjs.org",
+      "identifier": "@s-gw/s-gw",
+      "version": "0.1.1",
+      "runtimeHint": "npx",
+      "runtimeArguments": [
+        {
+          "type": "positional",
+          "value": "-y"
+        }
+      ],
+      "packageArguments": [
+        {
+          "type": "positional",
+          "value": "mcp"
+        }
+      ],
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -57,13 +57,19 @@ interface ParsedArgs {
 
 async function main(): Promise<void> {
   const parsed = parseArgs(process.argv.slice(2));
-  const store = new SecretStore();
   const [first, second, third] = parsed.command;
 
   if (!first || first === "help" || first === "--help") {
     printHelp();
     return;
   }
+
+  if (first === "mcp") {
+    await import("./mcp-server.js");
+    return;
+  }
+
+  const store = new SecretStore();
 
   if (first === "init") {
     await store.init();
@@ -1686,6 +1692,7 @@ Commands:
   s-gw stop
   s-gw doctor
   s-gw update check [--force]
+  s-gw mcp
   s-gw console [--host 127.0.0.1] [--port 8718] [--no-open]
   s-gw app app-path
   s-gw app open [--port 8718] [--console-url URL]

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -6,11 +6,12 @@ import { executeApprovedRequest } from "./executor.js";
 import { buildEnvCommandAction, buildSshSessionAction, scanLocalFile, scanLocalText } from "./gateway.js";
 import { SecretStore } from "./store.js";
 import { defaultSshInjectEnv } from "./ssh.js";
+import { CURRENT_VERSION } from "./version.js";
 
 const store = new SecretStore();
 const server = new McpServer({
   name: "s-gw",
-  version: "0.1.0"
+  version: CURRENT_VERSION
 });
 
 function mcpAgentContext() {

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const CURRENT_VERSION = "0.1.0";
+export const CURRENT_VERSION = "0.1.1";

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -6,6 +6,7 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { KNOWN_COMMANDS, suggestCommands, unknownCommandMessage } from "../src/command-suggest.js";
+import { CURRENT_VERSION } from "../src/version.js";
 
 const repoRoot = process.cwd();
 const tsxBin = path.join(repoRoot, "node_modules", ".bin", process.platform === "win32" ? "tsx.cmd" : "tsx");
@@ -73,7 +74,7 @@ describe("CLI unknown-command behavior (end to end)", () => {
 
     expect(result).toMatchObject({
       checked: false,
-      currentVersion: "0.1.0",
+      currentVersion: CURRENT_VERSION,
       available: false
     });
   });

--- a/tests/mcp-e2e.test.ts
+++ b/tests/mcp-e2e.test.ts
@@ -29,6 +29,25 @@ afterEach(async () => {
 });
 
 describe("MCP end-to-end flow", () => {
+  it("starts through the primary CLI", async () => {
+    const transport = new StdioClientTransport({
+      command: tsxBin,
+      args: ["src/cli.ts", "mcp"],
+      cwd: repoRoot,
+      env: testEnv as Record<string, string>,
+      stderr: "pipe"
+    });
+    const client = new Client({ name: "codex-mcp-client", version: "0.0.1" });
+
+    await client.connect(transport);
+    try {
+      const tools = await client.listTools();
+      expect(tools.tools.map((tool) => tool.name)).toContain("sgw_request_execution");
+    } finally {
+      await client.close();
+    }
+  });
+
   it("denies execution before approval and returns sanitized output after approval", async () => {
     runCli(["init"]);
     const addPayload = JSON.parse(


### PR DESCRIPTION
## Summary

- add official MCP Registry metadata and npm ownership metadata
- expose `s-gw mcp` for registry-managed stdio launch
- prepare the 0.1.1 patch release and document Registry publishing order

## Verification

- `npm run verify` (26 test files, 171 tests, Rust fmt/Clippy/tests, zero npm audit findings, package dry-run)
- `server.json` validated against the official 2025-12-11 Registry schema