### PR TITLE
Fix release asset runner

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,13 +4,18 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Existing release tag to rebuild assets for
+        required: false
+        type: string
 
 permissions:
   contents: read
 
 jobs:
   publish:
-    if: github.repository == 'sgateway/s-gw'
+    if: github.repository == 'sgateway/s-gw' && (github.event_name == 'release' || inputs.release_tag == '')
     runs-on: ubuntu-latest
     environment: npm
     permissions:
@@ -67,12 +72,16 @@ jobs:
           ./mcp-publisher publish server.json
 
   release-assets:
-    if: github.event_name == 'release' && github.repository == 'sgateway/s-gw'
+    if: github.repository == 'sgateway/s-gw' && (github.event_name == 'release' || inputs.release_tag != '')
     runs-on: macos-15
     permissions:
       contents: write
+    env:
+      RELEASE_TAG: ${{ github.event_name == 'release' && github.ref_name || inputs.release_tag }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ env.RELEASE_TAG }}
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
@@ -85,7 +94,7 @@ jobs:
       - name: Verify release asset version
         run: |
           package_version="$(node -p "require('./package.json').version")"
-          test "v${package_version}" = "${GITHUB_REF_NAME}"
+          test "v${package_version}" = "${RELEASE_TAG}"
 
       - run: npm run verify
       - run: npm run build:installers
@@ -98,20 +107,20 @@ jobs:
           bridge="dist/installers/0-s-gw-legacy-${package_version}.tgz"
 
           for asset in dist/installers/*; do
-            gh release delete-asset "$GITHUB_REF_NAME" "$(basename "$asset")" --yes >/dev/null 2>&1 || true
+            gh release delete-asset "$RELEASE_TAG" "$(basename "$asset")" --yes >/dev/null 2>&1 || true
           done
 
           for checksum in dist/installers/*.sha256 dist/installers/SHA256SUMS.txt; do
-            gh release upload "$GITHUB_REF_NAME" "$checksum"
+            gh release upload "$RELEASE_TAG" "$checksum"
           done
 
-          gh release upload "$GITHUB_REF_NAME" "$bridge"
+          gh release upload "$RELEASE_TAG" "$bridge"
           for asset in dist/installers/*; do
             case "$asset" in
               "$bridge"|*.sha256|*/SHA256SUMS.txt) continue ;;
             esac
-            gh release upload "$GITHUB_REF_NAME" "$asset"
+            gh release upload "$RELEASE_TAG" "$asset"
           done
 
-          first_tgz="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${GITHUB_REF_NAME}" --jq '[.assets[] | select(.name | endswith(".tgz"))][0].name')"
+          first_tgz="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}" --jq '[.assets[] | select(.name | endswith(".tgz"))][0].name')"
           test "$first_tgz" = "$(basename "$bridge")"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,7 +68,7 @@ jobs:
 
   release-assets:
     if: github.event_name == 'release' && github.repository == 'sgateway/s-gw'
-    runs-on: macos-14
+    runs-on: macos-15
     permissions:
       contents: write
     steps:

--- a/tests/installers.test.ts
+++ b/tests/installers.test.ts
@@ -128,7 +128,10 @@ describe("platform installers", () => {
     ]);
     const assetJob = workflow.slice(workflow.indexOf("  release-assets:"));
 
-    expect(assetJob).toContain("runs-on: macos-14");
+    expect(assetJob).toContain("runs-on: macos-15");
+    expect(workflow).toContain("release_tag:");
+    expect(assetJob).toContain("inputs.release_tag != ''");
+    expect(assetJob).toContain("ref: ${{ env.RELEASE_TAG }}");
     expect(assetJob).toContain("npm run verify");
     expect(assetJob).toContain("npm run build:installers");
     expect(assetJob).toContain("first_tgz");


### PR DESCRIPTION
The v0.1.2 release asset job exposed a runner mismatch: the Swift packages require Swift 6, while macos-14 provides Swift 5.10.

- Use the same macos-15 arm64 runner already exercised by native CI.
- Add a release_tag workflow-dispatch input so assets for an immutable existing tag can be rebuilt without republishing npm or MCP packages.

Verification:
- actionlint .github/workflows/publish.yml
- git diff --check