### PR TITLE
Publish releases to the MCP Registry

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish npm package
+name: Publish release
 
 on:
   release:
@@ -36,3 +36,28 @@ jobs:
           test "v${package_version}" = "${GITHUB_REF_NAME}"
 
       - run: npm publish --access public
+
+      - name: Verify npm publication
+        run: |
+          package_version="$(node -p "require('./package.json').version")"
+          for _ in 1 2 3 4 5 6; do
+            if npm view "@s-gw/s-gw@${package_version}" version; then
+              exit 0
+            fi
+            sleep 10
+          done
+          exit 1
+
+      - name: Install MCP Registry publisher
+        run: |
+          curl -fsSL \
+            https://github.com/modelcontextprotocol/registry/releases/download/v1.7.9/mcp-publisher_linux_amd64.tar.gz \
+            -o mcp-publisher.tar.gz
+          echo "ab128162b0616090b47cf245afe0a23f3ef08936fdce19074f5ba0a4469281ac  mcp-publisher.tar.gz" | sha256sum -c -
+          tar -xzf mcp-publisher.tar.gz mcp-publisher
+          chmod +x mcp-publisher
+
+      - name: Publish to the official MCP Registry
+        run: |
+          ./mcp-publisher login github-oidc
+          ./mcp-publisher publish server.json


### PR DESCRIPTION
## Summary

- publish the official MCP Registry entry from the existing release workflow
- authenticate to the Registry with GitHub OIDC instead of a long-lived token
- pin and checksum-verify mcp-publisher 1.7.9
- wait for the npm version to become readable before Registry validation

## Verification

- `actionlint .github/workflows/publish.yml`
- downloaded publisher archive matched the official SHA-256 and contained the expected binary
- `git diff --check`