### PR TITLE
Allow manual MCP Registry publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,7 @@ name: Publish release
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -31,11 +32,14 @@ jobs:
       - run: npm run verify
 
       - name: Verify release version
+        if: github.event_name == 'release'
         run: |
           package_version="$(node -p "require('./package.json').version")"
           test "v${package_version}" = "${GITHUB_REF_NAME}"
 
-      - run: npm publish --access public
+      - name: Publish to npm
+        if: github.event_name == 'release'
+        run: npm publish --access public
 
       - name: Verify npm publication
         run: |


### PR DESCRIPTION
Add a workflow_dispatch recovery path for publishing existing npm versions to the official MCP Registry. Manual runs keep the full verification and npm-visibility checks but skip tag validation and npm publishing.

Verification: npm run verify (26 files, 171 tests; Rust checks/tests; npm audit; package dry run)