### PR TITLE
Release 0.1.3

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "s-gw",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Local s-gw plugin that lets coding agents use typed secret handles without receiving raw credentials.",
   "author": {
     "name": "Barry Yuan"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,15 +14,13 @@ permissions:
   contents: read
 
 jobs:
-  publish:
-    if: github.repository == 'sgateway/s-gw' && (github.event_name == 'release' || inputs.release_tag == '')
-    runs-on: ubuntu-latest
+  publish-npm:
+    if: github.repository == 'sgateway/s-gw' && github.event_name == 'release'
+    runs-on: macos-15
     environment: npm
     permissions:
       contents: read
       id-token: write
-    env:
-      SGW_E2E_CHROME: /usr/bin/google-chrome
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
@@ -37,14 +35,71 @@ jobs:
       - run: npm run verify
 
       - name: Verify release version
-        if: github.event_name == 'release'
         run: |
           package_version="$(node -p "require('./package.json').version")"
           test "v${package_version}" = "${GITHUB_REF_NAME}"
 
+      - name: Validate native npm package
+        run: |
+          npm run validate:npm-package
+          for binary in \
+            dist/native/darwin-arm64/s-gw-core \
+            dist/native/darwin-arm64/s-gw-keychain-helper \
+            dist/s-gw.app/Contents/MacOS/s-gw \
+            "dist/s-gw Menu Bar.app/Contents/MacOS/s-gw-menu-bar-helper"; do
+            lipo "$binary" -verify_arch arm64
+          done
+
       - name: Publish to npm
-        if: github.event_name == 'release'
-        run: npm publish --access public
+        run: npm publish --access public --ignore-scripts
+
+      - name: Verify published npm package
+        run: |
+          package_version="$(node -p "require('./package.json').version")"
+          prefix="${RUNNER_TEMP}/s-gw-npm-${package_version}"
+          installed=0
+          for _ in 1 2 3 4 5 6; do
+            rm -rf "$prefix"
+            if npm install --global --prefix "$prefix" --ignore-scripts --no-audit --no-fund --prefer-online "@s-gw/s-gw@${package_version}"; then
+              installed=1
+              break
+            fi
+            sleep 10
+          done
+          test "$installed" = 1
+
+          package_root="$prefix/lib/node_modules/@s-gw/s-gw"
+          test -x "$prefix/bin/s-gw"
+          test -x "$package_root/dist/native/darwin-arm64/s-gw-core"
+          test -x "$package_root/dist/native/darwin-arm64/s-gw-keychain-helper"
+          test -x "$package_root/dist/s-gw.app/Contents/MacOS/s-gw"
+          test -x "$package_root/dist/s-gw Menu Bar.app/Contents/MacOS/s-gw-menu-bar-helper"
+          test ! -e "$package_root/dist/native/s-gw-core"
+          test ! -e "$package_root/dist/native/s-gw-core.exe"
+          test ! -e "$package_root/dist/native/s-gw-keychain-helper"
+          test "$("$package_root/dist/native/darwin-arm64/s-gw-core" --version)" = "sgw-core ${package_version}"
+          "$prefix/bin/s-gw" help >/dev/null
+          lipo "$package_root/dist/native/darwin-arm64/s-gw-core" -verify_arch arm64
+
+  publish-registry:
+    needs: publish-npm
+    if: >-
+      always() &&
+      github.repository == 'sgateway/s-gw' &&
+      (github.event_name == 'release' || inputs.release_tag == '') &&
+      (github.event_name != 'release' || needs.publish-npm.result == 'success')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
 
       - name: Verify npm publication
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ Notable changes to s-gw are documented here. The project follows [Semantic Versi
 
 ## Unreleased
 
+## 0.1.3 - 2026-07-11
+
+### Added
+
+- Persistent update checks and notifications in the login-started macOS menu helper, including release links and durable per-version deduplication.
+- Platform-and-architecture-scoped native executable paths with package validation for the Apple Silicon npm release.
+
+### Changed
+
+- Settings now use clear section cards and plain-language approval duration choices instead of the previous compact tab switcher and raw millisecond field.
+- The public npm package includes the Apple Silicon native app, menu helper, Keychain helper, and Rust execution core; other targets use the TypeScript execution path when no matching core is present.
+
+### Fixed
+
+- Light mode now applies consistently to activity tables, dashboard widgets, menus, dialogs, settings, status text, and code panels.
+- TypeScript and Swift update comparisons now follow SemVer precedence, so stable releases outrank their prereleases and invalid tags are ignored.
+- Failed package updates restore previously running console and menu services after safe-to-recover failures, without masking the original update error if restart also fails. A missing-data guard keeps services stopped until backup restoration.
+- Legacy package migration retains verified rollback instructions when inspection fails after removal.
+- Concurrent agent installs and uninstalls are serialized so ownership-manifest entries cannot overwrite each other.
+- Automatic execution rejects incompatible native binaries before launch and safely falls back to TypeScript; explicitly required Rust execution still fails closed.
+
 ## 0.1.2 - 2026-07-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,7 +143,7 @@ dependencies = [
 
 [[package]]
 name = "sgw-core"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "base64",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/sgw-core"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/sgateway/s-gw"

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ s-gw status
 
 To build from source, use a stable Rust toolchain. Building the native macOS surfaces also requires a Swift toolchain.
 
-Preview desktop builds are available from [GitHub Releases](https://github.com/sgateway/s-gw/releases). The current macOS and Windows downloads are unsigned preview artifacts. The npm package is the recommended installation path; use the source steps below for development and contribution work.
+Preview desktop builds are available from [GitHub Releases](https://github.com/sgateway/s-gw/releases). The current macOS and Windows downloads are unsigned preview artifacts. The npm package is the recommended installation path. It includes the native app, menu helper, Keychain helper, and Rust core for Apple Silicon Macs; Linux and Windows use the TypeScript execution path when a matching native core is not packaged. Intel Macs must build the native Keychain and desktop surfaces from source for now; the npm package and DMG reject their arm64-only helpers with a clear compatibility error.
 
 ```bash
 git clone https://github.com/sgateway/s-gw.git
@@ -206,11 +206,12 @@ The model can complete the task without receiving the raw access key.
 
 | Platform | Status | Credential store | User interface |
 | --- | --- | --- | --- |
-| macOS 14+ | Primary development platform | Keychain | Native app, menu helper, local web console |
+| macOS 14+ on Apple Silicon | Primary development platform | Keychain | Native app, menu helper, local web console |
+| macOS 14+ on Intel | Build-from-source candidate; not QA-tested | Source-built Keychain helper | Source-built native surfaces or local web console |
 | Windows 10/11 | Preview | Credential Manager | PowerShell client, tray helper, local web console |
 | Linux | Experimental CLI | Environment-provided unlock material | Local web console |
 
-Preview installers are available from [GitHub Releases](https://github.com/sgateway/s-gw/releases). The macOS DMG is ad-hoc signed and unnotarized, and the Windows package is unsigned preview software. Build the same artifacts locally with `npm run build:installers`.
+Preview installers are available from [GitHub Releases](https://github.com/sgateway/s-gw/releases). The Apple Silicon macOS DMG is ad-hoc signed and unnotarized, and the Windows package is unsigned preview software. Build the same artifacts locally with `npm run build:installers`.
 
 ## Security Model
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -48,7 +48,7 @@ The approval broker claims the request, validates the handle policy again, and r
 
 The Rust runner clears the child environment, restores a small allowlist of ordinary process variables, injects only approved credential bindings, enforces the timeout, captures bounded stdout and stderr, replaces known values with handles, and returns a proof-bound result. The broker rejects malformed responses, raw credential output, or an invalid proof before updating the request record.
 
-Owned SSH sessions use the TypeScript execution path. Platform-native packages include the Rust runner and select it automatically for approved environment commands. A Windows preview assembled on macOS uses the TypeScript compatibility path because it cannot contain a Windows-native runner; Windows builds include `sgw-core.exe`. `SGW_EXECUTION_ENGINE=rust` can require the compiled runner, while `SGW_EXECUTION_ENGINE=typescript` selects the compatibility path explicitly.
+Owned SSH sessions use the TypeScript execution path. Native runners live under `dist/native/<platform>-<architecture>/`, and automatic mode only selects the current target. The public npm package includes the macOS arm64 runner; Linux, Windows, and other architectures use the TypeScript compatibility path when their target directory is absent. Native Windows source builds produce `dist/native/win32-x64/s-gw-core.exe`. `SGW_EXECUTION_ENGINE=rust` requires a compatible compiled runner, while `SGW_EXECUTION_ENGINE=typescript` selects the compatibility path explicitly.
 
 ### User Interfaces
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -20,14 +20,14 @@ Raw credentials stay in the local encrypted ledger and are decrypted only inside
 
 ### npm Registry
 
-The public npm package is the recommended installation path for individual users. It installs the `s-gw`, `sgw`, `s-gw-mcp`, and `secret-gateway-mcp` commands.
+The public npm package is the recommended installation path for individual users. It installs the `s-gw`, `sgw`, `s-gw-mcp`, and `secret-gateway-mcp` commands. Releases are built on macOS arm64 so Apple Silicon users also receive the native app, menu helper, Keychain helper, and matching Rust core. Linux and Windows use the TypeScript execution path when the package has no matching native core. Intel Macs must build the native Keychain and desktop surfaces from source; packaged arm64-only helpers are rejected before launch.
 
 ```bash
 npm install -g @s-gw/s-gw
 s-gw setup
 ```
 
-For most macOS users, this is the complete first run. `s-gw setup` generates a strong local unlock secret, stores it in macOS Keychain, initializes the encrypted ledger, installs and starts the console LaunchAgent, installs and starts the menu-bar helper, and opens the native macOS app. The browser console remains installed as a fallback local UI.
+For Apple Silicon Mac users, this is the complete first run. `s-gw setup` generates a strong local unlock secret, stores it in macOS Keychain, initializes the encrypted ledger, installs and starts the console LaunchAgent, installs and starts the menu-bar helper, and opens the native macOS app. The browser console remains installed as a fallback local UI.
 
 ### Local Tarball Or Source
 
@@ -357,7 +357,7 @@ Supported means s-gw has a documented standard MCP stdio path. Profiled means `s
 
 ## Upgrade
 
-The CLI and local console cache successful responses from the public `sgateway/s-gw` GitHub Releases feed for six hours. Drafts are ignored; preview releases are included while s-gw is in preview. If GitHub's unauthenticated Releases API is rate-limited, clients fall back to the repository's public Atom release feed; the macOS app then checks the deterministic package and checksum URLs before offering an upgrade. The CLI prints a notice in interactive terminals and supports `s-gw update check`, the local console shows an update banner, and the Windows tray helper shows a notification plus a release link. The native macOS checker starts with the app, polls every 15 minutes, and skips the network until six hours after its last successful response. A failed request does not advance that timestamp, so it retries on the next 15-minute poll. The app sends one macOS notification per available version, falls back to its in-app banner when notification permission is unavailable, and provides manual checks from Settings or the `Check for Updates` menu command.
+The CLI and local console cache successful responses from the public `sgateway/s-gw` GitHub Releases feed for six hours. Drafts are ignored; preview releases are included while s-gw is in preview. If GitHub's unauthenticated Releases API is rate-limited, clients fall back to the repository's public Atom release feed; the macOS app then checks the deterministic package and checksum URLs before offering an upgrade. The CLI prints a notice in interactive terminals and supports `s-gw update check`, the local console shows an update banner, and the Windows tray helper shows a notification plus a release link. The login-started macOS menu helper checks immediately and every 15 minutes, while the main app performs one startup check and supports manual checks. Both skip the network until six hours after the last successful response. A failed request does not advance that timestamp, so the helper retries on its next poll. The helper sends one macOS notification per available version and opens the matching release when clicked; the main app retains its in-app banner when notification permission is unavailable.
 
 The release workflow runs the full verification suite, then builds and uploads the scoped package, legacy bridge, platform installers, `SHA256SUMS.txt`, and per-file `.sha256` assets. It refuses to upload an update package whose identity or checksum cannot be verified. The macOS app accepts either checksum format, installs through the same package migration path as the CLI, refreshes the service/menu helper, and reopens s-gw. The original `0.1.0` app can take the legacy bridge on its next update check; once that fixed app is installed, later releases migrate it to the scoped package automatically. Other clients open the release page for the platform installer. Update checks fail quietly when GitHub is unavailable and never block local credential operations.
 
@@ -370,7 +370,7 @@ s-gw update install
 s-gw setup
 ```
 
-Use `--package PATH_OR_SPEC` with `plan` or `install` for a verified local tarball or a specific npm version. The installer checks the target package metadata before changing anything. If the legacy unscoped `s-gw` package is installed, it creates and verifies a temporary local rollback tarball, stops the running surfaces, removes only that legacy package, and then installs `@s-gw/s-gw`. A failed install prints a rollback command that points to the saved local tarball; it never suggests the unpublished `s-gw@0.1.0` registry package.
+Use `--package PATH_OR_SPEC` with `plan` or `install` for a verified local tarball or a specific npm version. The installer checks the target package metadata before changing anything. If the legacy unscoped `s-gw` package is installed, it creates and verifies a temporary local rollback tarball, stops the running surfaces, removes only that legacy package, and then installs `@s-gw/s-gw`. A failed migration restores and verifies that rollback before restarting previously running surfaces. If automatic rollback fails, the error retains commands pointing to the saved local tarball; it never suggests the unpublished `s-gw@0.1.0` registry package. If the existing data directory disappears, services stay stopped and setup is withheld until the user restores the backup.
 
 If the original `0.1.0` app cannot reach a release containing the legacy bridge, bootstrap that one upgrade with the current scoped CLI without installing it over the old command first:
 
@@ -414,12 +414,15 @@ Before publishing a build:
 
 ```bash
 npm run verify
+npm run validate:npm-package
 npm pack
 ```
 
 For macOS production packages, also verify:
 
-- native helper exists at `dist/native/s-gw-keychain-helper`;
+- native helper exists at `dist/native/darwin-arm64/s-gw-keychain-helper`;
+- Rust core exists at `dist/native/darwin-arm64/s-gw-core`;
+- all four native executables report `arm64` through `lipo -verify_arch`;
 - native macOS app exists at `dist/s-gw.app`;
 - `s-gw unlock status` reports `provider: "native-helper"`;
 - real Keychain + MCP e2e passes with no `SGW_MASTER_PASSPHRASE`;
@@ -442,18 +445,18 @@ For Windows preview packages, also verify:
 
 ## What The Package Contains
 
-The current npm/tarball package contains:
+The public npm package contains:
 
 - `s-gw` CLI and `s-gw-mcp` stdio MCP server;
 - compiled TypeScript under `dist`;
-- compiled Rust execution core at `dist/native/s-gw-core` or `s-gw-core.exe`;
-- native macOS Keychain helper at `dist/native/s-gw-keychain-helper`;
+- compiled Rust execution core at `dist/native/darwin-arm64/s-gw-core`;
+- native macOS Keychain helper at `dist/native/darwin-arm64/s-gw-keychain-helper`;
 - native macOS management app at `dist/s-gw.app`;
 - native macOS menu-bar helper app at `dist/s-gw Menu Bar.app`;
 - local console HTML/CSS/JS assets under `docs/ui`;
 - integration docs and agent profile docs;
 
-It intentionally does not contain native application source files, source maps, credentials, user policy files, npm build caches, SwiftPM `.build` caches, or any pre-seeded Keychain material.
+Native executable paths are scoped by platform and architecture. A source build writes its runner and helper under `dist/native/<platform>-<architecture>/`; automatic execution ignores binaries for other targets and uses the TypeScript path when no matching core exists. The package intentionally does not contain native application source files, source maps, credentials, user policy files, npm build caches, SwiftPM `.build` caches, or any pre-seeded Keychain material.
 
 ## Reference Docs
 

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -28,7 +28,7 @@ unset SGW_UNLOCK
 s-gw unlock status
 ```
 
-For automation, `SGW_MASTER_PASSPHRASE` still works as a fallback. Keep real passphrases in a local user environment or OS credential store, not in project-scoped MCP files. On macOS, the normal path uses the bundled native helper at `dist/native/s-gw-keychain-helper`; on Windows preview builds it uses `dist\windows\s-gw-credential.ps1`. Both helpers receive new passphrases on stdin.
+For automation, `SGW_MASTER_PASSPHRASE` still works as a fallback. Keep real passphrases in a local user environment or OS credential store, not in project-scoped MCP files. On Apple Silicon Macs, the normal path uses the bundled native helper at `dist/native/darwin-arm64/s-gw-keychain-helper`; on Windows preview builds it uses `dist\windows\s-gw-credential.ps1`. Both helpers receive new passphrases on stdin.
 
 ## Guarded Launch
 

--- a/native/macos-app/Sources/SgwMac/App/AppState.swift
+++ b/native/macos-app/Sources/SgwMac/App/AppState.swift
@@ -43,11 +43,9 @@ final class AppState {
   }
 
   @ObservationIgnored private var refreshTask: Task<Void, Never>?
-  @ObservationIgnored private var updateTask: Task<Void, Never>?
   @ObservationIgnored private let defaults: UserDefaults
   @ObservationIgnored private let now: () -> Date
   @ObservationIgnored private let updateCheckInterval: TimeInterval
-  @ObservationIgnored private let updateRetryInterval: TimeInterval
   @ObservationIgnored private var seenPendingRequestIds = Set<String>()
 
   init(
@@ -55,15 +53,13 @@ final class AppState {
     updateNotifier: UpdateNotifier? = nil,
     defaults: UserDefaults = .standard,
     now: @escaping () -> Date = Date.init,
-    updateCheckInterval: TimeInterval = 6 * 60 * 60,
-    updateRetryInterval: TimeInterval = 15 * 60
+    updateCheckInterval: TimeInterval = 6 * 60 * 60
   ) {
     self.updater = updater
     self.updateNotifier = updateNotifier ?? UpdateNotifier(defaults: defaults)
     self.defaults = defaults
     self.now = now
     self.updateCheckInterval = updateCheckInterval
-    self.updateRetryInterval = updateRetryInterval
     updateRepository = savedSgwUpdateRepository(defaults: defaults)
   }
 
@@ -150,17 +146,13 @@ final class AppState {
     Task {
       await refresh()
     }
+    Task {
+      await checkForUpdates()
+    }
     refreshTask = Task { [weak self] in
       while !Task.isCancelled {
         try? await Task.sleep(for: .seconds(4))
         await self?.refreshQuietly()
-      }
-    }
-    updateTask = Task { [weak self] in
-      while !Task.isCancelled {
-        await self?.checkForUpdates()
-        let retryInterval = self?.updateRetryInterval ?? 15 * 60
-        try? await Task.sleep(for: .seconds(retryInterval))
       }
     }
   }
@@ -168,8 +160,6 @@ final class AppState {
   func stop() {
     refreshTask?.cancel()
     refreshTask = nil
-    updateTask?.cancel()
-    updateTask = nil
   }
 
   func refreshQuietly() async {

--- a/native/macos-app/Sources/SgwMac/Services/UpdateChecker.swift
+++ b/native/macos-app/Sources/SgwMac/Services/UpdateChecker.swift
@@ -64,22 +64,14 @@ actor UpdateChecker: UpdateChecking {
     private let cli = CLIRunner()
 
     static var currentVersion: String {
-        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.1.2"
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.1.3"
     }
 
     static func isNewer(_ candidate: String, than current: String) -> Bool {
-        let left = versionParts(candidate)
-        let right = versionParts(current)
-        let count = max(left.count, right.count)
-
-        for index in 0..<count {
-            let a = index < left.count ? left[index] : 0
-            let b = index < right.count ? right[index] : 0
-            if a > b { return true }
-            if a < b { return false }
+        guard let left = semanticVersion(candidate), let right = semanticVersion(current) else {
+            return false
         }
-
-        return false
+        return compare(left, right) == .orderedDescending
     }
 
     func latestRelease(repository: String) async throws -> ReleaseInfo? {
@@ -105,6 +97,7 @@ actor UpdateChecker: UpdateChecking {
             let releases = try JSONDecoder().decode([GitHubRelease].self, from: data)
             guard let release = releases
                 .filter({ !$0.draft })
+                .filter({ Self.semanticVersion($0.tagName) != nil })
                 .sorted(by: { Self.isNewer($0.tagName, than: $1.tagName) })
                 .first else {
                 return nil
@@ -182,7 +175,7 @@ actor UpdateChecker: UpdateChecking {
             ?? id?.split(separator: "/").last.map(String.init)
             ?? ""
         let version = parseVersion(tag)
-        guard !tag.isEmpty, !version.isEmpty else { return nil }
+        guard !tag.isEmpty, semanticVersion(version) != nil else { return nil }
 
         let packageName = "s-gw-\(version).tgz"
         let downloadBase = "https://github.com/\(repository)/releases/download/\(tag)"
@@ -419,10 +412,12 @@ actor UpdateChecker: UpdateChecking {
         let script = """
         sleep 1
         if [ -n "$SGW_UPDATE_CLI" ] && [ -x "$SGW_UPDATE_CLI" ]; then
-          "$SGW_UPDATE_CLI" setup --no-open-app >/dev/null 2>&1 || true
+          "$SGW_UPDATE_CLI" setup --no-open-app >/dev/null 2>&1 || \
+            "$SGW_UPDATE_CLI" start --no-open-app >/dev/null 2>&1 || true
           "$SGW_UPDATE_CLI" app open >/dev/null 2>&1 || true
         else
-          PATH="/opt/homebrew/bin:/usr/local/bin:$PATH" /usr/bin/env s-gw setup --no-open-app >/dev/null 2>&1 || true
+          PATH="/opt/homebrew/bin:/usr/local/bin:$PATH" /usr/bin/env s-gw setup --no-open-app >/dev/null 2>&1 || \
+            PATH="/opt/homebrew/bin:/usr/local/bin:$PATH" /usr/bin/env s-gw start --no-open-app >/dev/null 2>&1 || true
           PATH="/opt/homebrew/bin:/usr/local/bin:$PATH" /usr/bin/env s-gw app open >/dev/null 2>&1 || true
         fi
         """
@@ -448,13 +443,93 @@ actor UpdateChecker: UpdateChecking {
         return cleaned
     }
 
-    private static func versionParts(_ version: String) -> [Int] {
-        parseVersion(version)
-            .split(separator: ".")
-            .map { part in
-                let digits = part.prefix { $0.isNumber }
-                return Int(digits) ?? 0
+    private static func semanticVersion(_ version: String) -> SemanticVersion? {
+        let cleaned = parseVersion(version)
+        let buildParts = cleaned.split(separator: "+", maxSplits: 1, omittingEmptySubsequences: false)
+        guard buildParts.count <= 2 else { return nil }
+        if buildParts.count == 2 && !validIdentifiers(buildParts[1], rejectLeadingZeroes: false) {
+            return nil
+        }
+
+        let precedence = buildParts[0]
+        let prereleaseParts = precedence.split(separator: "-", maxSplits: 1, omittingEmptySubsequences: false)
+        let core = prereleaseParts[0].split(separator: ".", omittingEmptySubsequences: false)
+        guard core.count == 3, core.allSatisfy(validCoreIdentifier) else { return nil }
+
+        var prerelease: [String] = []
+        if prereleaseParts.count == 2 {
+            guard validIdentifiers(prereleaseParts[1], rejectLeadingZeroes: true) else { return nil }
+            prerelease = prereleaseParts[1].split(separator: ".").map(String.init)
+        }
+        return SemanticVersion(core: core.map(String.init), prerelease: prerelease)
+    }
+
+    private static func compare(_ left: SemanticVersion, _ right: SemanticVersion) -> ComparisonResult {
+        for index in 0..<3 {
+            let result = compareNumeric(left.core[index], right.core[index])
+            if result != .orderedSame { return result }
+        }
+
+        if left.prerelease.isEmpty || right.prerelease.isEmpty {
+            if left.prerelease.isEmpty == right.prerelease.isEmpty { return .orderedSame }
+            return left.prerelease.isEmpty ? .orderedDescending : .orderedAscending
+        }
+
+        let count = max(left.prerelease.count, right.prerelease.count)
+        for index in 0..<count {
+            guard index < left.prerelease.count else { return .orderedAscending }
+            guard index < right.prerelease.count else { return .orderedDescending }
+            let a = left.prerelease[index]
+            let b = right.prerelease[index]
+            let aNumeric = isNumeric(a)
+            let bNumeric = isNumeric(b)
+
+            if aNumeric && bNumeric {
+                let result = compareNumeric(a, b)
+                if result != .orderedSame { return result }
+                continue
             }
+            if aNumeric != bNumeric {
+                return aNumeric ? .orderedAscending : .orderedDescending
+            }
+            if a != b { return a < b ? .orderedAscending : .orderedDescending }
+        }
+        return .orderedSame
+    }
+
+    private static func compareNumeric(_ left: String, _ right: String) -> ComparisonResult {
+        if left.count != right.count {
+            return left.count < right.count ? .orderedAscending : .orderedDescending
+        }
+        if left == right { return .orderedSame }
+        return left < right ? .orderedAscending : .orderedDescending
+    }
+
+    private static func validCoreIdentifier(_ value: Substring) -> Bool {
+        isNumeric(value) && (value.count == 1 || value.first != "0")
+    }
+
+    private static func validIdentifiers(_ value: Substring, rejectLeadingZeroes: Bool) -> Bool {
+        let identifiers = value.split(separator: ".", omittingEmptySubsequences: false)
+        guard !identifiers.isEmpty else { return false }
+        return identifiers.allSatisfy { identifier in
+            guard !identifier.isEmpty, identifier.utf8.allSatisfy(isSemVerByte) else { return false }
+            if rejectLeadingZeroes && isNumeric(identifier) && identifier.count > 1 && identifier.first == "0" {
+                return false
+            }
+            return true
+        }
+    }
+
+    private static func isNumeric<S: StringProtocol>(_ value: S) -> Bool {
+        !value.isEmpty && value.utf8.allSatisfy { $0 >= 48 && $0 <= 57 }
+    }
+
+    private static func isSemVerByte(_ value: UInt8) -> Bool {
+        (value >= 48 && value <= 57)
+            || (value >= 65 && value <= 90)
+            || (value >= 97 && value <= 122)
+            || value == 45
     }
 
     private static func installedCLIPath(from output: String) -> String? {
@@ -468,6 +543,11 @@ actor UpdateChecker: UpdateChecking {
         return FileManager.default.isExecutableFile(atPath: path) ? path : nil
     }
 
+}
+
+private struct SemanticVersion {
+    let core: [String]
+    let prerelease: [String]
 }
 
 private struct GitHubRelease: Decodable {

--- a/native/macos-app/Tests/AppStateGuardTests.swift
+++ b/native/macos-app/Tests/AppStateGuardTests.swift
@@ -243,6 +243,7 @@ struct AppStateGuardTests {
     await runIncompleteReleaseRetryTest()
     await runUpdateNotificationTest()
     await runDeniedNotificationFallbackTest()
+    runSemVerComparisonTest()
     runAtomFallbackParsingTest()
     runChecksumManifestTest()
 
@@ -536,6 +537,21 @@ struct AppStateGuardTests {
     } catch {
       fail("a raw digest should remain valid in an exact per-file checksum: \(error)")
     }
+  }
+
+  static func runSemVerComparisonTest() {
+    check(!UpdateChecker.isNewer("0.2.0-preview.1", than: "0.2.0"),
+          "a preview must not outrank its stable release")
+    check(UpdateChecker.isNewer("0.2.0", than: "0.2.0-preview.1"),
+          "preview users must receive the stable release")
+    check(UpdateChecker.isNewer("0.2.0-preview.10", than: "0.2.0-preview.2"),
+          "numeric prerelease identifiers must compare numerically")
+    check(UpdateChecker.isNewer("0.2.0-beta", than: "0.2.0-alpha"),
+          "text prerelease identifiers must compare lexically")
+    check(!UpdateChecker.isNewer("0.2.0-1", than: "0.2.0-alpha"),
+          "numeric prerelease identifiers must sort before text identifiers")
+    check(!UpdateChecker.isNewer("0.2.0+build.2", than: "0.2.0+build.1"),
+          "build metadata must not affect precedence")
   }
 
   static func runAtomFallbackParsingTest() {

--- a/native/menu-bar-helper/Sources/AppDelegate.swift
+++ b/native/menu-bar-helper/Sources/AppDelegate.swift
@@ -2,7 +2,7 @@ import AppKit
 import Darwin
 import Foundation
 import SwiftUI
-import UserNotifications
+@preconcurrency import UserNotifications
 
 extension Notification.Name {
   static let sgwShowMenuHelper = Notification.Name("com.s-gw.sgw.showMenuHelper")

--- a/native/menu-bar-helper/Sources/AppDelegate.swift
+++ b/native/menu-bar-helper/Sources/AppDelegate.swift
@@ -491,12 +491,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
   private func sendUpdateNotification(_ update: HelperUpdate) async -> Bool {
     guard notificationsEnabled else { return false }
     let center = UNUserNotificationCenter.current()
-    var status = await center.notificationSettings().authorizationStatus
+    var status = await notificationAuthorizationStatus(center)
     if status == .notDetermined {
       guard (try? await center.requestAuthorization(options: [.alert, .sound])) == true else {
         return false
       }
-      status = await center.notificationSettings().authorizationStatus
+      status = await notificationAuthorizationStatus(center)
     }
     guard status == .authorized || status == .provisional else {
       return false
@@ -517,6 +517,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
       return true
     } catch {
       return false
+    }
+  }
+
+  private func notificationAuthorizationStatus(_ center: UNUserNotificationCenter) async -> UNAuthorizationStatus {
+    await withCheckedContinuation { continuation in
+      center.getNotificationSettings { settings in
+        continuation.resume(returning: settings.authorizationStatus)
+      }
     }
   }
 

--- a/native/menu-bar-helper/Sources/AppDelegate.swift
+++ b/native/menu-bar-helper/Sources/AppDelegate.swift
@@ -107,6 +107,29 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     )
   }()
 
+  private lazy var updateMonitor: UpdateMonitor = {
+    let node = nodePath
+    let cli = cliPath
+    let root = repoRoot
+    let environment = ProcessInfo.processInfo.environment
+    let args = UpdateMonitor.command
+    return UpdateMonitor(
+      runCheck: {
+        runSgwCli(
+          node: node,
+          cli: cli,
+          repoRoot: root,
+          args: args,
+          environment: environment
+        )
+      },
+      notify: { [weak self] update in
+        guard let self else { return false }
+        return await self.sendUpdateNotification(update)
+      }
+    )
+  }()
+
   override init() {
     let env = ProcessInfo.processInfo.environment
     let cwd = FileManager.default.currentDirectoryPath
@@ -157,6 +180,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     installDistributedObservers()
     requestNotificationPermission()
     refreshState()
+    updateMonitor.start()
 
     timer = Timer.scheduledTimer(withTimeInterval: 4, repeats: true) { [weak self] _ in
       guard let delegate = self else { return }
@@ -172,6 +196,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
   func applicationWillTerminate(_ notification: Notification) {
     timer?.invalidate()
+    updateMonitor.stop()
     removeOutsideClickMonitor()
     DistributedNotificationCenter.default().removeObserver(self)
     HelperLaunchGuard.shared.release()
@@ -463,11 +488,56 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     ))
   }
 
+  private func sendUpdateNotification(_ update: HelperUpdate) async -> Bool {
+    guard notificationsEnabled else { return false }
+    let center = UNUserNotificationCenter.current()
+    var status = await center.notificationSettings().authorizationStatus
+    if status == .notDetermined {
+      guard (try? await center.requestAuthorization(options: [.alert, .sound])) == true else {
+        return false
+      }
+      status = await center.notificationSettings().authorizationStatus
+    }
+    guard status == .authorized || status == .provisional else {
+      return false
+    }
+
+    let content = UNMutableNotificationContent()
+    content.title = "s-gw \(update.version) is available"
+    content.body = "Open s-gw to review and upgrade."
+    content.sound = .default
+    content.userInfo = ["releaseURL": update.releaseURL.absoluteString]
+
+    do {
+      try await center.add(UNNotificationRequest(
+        identifier: "s-gw-update-\(update.version)",
+        content: content,
+        trigger: nil
+      ))
+      return true
+    } catch {
+      return false
+    }
+  }
+
   nonisolated func userNotificationCenter(
     _ center: UNUserNotificationCenter,
     willPresent notification: UNNotification,
     withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
   ) {
     completionHandler([.banner, .sound])
+  }
+
+  nonisolated func userNotificationCenter(
+    _ center: UNUserNotificationCenter,
+    didReceive response: UNNotificationResponse,
+    withCompletionHandler completionHandler: @escaping () -> Void
+  ) {
+    let releaseURL = response.notification.request.content.userInfo["releaseURL"] as? String
+    completionHandler()
+    guard let releaseURL, let url = URL(string: releaseURL) else { return }
+    Task { @MainActor in
+      NSWorkspace.shared.open(url)
+    }
   }
 }

--- a/native/menu-bar-helper/Sources/UpdateMonitor.swift
+++ b/native/menu-bar-helper/Sources/UpdateMonitor.swift
@@ -1,0 +1,104 @@
+import Foundation
+
+struct HelperUpdate: Sendable {
+  let version: String
+  let releaseURL: URL
+}
+
+@MainActor
+final class UpdateMonitor {
+  // The login helper owns the recurring update check so quitting the main app cannot silence it.
+  static let command = ["update", "check"]
+  static let pollInterval: TimeInterval = 15 * 60
+
+  private static let lastVersionKey = "lastNotifiedUpdateVersion"
+  private static let versionsKey = "notifiedUpdateVersions"
+
+  private let defaults: UserDefaults
+  private let runCheck: @Sendable () -> CliRunResult
+  private let notify: @MainActor (HelperUpdate) async -> Bool
+  private var checking = false
+  private var timer: Timer?
+
+  init(
+    defaults: UserDefaults = UserDefaults(suiteName: "com.s-gw.sgw.app") ?? .standard,
+    runCheck: @escaping @Sendable () -> CliRunResult,
+    notify: @escaping @MainActor (HelperUpdate) async -> Bool
+  ) {
+    self.defaults = defaults
+    self.runCheck = runCheck
+    self.notify = notify
+  }
+
+  func start() {
+    guard timer == nil else { return }
+    Task { await checkNow() }
+    timer = Timer.scheduledTimer(withTimeInterval: Self.pollInterval, repeats: true) { [weak self] _ in
+      Task { @MainActor in
+        await self?.checkNow()
+      }
+    }
+  }
+
+  func stop() {
+    timer?.invalidate()
+    timer = nil
+  }
+
+  func checkNow() async {
+    guard !checking else { return }
+    checking = true
+    defer { checking = false }
+
+    let check = runCheck
+    let result = await Task.detached(priority: .utility) {
+      check()
+    }.value
+    guard let update = Self.availableUpdate(from: result), !wasNotified(update.version) else {
+      return
+    }
+
+    if await notify(update) {
+      recordNotified(update.version)
+    }
+  }
+
+  private static func availableUpdate(from result: CliRunResult) -> HelperUpdate? {
+    guard result.ok, let output = result.stdout, let data = output.data(using: .utf8) else {
+      return nil
+    }
+    guard let checked = try? JSONDecoder().decode(CliUpdateCheck.self, from: data),
+          checked.available,
+          let version = checked.latestVersion?.trimmingCharacters(in: .whitespacesAndNewlines),
+          !version.isEmpty,
+          let urlText = checked.releaseUrl,
+          let url = URL(string: urlText),
+          url.scheme == "https" || url.scheme == "http" else {
+      return nil
+    }
+    return HelperUpdate(version: version, releaseURL: url)
+  }
+
+  private func wasNotified(_ version: String) -> Bool {
+    if defaults.string(forKey: Self.lastVersionKey) == version { return true }
+    return defaults.stringArray(forKey: Self.versionsKey)?.contains(version) == true
+  }
+
+  private func recordNotified(_ version: String) {
+    var versions = defaults.stringArray(forKey: Self.versionsKey) ?? []
+    if let previous = defaults.string(forKey: Self.lastVersionKey), !versions.contains(previous) {
+      versions.append(previous)
+    }
+    if !versions.contains(version) {
+      versions.append(version)
+    }
+    defaults.set(Array(versions.suffix(32)), forKey: Self.versionsKey)
+    defaults.set(version, forKey: Self.lastVersionKey)
+  }
+}
+
+private struct CliUpdateCheck: Decodable {
+  let available: Bool
+  let latestVersion: String?
+  let releaseUrl: String?
+}

--- a/native/menu-bar-helper/Tests/DecisionGuardTests.swift
+++ b/native/menu-bar-helper/Tests/DecisionGuardTests.swift
@@ -23,6 +23,29 @@ private func check(_ cond: Bool, _ message: String) {
   if !cond { fail(message) }
 }
 
+private final class FakeHelperUpdateRunner: @unchecked Sendable {
+  private let lock = NSLock()
+  private var results: [CliRunResult]
+
+  init(_ results: [CliRunResult]) {
+    self.results = results
+  }
+
+  func run() -> CliRunResult {
+    lock.lock()
+    defer { lock.unlock() }
+    if results.isEmpty { return CliRunResult(ok: false, stdout: nil, stderr: "no result") }
+    return results.removeFirst()
+  }
+}
+
+private func helperUpdateResult(_ version: String, available: Bool = true) -> CliRunResult {
+  let json = """
+  {"checked":true,"currentVersion":"0.1.2","latestVersion":"\(version)","available":\(available),"releaseUrl":"https://example.test/releases/v\(version)"}
+  """
+  return CliRunResult(ok: true, stdout: json, stderr: nil)
+}
+
 // Scratch dir holding the fake CLI, its invocation log, and the FIFO it blocks on.
 fileprivate struct Scratch {
   let dir: URL
@@ -132,6 +155,7 @@ struct DecisionGuardTests {
     runRouteAndSizingTest()
     runApprovalFlowTest()
     runLaunchLockTest(scratch)
+    await runPersistentUpdateMonitorTest()
 
     print("ALL_MENUBAR_TESTS_OK")
   }
@@ -241,6 +265,57 @@ struct DecisionGuardTests {
     let pendingSize = HelperPopoverMetrics.size(for: idle)
     check(pendingSize.width == 400 && pendingSize.height == 500,
           "pending popover should expand to 400x500")
+  }
+
+  @MainActor
+  static func runPersistentUpdateMonitorTest() async {
+    let suite = "com.s-gw.tests.helper-updates.\(UUID().uuidString)"
+    let defaults = UserDefaults(suiteName: suite)!
+    defaults.removePersistentDomain(forName: suite)
+    defer { defaults.removePersistentDomain(forName: suite) }
+    var notified: [String] = []
+    let firstRunner = FakeHelperUpdateRunner([
+      helperUpdateResult("9.1.0"),
+      helperUpdateResult("9.1.0")
+    ])
+    let first = UpdateMonitor(
+      defaults: defaults,
+      runCheck: { firstRunner.run() },
+      notify: { update in notified.append(update.version); return true }
+    )
+
+    await first.checkNow()
+    await first.checkNow()
+    check(notified == ["9.1.0"], "the helper should notify once per available version")
+
+    let afterRestartRunner = FakeHelperUpdateRunner([
+      helperUpdateResult("9.1.0"),
+      helperUpdateResult("9.2.0")
+    ])
+    let afterRestart = UpdateMonitor(
+      defaults: defaults,
+      runCheck: { afterRestartRunner.run() },
+      notify: { update in notified.append(update.version); return true }
+    )
+    await afterRestart.checkNow()
+    await afterRestart.checkNow()
+    check(notified == ["9.1.0", "9.2.0"],
+          "persisted update history should suppress a duplicate after helper restart")
+
+    let retryRunner = FakeHelperUpdateRunner([
+      CliRunResult(ok: false, stdout: nil, stderr: "offline"),
+      CliRunResult(ok: true, stdout: "not-json", stderr: nil),
+      helperUpdateResult("9.3.0")
+    ])
+    let retry = UpdateMonitor(
+      defaults: defaults,
+      runCheck: { retryRunner.run() },
+      notify: { update in notified.append(update.version); return true }
+    )
+    await retry.checkNow()
+    await retry.checkNow()
+    await retry.checkNow()
+    check(notified.last == "9.3.0", "failed and invalid checks must retry without consuming a version")
   }
 
   static func runApprovalFlowTest() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,31 @@
         "node": ">=20"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
@@ -2736,6 +2761,27 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
       "dev": true,
@@ -2946,7 +2992,6 @@
       "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2957,7 +3002,6 @@
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2968,7 +3012,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3759,7 +3802,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -4019,7 +4061,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
       "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -4647,7 +4688,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4838,7 +4878,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4848,7 +4887,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -4892,15 +4930,13 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-redux": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
       "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -5046,8 +5082,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -5437,7 +5472,6 @@
       "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.28.0"
       },
@@ -5652,7 +5686,6 @@
       "integrity": "sha512-6YYPbRXTxx6bRXmOn7XdnQAy5DQNHhDgtjhDHI13oe4pY93kkcdGJWxpGwOm++/Wh0QpQhDrpIoVMrmrsI5AGQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -5880,7 +5913,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@s-gw/s-gw",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@s-gw/s-gw",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",
@@ -52,31 +52,6 @@
       },
       "engines": {
         "node": ">=20"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
-      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
-      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -2463,7 +2438,7 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.11.2",
+      "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
       "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
       "dev": true,
@@ -2475,7 +2450,7 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.11.2",
+      "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
       "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
       "dev": true,
@@ -2761,27 +2736,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
       "dev": true,
@@ -2992,6 +2946,7 @@
       "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -3002,6 +2957,7 @@
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3012,6 +2968,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3802,6 +3759,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -4061,6 +4019,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
       "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -4688,6 +4647,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4878,6 +4838,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4887,6 +4848,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -4930,13 +4892,15 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-redux": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
       "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -5082,7 +5046,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -5472,6 +5437,7 @@
       "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.28.0"
       },
@@ -5686,6 +5652,7 @@
       "integrity": "sha512-6YYPbRXTxx6bRXmOn7XdnQAy5DQNHhDgtjhDHI13oe4pY93kkcdGJWxpGwOm++/Wh0QpQhDrpIoVMrmrsI5AGQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -5913,6 +5880,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-gw/s-gw",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "mcpName": "io.github.sgateway/s-gw",
   "description": "Local credential control for AI coding agents.",
   "type": "module",
@@ -36,6 +36,10 @@
     "!dist/assets/icons/s-gw-*.png",
     "!dist/assets/icons/AppIcon.icns",
     "!dist/installers",
+    "!dist/native/s-gw-core",
+    "!dist/native/s-gw-core.exe",
+    "!dist/native/s-gw-keychain-helper",
+    "!dist/native/sgw-keychain-helper",
     "!dist/**/*.map",
     "!docs/ui/local-console*.png",
     "!assets/icons/s-gw-source.png",
@@ -58,12 +62,14 @@
     "check": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.console.json --noEmit",
     "package:local": "npm run verify && npm pack",
     "package:dry-run": "npm pack --dry-run",
+    "validate:npm-package": "node scripts/validate-npm-package.mjs",
     "validate:release-assets": "node scripts/validate-release-assets.mjs dist/installers",
     "check:rust": "cargo fmt --all -- --check && cargo clippy --locked --all-targets -- -D warnings && cargo test --locked -p sgw-core",
     "pretest": "npm run build:rust-core",
     "test": "vitest run",
     "test:watch": "vitest",
     "verify": "npm run build && npm run check:rust && npm test && npm audit && npm run package:dry-run",
+    "prepublishOnly": "npm run validate:npm-package",
     "prepack": "npm run build"
   },
   "keywords": [

--- a/scripts/build-native-keychain.mjs
+++ b/scripts/build-native-keychain.mjs
@@ -5,8 +5,12 @@ import { fileURLToPath } from "node:url";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const source = resolve(root, "native/macos-keychain/SgwKeychain.swift");
-const output = resolve(root, "dist/native/s-gw-keychain-helper");
-const legacyOutput = resolve(root, "dist/native/sgw-keychain-helper");
+const target = `${process.platform}-${process.arch}`;
+const output = resolve(root, "dist/native", target, "s-gw-keychain-helper");
+const legacyOutputs = [
+  resolve(root, "dist/native/s-gw-keychain-helper"),
+  resolve(root, "dist/native/sgw-keychain-helper")
+];
 
 if (process.platform !== "darwin") {
   console.log("Skipping native Keychain helper build on non-macOS platform.");
@@ -30,7 +34,9 @@ if (swiftVersion.status !== 0) {
 }
 
 mkdirSync(dirname(output), { recursive: true });
-rmSync(legacyOutput, { force: true });
+for (const legacyOutput of legacyOutputs) {
+  rmSync(legacyOutput, { force: true });
+}
 
 const result = spawnSync("swiftc", [source, "-O", "-o", output], {
   encoding: "utf8",

--- a/scripts/build-rust-core.mjs
+++ b/scripts/build-rust-core.mjs
@@ -1,12 +1,17 @@
-import { chmodSync, copyFileSync, existsSync, mkdirSync } from "node:fs";
+import { chmodSync, copyFileSync, existsSync, mkdirSync, rmSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const extension = process.platform === "win32" ? ".exe" : "";
+const target = `${process.platform}-${process.arch}`;
 const built = resolve(root, "target", "release", `sgw-core${extension}`);
-const output = resolve(root, "dist", "native", `s-gw-core${extension}`);
+const output = resolve(root, "dist", "native", target, `s-gw-core${extension}`);
+const legacyOutputs = [
+  resolve(root, "dist", "native", "s-gw-core"),
+  resolve(root, "dist", "native", "s-gw-core.exe")
+];
 
 const cargo = spawnSync("cargo", ["build", "--release", "--locked", "-p", "sgw-core"], {
   cwd: root,
@@ -28,6 +33,9 @@ if (!existsSync(built)) {
 }
 
 mkdirSync(dirname(output), { recursive: true });
+for (const legacyOutput of legacyOutputs) {
+  rmSync(legacyOutput, { force: true });
+}
 copyFileSync(built, output);
 chmodSync(output, 0o755);
 

--- a/scripts/validate-npm-package.mjs
+++ b/scripts/validate-npm-package.mjs
@@ -1,0 +1,106 @@
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const expectedPlatform = "darwin";
+const expectedArch = "arm64";
+const target = `${expectedPlatform}-${expectedArch}`;
+
+if (process.platform !== expectedPlatform || process.arch !== expectedArch) {
+  throw new Error(
+    `The public npm package must be published from macOS arm64; current target is ${process.platform}-${process.arch}.`
+  );
+}
+
+const packageInfo = JSON.parse(readFileSync(resolve(root, "package.json"), "utf8"));
+if (packageInfo.name !== "@s-gw/s-gw" || !packageInfo.version) {
+  throw new Error("Unexpected npm package identity.");
+}
+
+const packed = npmPackManifest();
+if (packed.name !== packageInfo.name || packed.version !== packageInfo.version) {
+  throw new Error("npm pack metadata does not match package.json.");
+}
+
+const files = new Map(packed.files.map((entry) => [entry.path, entry]));
+const requiredExecutables = [
+  `dist/native/${target}/s-gw-core`,
+  `dist/native/${target}/s-gw-keychain-helper`,
+  "dist/s-gw.app/Contents/MacOS/s-gw",
+  "dist/s-gw Menu Bar.app/Contents/MacOS/s-gw-menu-bar-helper"
+];
+
+for (const filePath of requiredExecutables) {
+  const entry = files.get(filePath);
+  if (!entry) {
+    throw new Error(`npm package is missing required native executable: ${filePath}`);
+  }
+  if ((entry.mode & 0o111) === 0) {
+    throw new Error(`npm package native executable is not executable: ${filePath}`);
+  }
+}
+
+const coreSmoke = spawnSync(resolve(root, requiredExecutables[0]), ["--version"], {
+  encoding: "utf8",
+  stdio: ["ignore", "pipe", "pipe"]
+});
+if (coreSmoke.status !== 0 || coreSmoke.stdout.trim() !== `sgw-core ${packageInfo.version}`) {
+  throw new Error(coreSmoke.stderr.trim() || "Packaged Rust core version does not match package.json.");
+}
+
+const forbidden = [
+  "dist/native/s-gw-core",
+  "dist/native/s-gw-core.exe",
+  "dist/native/s-gw-keychain-helper",
+  "dist/native/sgw-keychain-helper"
+];
+for (const filePath of forbidden) {
+  if (files.has(filePath)) {
+    throw new Error(`npm package contains a legacy unscoped native executable: ${filePath}`);
+  }
+}
+
+const targetExecutables = [...files.keys()].filter((filePath) => (
+  /^dist\/native\/[^/]+\/s-gw-core(?:\.exe)?$/.test(filePath)
+  || /^dist\/native\/[^/]+\/(?:s-gw-keychain-helper|sgw-keychain-helper)$/.test(filePath)
+));
+for (const filePath of targetExecutables) {
+  if (!filePath.startsWith(`dist/native/${target}/`)) {
+    throw new Error(`npm package contains a native executable for another target: ${filePath}`);
+  }
+}
+
+console.log(`Validated ${packageInfo.name}@${packageInfo.version} for ${target}.`);
+
+function npmPackManifest() {
+  const args = ["pack", "--dry-run", "--json", "--ignore-scripts"];
+  const npmCli = process.env.npm_execpath;
+  const result = npmCli
+    ? spawnSync(process.execPath, [npmCli, ...args], packOptions())
+    : spawnSync("npm", args, packOptions());
+
+  if (result.status !== 0) {
+    throw new Error(result.stderr.trim() || result.stdout.trim() || "npm pack validation failed.");
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(result.stdout);
+  } catch {
+    throw new Error("npm pack returned invalid JSON.");
+  }
+  if (!Array.isArray(parsed) || parsed.length !== 1 || !Array.isArray(parsed[0]?.files)) {
+    throw new Error("npm pack returned an unexpected manifest.");
+  }
+  return parsed[0];
+}
+
+function packOptions() {
+  return {
+    cwd: root,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"]
+  };
+}

--- a/server.json
+++ b/server.json
@@ -15,13 +15,13 @@
     "url": "https://github.com/sgateway/s-gw",
     "source": "github"
   },
-  "version": "0.1.2",
+  "version": "0.1.3",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@s-gw/s-gw",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "runtimeHint": "npx",
       "runtimeArguments": [
         {

--- a/src/agent-install.ts
+++ b/src/agent-install.ts
@@ -103,6 +103,18 @@ interface AgentManifest {
   agents: Record<string, AgentOwnership>;
 }
 
+interface AgentIntegrationLockOwner {
+  pid: number;
+  startedAt: number;
+  token: string;
+}
+
+interface AgentIntegrationLockState {
+  markerPath?: string;
+  owner?: AgentIntegrationLockOwner;
+  modifiedAt: number;
+}
+
 interface WorkContext {
   homeDir: string;
   pathEnv: string;
@@ -136,6 +148,9 @@ interface TomlSection {
 
 const managedStart = "# >>> s-gw managed MCP server";
 const managedEnd = "# <<< s-gw managed MCP server";
+const agentLockTimeoutMs = 35_000;
+const staleAgentLockMs = 30_000;
+const agentLockPollMs = 25;
 
 function envPath(value: string | undefined, fallback: string): string {
   const configured = value?.trim();
@@ -272,6 +287,11 @@ export function agentIntegrationStatus(options: AgentIntegrationOptions = {}): A
 }
 
 export function installAgentIntegrations(options: AgentIntegrationOptions = {}): AgentIntegrationResult[] {
+  if (options.dryRun) return installAgentIntegrationsUnlocked(options);
+  return withAgentIntegrationLock(options, () => installAgentIntegrationsUnlocked(options));
+}
+
+function installAgentIntegrationsUnlocked(options: AgentIntegrationOptions): AgentIntegrationResult[] {
   const ctx = loadContext(options);
   const explicit = Boolean(options.agentIds?.length);
   const profiles = selectedProfiles(options.agentIds);
@@ -307,6 +327,11 @@ export function installAgentIntegrations(options: AgentIntegrationOptions = {}):
 }
 
 export function uninstallAgentIntegrations(options: AgentIntegrationOptions = {}): AgentIntegrationResult[] {
+  if (options.dryRun) return uninstallAgentIntegrationsUnlocked(options);
+  return withAgentIntegrationLock(options, () => uninstallAgentIntegrationsUnlocked(options));
+}
+
+function uninstallAgentIntegrationsUnlocked(options: AgentIntegrationOptions): AgentIntegrationResult[] {
   const ctx = loadContext(options);
   const ids = options.agentIds?.length
     ? options.agentIds
@@ -345,7 +370,7 @@ export function uninstallAgentIntegrations(options: AgentIntegrationOptions = {}
 function loadContext(options: AgentIntegrationOptions): WorkContext {
   const env = options.env || process.env;
   const platform = options.platform || process.platform;
-  const homeDir = path.resolve(options.homeDir || env.HOME || env.USERPROFILE || os.homedir());
+  const homeDir = integrationHome(options);
   const pathEnv = options.pathEnv ?? env.PATH ?? "";
   const manifestPath = path.join(homeDir, ".s-gw", "agent-integrations.json");
   const windowsMcp = platform === "win32";
@@ -373,6 +398,183 @@ function loadContext(options: AgentIntegrationOptions): WorkContext {
     manifest,
     manifestError
   };
+}
+
+function integrationHome(options: AgentIntegrationOptions): string {
+  const env = options.env || process.env;
+  return path.resolve(options.homeDir || env.HOME || env.USERPROFILE || os.homedir());
+}
+
+function withAgentIntegrationLock<T>(options: AgentIntegrationOptions, body: () => T): T {
+  const homeDir = integrationHome(options);
+  mkdirSync(homeDir, { recursive: true, mode: 0o700 });
+  const lockPath = path.join(homeDir, ".s-gw-agent-integrations.lock");
+  const owner: AgentIntegrationLockOwner = {
+    pid: process.pid,
+    startedAt: Date.now(),
+    token: randomUUID()
+  };
+  const markerName = agentLockMarkerName(owner.token);
+  const started = Date.now();
+  const waiter = new Int32Array(new SharedArrayBuffer(4));
+
+  while (!publishAgentIntegrationLock(lockPath, markerName, owner)) {
+    if (Date.now() - started >= agentLockTimeoutMs) {
+      throw new Error(`Timed out waiting for the agent integration lock at ${lockPath}. Another install or uninstall may still be running.`);
+    }
+    if (removeAbandonedAgentLock(lockPath)) continue;
+    Atomics.wait(waiter, 0, 0, agentLockPollMs);
+  }
+
+  try {
+    return body();
+  } finally {
+    releaseAgentIntegrationLock(lockPath, markerName);
+  }
+}
+
+function publishAgentIntegrationLock(
+  lockPath: string,
+  markerName: string,
+  owner: AgentIntegrationLockOwner
+): boolean {
+  const tmpPath = `${lockPath}.tmp-${process.pid}-${owner.token}`;
+  const markerPath = path.join(tmpPath, markerName);
+  let markerFd: number | undefined;
+  try {
+    mkdirSync(tmpPath, { mode: 0o700 });
+    markerFd = openSync(markerPath, "wx", 0o600);
+    writeFileSync(markerFd, `${JSON.stringify(owner)}\n`);
+    fsyncSync(markerFd);
+    closeSync(markerFd);
+    markerFd = undefined;
+
+    try {
+      renameSync(tmpPath, lockPath);
+      return true;
+    } catch (error) {
+      if (isNodeError(error) && (error.code === "EEXIST" || error.code === "ENOTEMPTY")) return false;
+      if (process.platform === "win32" && isNodeError(error) && (error.code === "EPERM" || error.code === "EACCES")) {
+        return false;
+      }
+      if (isNodeError(error) && (error.code === "EPERM" || error.code === "EACCES") && existsSync(lockPath)) return false;
+      throw error;
+    }
+  } finally {
+    if (markerFd !== undefined) closeSync(markerFd);
+    tryUnlink(markerPath);
+    tryRmdir(tmpPath);
+  }
+}
+
+function inspectAgentIntegrationLock(lockPath: string): AgentIntegrationLockState {
+  const lockInfo = lstatSync(lockPath);
+  if (lockInfo.isSymbolicLink() || !lockInfo.isDirectory()) {
+    throw new Error(`${lockPath} is not a regular directory. s-gw refuses to remove it.`);
+  }
+
+  const entries = readdirSync(lockPath);
+  if (entries.length === 0) return { modifiedAt: lockInfo.mtimeMs };
+  if (entries.length > 1) {
+    throw new Error(`${lockPath} contains unexpected files. s-gw refuses to remove it.`);
+  }
+
+  const markerName = entries[0];
+  const markerPath = path.join(lockPath, markerName);
+  const markerInfo = lstatSync(markerPath);
+  if (markerInfo.isSymbolicLink() || !markerInfo.isFile()) {
+    throw new Error(`${markerPath} is not a regular file. s-gw refuses to remove it.`);
+  }
+
+  const parsed = readAgentLockOwner(readFileSync(markerPath, "utf8"));
+  const owner = parsed && markerName === agentLockMarkerName(parsed.token) ? parsed : undefined;
+  return {
+    markerPath,
+    owner,
+    modifiedAt: Math.max(lockInfo.mtimeMs, markerInfo.mtimeMs)
+  };
+}
+
+function removeAbandonedAgentLock(lockPath: string): boolean {
+  let state: AgentIntegrationLockState;
+  try {
+    state = inspectAgentIntegrationLock(lockPath);
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") return true;
+    throw error;
+  }
+
+  if (state.owner) {
+    if (state.owner.pid === process.pid) {
+      throw new Error(`The current process already owns the agent integration lock at ${lockPath}.`);
+    }
+    if (processIsAlive(state.owner.pid)) return false;
+  } else if (Date.now() - state.modifiedAt <= staleAgentLockMs) {
+    return false;
+  }
+
+  // The marker name belongs to this generation, so an old cleaner cannot unlink a replacement.
+  if (state.markerPath) tryUnlink(state.markerPath);
+  return tryRmdir(lockPath);
+}
+
+function readAgentLockOwner(contents: string): AgentIntegrationLockOwner | undefined {
+  try {
+    const value = JSON.parse(contents) as Partial<AgentIntegrationLockOwner>;
+    if (!Number.isSafeInteger(value.pid) || (value.pid || 0) <= 0) return undefined;
+    if (!Number.isFinite(value.startedAt) || (value.startedAt || 0) <= 0) return undefined;
+    if (typeof value.token !== "string" || !value.token) return undefined;
+    return value as AgentIntegrationLockOwner;
+  } catch {
+    return undefined;
+  }
+}
+
+function agentLockMarkerName(token: string): string {
+  return `owner-${token}.json`;
+}
+
+function processIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return isNodeError(error) && error.code === "EPERM";
+  }
+}
+
+function releaseAgentIntegrationLock(lockPath: string, markerName: string): void {
+  tryUnlink(path.join(lockPath, markerName));
+  tryRmdir(lockPath);
+}
+
+function tryUnlink(filePath: string): void {
+  try {
+    unlinkSync(filePath);
+  } catch (error) {
+    if (!isNodeError(error) || error.code !== "ENOENT") throw error;
+  }
+}
+
+function tryRmdir(dirPath: string): boolean {
+  try {
+    rmdirSync(dirPath);
+    return true;
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") return true;
+    if (isNodeError(error) && (error.code === "ENOTEMPTY" || error.code === "EEXIST")) return false;
+    try {
+      if (readdirSync(dirPath).length > 0) return false;
+    } catch (readError) {
+      if (isNodeError(readError) && readError.code === "ENOENT") return true;
+      throw readError;
+    }
+    throw error;
+  }
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
 }
 
 function selectedProfiles(ids?: string[]): AgentProfile[] {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -28,10 +28,12 @@ import {
   openWindowsClient,
   openWindowsHelper,
   packageHealth,
+  restartWindowsSurfaces,
   startInstalledLaunchAgent,
   stopInstalledLaunchAgent,
   stopMacApp,
   stopWindowsSurfaces,
+  type WindowsStoppedSurfaces,
   uninstallConsoleLaunchAgent,
   uninstallMenuBarLaunchAgent
 } from "./install.js";
@@ -96,10 +98,12 @@ async function main(): Promise<void> {
       return;
     }
     if (second === "install") {
+      const services = updateServiceLifecycle(hasFlag(parsed.flags, "keep-app-running"));
       printJson(await installPackageUpdate({
         ...updateOptions,
         dryRun: hasFlag(parsed.flags, "dry-run"),
-        stopServices: () => stopLocalUpdateSurfaces(hasFlag(parsed.flags, "keep-app-running"))
+        stopServices: services.stop,
+        restartServices: services.restart
       }));
       return;
     }
@@ -1033,12 +1037,78 @@ async function handleStopCommand(): Promise<void> {
   printJson({ ok: true, service, menuBar });
 }
 
-async function stopLocalUpdateSurfaces(keepAppRunning: boolean): Promise<void> {
-  stopBackgroundSurfaces();
-  if (process.platform === "darwin" && !keepAppRunning) {
-    stopMacApp();
-  } else if (process.platform === "win32") {
-    stopWindowsSurfaces();
+function updateServiceLifecycle(keepAppRunning: boolean): {
+  stop: () => Promise<void>;
+  restart: () => Promise<void>;
+} {
+  const serviceWasLoaded = process.platform === "darwin" && launchAgentStatus("console").loaded;
+  const menuBarWasLoaded = process.platform === "darwin" && launchAgentStatus("menubar").loaded;
+  let macAppWasRunning = false;
+  let windowsStopped: WindowsStoppedSurfaces | undefined;
+
+  return {
+    stop: async () => {
+      stopBackgroundSurfaces();
+      if (process.platform === "darwin" && !keepAppRunning) {
+        macAppWasRunning = Boolean(stopMacApp());
+      } else if (process.platform === "win32") {
+        windowsStopped = stopWindowsSurfaces();
+      }
+    },
+    restart: async () => {
+      const failures: string[] = [];
+      if (process.platform === "darwin") {
+        restartLaunchAgent("console", serviceWasLoaded, failures);
+        restartLaunchAgent("menubar", menuBarWasLoaded, failures);
+        await verifyRestoredLaunchAgents(serviceWasLoaded, menuBarWasLoaded, failures);
+        if (macAppWasRunning) {
+          try {
+            openMacApp();
+          } catch (error) {
+            failures.push(`app: ${error instanceof Error ? error.message : String(error)}`);
+          }
+        }
+      } else if (process.platform === "win32" && windowsStopped) {
+        try {
+          await restartWindowsSurfaces(windowsStopped);
+        } catch (error) {
+          failures.push(`Windows surfaces: ${error instanceof Error ? error.message : String(error)}`);
+        }
+      }
+
+      if (failures.length > 0) {
+        throw new Error(failures.join("; "));
+      }
+    }
+  };
+}
+
+async function verifyRestoredLaunchAgents(
+  serviceWasLoaded: boolean,
+  menuBarWasLoaded: boolean,
+  failures: string[]
+): Promise<void> {
+  if (!serviceWasLoaded && !menuBarWasLoaded) return;
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    const serviceReady = !serviceWasLoaded || launchAgentStatus("console").loaded;
+    const menuReady = !menuBarWasLoaded || launchAgentStatus("menubar").loaded;
+    if (serviceReady && menuReady) return;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  if (serviceWasLoaded && !launchAgentStatus("console").loaded) failures.push("console: did not remain loaded");
+  if (menuBarWasLoaded && !launchAgentStatus("menubar").loaded) failures.push("menubar: did not remain loaded");
+}
+
+function restartLaunchAgent(
+  kind: "console" | "menubar",
+  wasLoaded: boolean,
+  failures: string[]
+): void {
+  if (!wasLoaded) return;
+  try {
+    startInstalledLaunchAgent(kind);
+  } catch (error) {
+    failures.push(`${kind}: ${error instanceof Error ? error.message : String(error)}`);
   }
 }
 

--- a/src/console-ui/src/App.tsx
+++ b/src/console-ui/src/App.tsx
@@ -16,6 +16,7 @@ import {
   FileKey2,
   Gauge,
   GripHorizontal,
+  Info,
   KeyRound,
   LayoutDashboard,
   ListChecks,
@@ -60,7 +61,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { ChartContainer, ChartTooltip, ChartTooltipContent, type ChartConfig } from "@/components/ui/chart";
 import {
   Command,
@@ -254,7 +255,7 @@ function App() {
         <ConsoleProvider>
           {(ctx) => <EmbeddedSurface ctx={ctx} compact={embedView.compact} />}
         </ConsoleProvider>
-        <Toaster richColors />
+        <Toaster richColors theme={theme === "light" ? "light" : "dark"} />
       </TooltipProvider>
     );
   }
@@ -265,7 +266,7 @@ function App() {
         <ConsoleProvider>
           {(ctx) => <MenubarSurface ctx={ctx} />}
         </ConsoleProvider>
-        <Toaster richColors />
+        <Toaster richColors theme={theme === "light" ? "light" : "dark"} />
       </TooltipProvider>
     );
   }
@@ -275,7 +276,7 @@ function App() {
       <ConsoleProvider>
         {(ctx) => <ConsoleShell ctx={ctx} theme={theme} setTheme={setTheme} />}
       </ConsoleProvider>
-      <Toaster richColors />
+      <Toaster richColors theme={theme === "light" ? "light" : "dark"} />
     </TooltipProvider>
   );
 }
@@ -723,7 +724,7 @@ function ViewContent({
     case "audit":
       return <AuditLogView state={ctx.state} search={search} setSearch={setSearch} />;
     case "settings":
-      return <SettingsView state={ctx.state} onDone={() => void ctx.refresh()} />;
+      return <SettingsView state={ctx.state} onDone={() => ctx.refresh()} />;
     default:
       return (
         <OverviewDashboard
@@ -913,7 +914,7 @@ function PendingApprovalsPanel({ state, setApproval, setView }: { state: Console
     <div className="flex h-full flex-col justify-between gap-3">
       <div>
         <div className="text-4xl font-semibold">{state.metrics.pendingApprovals}</div>
-        <div className="mt-1 text-sm text-amber-300">{state.metrics.pendingApprovals ? "Approval needed" : "No pending approvals"}</div>
+        <div className="mt-1 text-sm text-amber-700 dark:text-amber-300">{state.metrics.pendingApprovals ? "Approval needed" : "No pending approvals"}</div>
       </div>
       {first ? (
         <div className="rounded-md border bg-muted/25 p-3 text-sm">
@@ -1435,8 +1436,8 @@ function PolicyStatusControl({
       data-policy-status
       className={cn(
         "inline-flex min-w-[92px] items-center gap-2 rounded-md px-2 py-1.5 text-xs font-medium outline-none transition-colors",
-        "hover:bg-white/5 focus-visible:ring-2 focus-visible:ring-ring/60 disabled:cursor-wait disabled:opacity-65",
-        enabled ? "text-emerald-300" : "text-muted-foreground hover:text-foreground"
+        "hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring/60 disabled:cursor-wait disabled:opacity-65",
+        enabled ? "text-emerald-700 dark:text-emerald-300" : "text-muted-foreground hover:text-foreground"
       )}
     >
       {busy ? (
@@ -1607,7 +1608,7 @@ function AgentConfigurationSheet({
               <AgentCapability label="MCP registration" value={titleCase(agent.integration.mcp.state)} />
               <AgentCapability label="s-gw skill" value={titleCase(agent.integration.skill.state)} />
             </div>
-            {agent.integration.reason ? <p className="text-xs text-amber-300">{agent.integration.reason}</p> : null}
+            {agent.integration.reason ? <p className="text-xs text-amber-700 dark:text-amber-300">{agent.integration.reason}</p> : null}
           </section>
 
           <section className="grid gap-2 text-sm sm:grid-cols-2">
@@ -1630,7 +1631,7 @@ function AgentConfigurationSheet({
                   Copy snippet
                 </Button>
               </div>
-              <pre className="max-h-64 overflow-auto rounded-md border bg-black/25 p-3 font-mono text-xs leading-5 text-foreground"><code>{agent.mcp.snippet}</code></pre>
+              <pre className="max-h-64 overflow-auto rounded-md border bg-muted/70 p-3 font-mono text-xs leading-5 text-foreground"><code>{agent.mcp.snippet}</code></pre>
               <AgentPathList label="Configuration paths" paths={agent.mcp.configPaths} />
               {agent.mcp.notes.map((note) => <p key={note} className="text-xs text-muted-foreground">{note}</p>)}
               <CopyCommand value={agent.snippetCommand} label="Generate from CLI" onCopy={copy} />
@@ -1718,7 +1719,7 @@ function CopyCommand({
   onCopy: (value: string, label: string) => Promise<void>;
 }) {
   return (
-    <div className="flex items-center gap-2 rounded-md border bg-black/20 p-2">
+    <div className="flex items-center gap-2 rounded-md border bg-muted/60 p-2">
       <code className="min-w-0 flex-1 overflow-x-auto whitespace-pre font-mono text-xs">{value}</code>
       <Button variant="ghost" size="icon-sm" onClick={() => void onCopy(value, label)} aria-label={`Copy ${label.toLowerCase()}`}>
         <Copy className="h-4 w-4" />
@@ -2115,8 +2116,8 @@ function renderEventColumn(row: EventLogRow, column: EventColumnId, mode: "activ
 }
 
 function eventColumnClassName(column: EventColumnId): string {
-  if (column === "eventId") return "font-mono text-xs text-muted-foreground";
-  if (column === "timestamp") return "text-muted-foreground";
+  if (column === "eventId") return "max-w-[180px] truncate font-mono text-xs text-muted-foreground";
+  if (column === "timestamp") return "whitespace-nowrap text-muted-foreground";
   if (column === "ruleName") return "max-w-[240px] truncate";
   return "max-w-[220px] truncate";
 }
@@ -2193,96 +2194,310 @@ function EmptyEventRows({ message }: { message: string }) {
   return <div className="py-8 text-center text-sm text-muted-foreground">{message}</div>;
 }
 
-function SettingsView({ state, onDone }: { state: ConsoleState; onDone: () => void }) {
+const approvalModePresentation: Record<ApprovalMode, { label: string; detail: string }> = {
+  "per-transaction": {
+    label: "Ask every time",
+    detail: "Require approval for each credential operation."
+  },
+  "timed-session": {
+    label: "Reuse for a time window",
+    detail: "Reuse a matching approval for a limited period."
+  },
+  "login-session": {
+    label: "Reuse for this login session",
+    detail: "Reuse a matching approval until you sign out."
+  },
+  always: {
+    label: "Reuse until revoked",
+    detail: "Keep a matching approval active until you clear it."
+  }
+};
+
+const commonApprovalDurations = [
+  { value: 15 * 60 * 1000, label: "15 minutes" },
+  { value: 60 * 60 * 1000, label: "1 hour" },
+  { value: 8 * 60 * 60 * 1000, label: "8 hours" },
+  { value: 24 * 60 * 60 * 1000, label: "1 day" },
+  { value: 7 * 24 * 60 * 60 * 1000, label: "7 days" },
+  { value: 30 * 24 * 60 * 60 * 1000, label: "30 days" }
+];
+
+function approvalDurationChoices(savedMs: number): Array<{ value: number; label: string }> {
+  if (commonApprovalDurations.some((choice) => choice.value === savedMs)) {
+    return commonApprovalDurations;
+  }
+  return [{ value: savedMs, label: `Current setting · ${durationLabel(savedMs)}` }, ...commonApprovalDurations];
+}
+
+function SettingsView({ state, onDone }: { state: ConsoleState; onDone: () => Promise<void> }) {
   const [mode, setMode] = React.useState<ApprovalMode>(state.approvalSettings.mode);
-  const [durationMs, setDurationMs] = React.useState(String(state.approvalSettings.durationMs));
+  const [durationMs, setDurationMs] = React.useState(state.approvalSettings.durationMs);
+  const [saving, setSaving] = React.useState(false);
+  const [clearing, setClearing] = React.useState(false);
+  const durationChoices = approvalDurationChoices(state.approvalSettings.durationMs);
+  const durationEnabled = mode === "timed-session";
+  const isDirty = mode !== state.approvalSettings.mode || durationMs !== state.approvalSettings.durationMs;
+  const versionLabel = state.version.startsWith("v") ? state.version : `v${state.version}`;
+
+  const saveSettings = async () => {
+    if (saving) return;
+    setSaving(true);
+    try {
+      await saveApprovalSettings({ mode, durationMs });
+      toast.success("Approval settings updated");
+      await onDone();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Could not update approval settings");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const clearReusableGrants = async () => {
+    if (clearing) return;
+    setClearing(true);
+    try {
+      await clearGrants();
+      toast.success("Reusable approvals cleared");
+      await onDone();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Could not clear reusable approvals");
+    } finally {
+      setClearing(false);
+    }
+  };
+
   return (
     <PageFrame title="Settings" description="Approval behavior, reusable grants, and local console preferences.">
-      <Tabs defaultValue="approvals">
-        <TabsList>
-          <TabsTrigger value="approvals">Approvals</TabsTrigger>
-          <TabsTrigger value="grants">Reusable grants</TabsTrigger>
-          <TabsTrigger value="about">About</TabsTrigger>
+      <Tabs defaultValue="approvals" className="max-w-5xl gap-4">
+        <TabsList
+          aria-label="Settings sections"
+          data-settings-nav
+          className="grid h-auto! w-full grid-cols-3 items-stretch gap-2 rounded-xl border bg-card/70 p-2"
+        >
+          <TabsTrigger
+            value="approvals"
+            data-settings-tab="approvals"
+            className="h-auto min-h-14 flex-col gap-1.5 whitespace-normal px-2 py-2 text-center shadow-none after:hidden sm:min-h-16 sm:flex-row sm:justify-start sm:gap-3 sm:px-3 sm:text-left data-[state=active]:border-primary/50 data-[state=active]:bg-primary/10"
+          >
+            <span className="grid size-7 shrink-0 place-items-center rounded-lg bg-primary/10 text-primary sm:size-8">
+              <ShieldCheck className="size-4" aria-hidden="true" />
+            </span>
+            <span className="min-w-0">
+              <span className="block text-sm font-medium leading-tight text-foreground">Approval defaults</span>
+              <span className="mt-1 hidden text-xs font-normal leading-tight text-muted-foreground md:block">
+                Set default request behavior
+              </span>
+            </span>
+          </TabsTrigger>
+          <TabsTrigger
+            value="grants"
+            data-settings-tab="grants"
+            className="h-auto min-h-14 flex-col gap-1.5 whitespace-normal px-2 py-2 text-center shadow-none after:hidden sm:min-h-16 sm:flex-row sm:justify-start sm:gap-3 sm:px-3 sm:text-left data-[state=active]:border-primary/50 data-[state=active]:bg-primary/10"
+          >
+            <span className="grid size-7 shrink-0 place-items-center rounded-lg bg-primary/10 text-primary sm:size-8">
+              <Clock3 className="size-4" aria-hidden="true" />
+            </span>
+            <span className="min-w-0">
+              <span className="block text-sm font-medium leading-tight text-foreground">Reusable grants</span>
+              <span className="mt-1 hidden text-xs font-normal leading-tight text-muted-foreground md:block">
+                Review reusable access
+              </span>
+            </span>
+          </TabsTrigger>
+          <TabsTrigger
+            value="about"
+            data-settings-tab="about"
+            className="h-auto min-h-14 flex-col gap-1.5 whitespace-normal px-2 py-2 text-center shadow-none after:hidden sm:min-h-16 sm:flex-row sm:justify-start sm:gap-3 sm:px-3 sm:text-left data-[state=active]:border-primary/50 data-[state=active]:bg-primary/10"
+          >
+            <span className="grid size-7 shrink-0 place-items-center rounded-lg bg-primary/10 text-primary sm:size-8">
+              <Info className="size-4" aria-hidden="true" />
+            </span>
+            <span className="min-w-0">
+              <span className="block text-sm font-medium leading-tight text-foreground">About</span>
+              <span className="mt-1 hidden text-xs font-normal leading-tight text-muted-foreground md:block">
+                Version and local storage
+              </span>
+            </span>
+          </TabsTrigger>
         </TabsList>
-        <TabsContent value="approvals" className="mt-4">
-          <Card>
-            <CardHeader>
-              <CardTitle>Default approval mode</CardTitle>
+        <TabsContent value="approvals" className="m-0">
+          <Card data-settings-panel="approvals">
+            <CardHeader className="border-b">
+              <CardTitle>Default approval behavior</CardTitle>
               <CardDescription>Each approval is still scoped by handle, action, agent, and target context.</CardDescription>
             </CardHeader>
-            <CardContent className="grid gap-4 md:grid-cols-3">
-              <Select value={mode} onValueChange={(value) => setMode(value as ApprovalMode)}>
-                <SelectTrigger><SelectValue /></SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="per-transaction">Approve per transaction</SelectItem>
-                  <SelectItem value="timed-session">Approve same session for time</SelectItem>
-                  <SelectItem value="login-session">Approve current login session</SelectItem>
-                  <SelectItem value="always">Approve matching action always</SelectItem>
-                </SelectContent>
-              </Select>
-              <Input value={durationMs} onChange={(event) => setDurationMs(event.target.value)} placeholder="Duration ms" />
-              <Button
-                onClick={async () => {
-                  await saveApprovalSettings({ mode, durationMs: Number(durationMs) || 15 * 60 * 1000 });
-                  toast.success("Approval settings updated");
-                  onDone();
-                }}
-              >
-                Save approval settings
-              </Button>
+            <CardContent className="grid gap-6 md:grid-cols-2">
+              <div className="space-y-2">
+                <label htmlFor="approval-mode" className="text-sm font-medium">Approval mode</label>
+                <Select value={mode} onValueChange={(value) => setMode(value as ApprovalMode)}>
+                  <SelectTrigger
+                    id="approval-mode"
+                    data-settings-mode
+                    aria-describedby="approval-mode-help"
+                    className="h-10 w-full"
+                  >
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {(Object.keys(approvalModePresentation) as ApprovalMode[]).map((value) => (
+                      <SelectItem key={value} value={value}>{approvalModePresentation[value].label}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <p id="approval-mode-help" className="text-xs leading-relaxed text-muted-foreground">
+                  {approvalModePresentation[mode].detail}
+                </p>
+              </div>
+              <div className="space-y-2">
+                <label htmlFor="approval-duration" className="text-sm font-medium">Reusable duration</label>
+                <Select
+                  value={String(durationMs)}
+                  onValueChange={(value) => setDurationMs(Number(value))}
+                  disabled={!durationEnabled}
+                >
+                  <SelectTrigger
+                    id="approval-duration"
+                    data-settings-duration
+                    aria-describedby="approval-duration-help"
+                    className="h-10 w-full"
+                  >
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {durationChoices.map((choice) => (
+                      <SelectItem key={choice.value} value={String(choice.value)}>{choice.label}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <p id="approval-duration-help" className="text-xs leading-relaxed text-muted-foreground">
+                  {durationEnabled
+                    ? "Matching approvals expire after this window."
+                    : "Available when approval mode uses a time window."}
+                </p>
+              </div>
             </CardContent>
+            <CardFooter className="flex-col items-stretch justify-between gap-3 sm:flex-row sm:items-center">
+              <div className="flex items-start gap-2 text-xs text-muted-foreground">
+                {state.approvalGrants.length > 0 ? (
+                  <AlertTriangle className="mt-0.5 size-3.5 shrink-0 text-amber-500" aria-hidden="true" />
+                ) : null}
+                <p>
+                  {state.approvalGrants.length > 0
+                    ? `Saving clears ${state.approvalGrants.length} active reusable ${state.approvalGrants.length === 1 ? "grant" : "grants"}, so matching requests ask again.`
+                    : "Changes apply to new approvals."}
+                </p>
+              </div>
+              <Button
+                data-settings-save
+                className="w-full sm:w-auto"
+                disabled={!isDirty || saving}
+                onClick={() => void saveSettings()}
+              >
+                {saving ? <Loader2 className="size-4 animate-spin" aria-hidden="true" /> : null}
+                Save changes
+              </Button>
+            </CardFooter>
           </Card>
         </TabsContent>
-        <TabsContent value="grants" className="mt-4">
-          <DataCard>
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Handle</TableHead>
-                  <TableHead>Mode</TableHead>
-                  <TableHead>Agent</TableHead>
-                  <TableHead>Expires</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {state.approvalGrants.map((grant) => (
-                  <TableRow key={grant.id}>
-                    <TableCell className="font-mono text-xs">{shortHandle(grant.handle)}</TableCell>
-                    <TableCell>{grant.mode}</TableCell>
-                    <TableCell>
-                      {grant.agentName ? (
-                        <span className="flex items-center gap-2">
-                          <AgentIcon name={grant.agentName} className="h-6 w-6" />
-                          <span>{grant.agentName}</span>
-                        </span>
-                      ) : "Any agent"}
-                    </TableCell>
-                    <TableCell>{grant.expiresAt ? relativeTime(grant.expiresAt) : "No expiry"}</TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-            <Button
-              variant="destructive"
-              className="mt-4"
-              onClick={async () => {
-                await clearGrants();
-                toast.success("Reusable approvals cleared");
-                onDone();
-              }}
-            >
-              Clear reusable approvals
-            </Button>
-          </DataCard>
-        </TabsContent>
-        <TabsContent value="about" className="mt-4">
-          <Card>
-            <CardHeader>
-              <CardTitle>s-gw {state.version}</CardTitle>
-              <CardDescription>Local credential gateway for AI coding agents.</CardDescription>
+        <TabsContent value="grants" className="m-0">
+          <Card data-settings-panel="grants">
+            <CardHeader className="border-b">
+              <div className="flex items-start justify-between gap-4">
+                <div className="space-y-1">
+                  <CardTitle>Reusable grants</CardTitle>
+                  <CardDescription>Approvals that can be reused without prompting again.</CardDescription>
+                </div>
+                <Badge variant="secondary">{state.approvalGrants.length} active</Badge>
+              </div>
             </CardHeader>
-            <CardContent className="text-sm text-muted-foreground">
-              Store: <span className="font-mono">{state.status.storePath}</span>
+            <CardContent className="p-0">
+              {state.approvalGrants.length === 0 ? (
+                <div data-settings-grants-empty className="grid min-h-56 place-items-center px-6 py-10 text-center">
+                  <div>
+                    <span className="mx-auto grid size-10 place-items-center rounded-full bg-muted text-muted-foreground">
+                      <Clock3 className="size-5" aria-hidden="true" />
+                    </span>
+                    <h3 className="mt-3 font-medium">No reusable grants</h3>
+                    <p className="mt-1 max-w-sm text-sm text-muted-foreground">
+                      Time-window, login-session, and until-revoked approvals will appear here.
+                    </p>
+                  </div>
+                </div>
+              ) : (
+                <div className="overflow-x-auto">
+                  <Table className="min-w-[640px]">
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>Handle</TableHead>
+                        <TableHead>Mode</TableHead>
+                        <TableHead>Agent</TableHead>
+                        <TableHead>Expires</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {state.approvalGrants.map((grant) => (
+                        <TableRow key={grant.id}>
+                          <TableCell className="font-mono text-xs">{shortHandle(grant.handle)}</TableCell>
+                          <TableCell>{approvalModePresentation[grant.mode].label}</TableCell>
+                          <TableCell>
+                            {grant.agentName ? (
+                              <span className="flex items-center gap-2">
+                                <AgentIcon name={grant.agentName} className="h-6 w-6" />
+                                <span>{grant.agentName}</span>
+                              </span>
+                            ) : "Any agent"}
+                          </TableCell>
+                          <TableCell>{grant.expiresAt ? relativeTime(grant.expiresAt) : "No expiry"}</TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </div>
+              )}
+            </CardContent>
+            {state.approvalGrants.length > 0 ? (
+              <CardFooter className="flex-col items-stretch justify-between gap-3 sm:flex-row sm:items-center">
+                <p className="text-xs text-muted-foreground">Clearing grants makes matching requests ask for approval again.</p>
+                <Button
+                  variant="destructive"
+                  className="w-full sm:w-auto"
+                  disabled={clearing}
+                  onClick={() => void clearReusableGrants()}
+                >
+                  {clearing ? <Loader2 className="size-4 animate-spin" aria-hidden="true" /> : <Trash2 className="size-4" aria-hidden="true" />}
+                  Clear all grants
+                </Button>
+              </CardFooter>
+            ) : null}
+          </Card>
+        </TabsContent>
+        <TabsContent value="about" className="m-0">
+          <Card data-settings-panel="about">
+            <CardHeader className="border-b">
+              <div className="flex items-center gap-3">
+                <SgwLogo showText={false} />
+                <div>
+                  <CardTitle>s-gw</CardTitle>
+                  <CardDescription>Local credential gateway for AI coding agents.</CardDescription>
+                </div>
+              </div>
+            </CardHeader>
+            <CardContent>
+              <dl className="divide-y overflow-hidden rounded-lg border">
+                <div className="flex flex-col gap-1 px-4 py-3 sm:flex-row sm:items-center sm:justify-between sm:gap-6">
+                  <dt className="text-sm text-muted-foreground">Version</dt>
+                  <dd className="text-sm font-medium">{versionLabel}</dd>
+                </div>
+                <div className="flex flex-col gap-1 px-4 py-3 sm:flex-row sm:items-start sm:justify-between sm:gap-6">
+                  <dt className="shrink-0 text-sm text-muted-foreground">Store location</dt>
+                  <dd className="break-all font-mono text-xs sm:text-right">{state.status.storePath}</dd>
+                </div>
+                <div className="flex flex-col gap-1 px-4 py-3 sm:flex-row sm:items-center sm:justify-between sm:gap-6">
+                  <dt className="text-sm text-muted-foreground">Control plane</dt>
+                  <dd className="text-sm font-medium">Runs locally</dd>
+                </div>
+              </dl>
             </CardContent>
           </Card>
         </TabsContent>

--- a/src/console-ui/src/components/ui/tabs.tsx
+++ b/src/console-ui/src/components/ui/tabs.tsx
@@ -16,7 +16,7 @@ function Tabs({
       data-slot="tabs"
       data-orientation={orientation}
       className={cn(
-        "group/tabs flex gap-2 data-horizontal:flex-col",
+        "group/tabs flex gap-2 data-[orientation=horizontal]:flex-col",
         className
       )}
       {...props}
@@ -25,7 +25,7 @@ function Tabs({
 }
 
 const tabsListVariants = cva(
-  "group/tabs-list inline-flex w-fit items-center justify-center rounded-lg p-[3px] text-muted-foreground group-data-horizontal/tabs:h-8 group-data-vertical/tabs:h-fit group-data-vertical/tabs:flex-col data-[variant=line]:rounded-none",
+  "group/tabs-list inline-flex w-fit items-center justify-center rounded-lg p-[3px] text-muted-foreground group-data-[orientation=horizontal]/tabs:h-8 group-data-[orientation=vertical]/tabs:h-fit group-data-[orientation=vertical]/tabs:flex-col data-[variant=line]:rounded-none",
   {
     variants: {
       variant: {
@@ -63,10 +63,10 @@ function TabsTrigger({
     <TabsPrimitive.Trigger
       data-slot="tabs-trigger"
       className={cn(
-        "relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-1.5 py-0.5 text-sm font-medium whitespace-nowrap text-foreground/60 transition-all group-data-vertical/tabs:w-full group-data-vertical/tabs:justify-start hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50 has-data-[icon=inline-end]:pr-1 has-data-[icon=inline-start]:pl-1 dark:text-muted-foreground dark:hover:text-foreground group-data-[variant=default]/tabs-list:data-active:shadow-sm group-data-[variant=line]/tabs-list:data-active:shadow-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-        "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-active:bg-transparent dark:group-data-[variant=line]/tabs-list:data-active:border-transparent dark:group-data-[variant=line]/tabs-list:data-active:bg-transparent",
-        "data-active:bg-background data-active:text-foreground dark:data-active:border-input dark:data-active:bg-input/30 dark:data-active:text-foreground",
-        "after:absolute after:bg-foreground after:opacity-0 after:transition-opacity group-data-horizontal/tabs:after:inset-x-0 group-data-horizontal/tabs:after:bottom-[-5px] group-data-horizontal/tabs:after:h-0.5 group-data-vertical/tabs:after:inset-y-0 group-data-vertical/tabs:after:-right-1 group-data-vertical/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-active:after:opacity-100",
+        "relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-1.5 py-0.5 text-sm font-medium whitespace-nowrap text-foreground/60 transition-all group-data-[orientation=vertical]/tabs:w-full group-data-[orientation=vertical]/tabs:justify-start hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50 has-data-[icon=inline-end]:pr-1 has-data-[icon=inline-start]:pl-1 dark:text-muted-foreground dark:hover:text-foreground group-data-[variant=default]/tabs-list:data-[state=active]:shadow-sm group-data-[variant=line]/tabs-list:data-[state=active]:shadow-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:border-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent",
+        "data-[state=active]:bg-background data-[state=active]:text-foreground dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 dark:data-[state=active]:text-foreground",
+        "after:absolute after:bg-foreground after:opacity-0 after:transition-opacity group-data-[orientation=horizontal]/tabs:after:inset-x-0 group-data-[orientation=horizontal]/tabs:after:bottom-[-5px] group-data-[orientation=horizontal]/tabs:after:h-0.5 group-data-[orientation=vertical]/tabs:after:inset-y-0 group-data-[orientation=vertical]/tabs:after:-right-1 group-data-[orientation=vertical]/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-[state=active]:after:opacity-100",
         className
       )}
       {...props}

--- a/src/console-ui/src/index.css
+++ b/src/console-ui/src/index.css
@@ -33,6 +33,9 @@
   --chart-3: #2b9cff;
   --chart-4: #58e6ad;
   --chart-5: #f4c76a;
+  --status-success: #56e6ad;
+  --status-pending: #f0c243;
+  --status-failure: #ff5f6d;
   --sidebar: #050910;
   --sidebar-foreground: #edf6ff;
   --sidebar-primary: #3eb7ff;
@@ -65,6 +68,9 @@
   --border: rgb(7 17 28 / 0.12);
   --input: rgb(7 17 28 / 0.13);
   --ring: #0eb981;
+  --status-success: #087a55;
+  --status-pending: #976400;
+  --status-failure: #c72c3e;
   --sidebar: #f5fbff;
   --sidebar-foreground: #0b1825;
   --sidebar-primary: #0b78c8;
@@ -382,15 +388,15 @@
 }
 
 .sgw-activity-status-dot.is-success {
-  background: #56e6ad;
+  background: var(--status-success);
 }
 
 .sgw-activity-status-dot.is-pending {
-  background: #f4b64f;
+  background: var(--status-pending);
 }
 
 .sgw-activity-status-dot.is-failure {
-  background: #ff665e;
+  background: var(--status-failure);
 }
 
 .sgw-activity-flow-row.is-compact {
@@ -462,10 +468,10 @@
 
 .sgw-event-log-card {
   overflow: hidden;
-  border: 1px solid rgb(213 235 255 / 0.1);
+  border: 1px solid var(--border);
   border-radius: 0.75rem;
-  background: #131a23;
-  box-shadow: 0 20px 52px rgb(0 0 0 / 0.32), 0 1px 0 rgb(255 255 255 / 0.035) inset;
+  background: var(--card);
+  box-shadow: 0 20px 52px rgb(0 0 0 / 0.16), 0 1px 0 color-mix(in oklab, var(--foreground) 4%, transparent) inset;
 }
 
 .sgw-event-log-toolbar {
@@ -481,9 +487,9 @@
   flex: 0 0 auto;
   align-items: center;
   gap: 0.12rem;
-  border: 1px solid rgb(255 255 255 / 0.15);
+  border: 1px solid var(--input);
   border-radius: 0.5rem;
-  background: rgb(0 0 0 / 0.24);
+  background: var(--background);
   padding: 0.15rem;
 }
 
@@ -492,7 +498,7 @@
   border: 0;
   border-radius: 0.34rem;
   background: transparent;
-  color: rgb(255 255 255 / 0.52);
+  color: var(--muted-foreground);
   font: inherit;
   font-size: 0.78rem;
   font-weight: 500;
@@ -500,9 +506,9 @@
 }
 
 .sgw-event-mode-toggle button.is-active {
-  background: rgb(137 154 217 / 0.22);
-  color: rgb(255 255 255 / 0.92);
-  box-shadow: 0 0 0 1px rgb(100 158 245 / 0.2) inset;
+  background: var(--accent);
+  color: var(--accent-foreground);
+  box-shadow: 0 0 0 1px var(--border) inset;
 }
 
 .sgw-event-query {
@@ -511,11 +517,11 @@
   flex: 1 1 24rem;
   align-items: center;
   gap: 0.5rem;
-  border: 1px solid rgb(255 255 255 / 0.16);
+  border: 1px solid var(--input);
   border-radius: 0.5rem;
-  background: rgb(0 0 0 / 0.22);
+  background: var(--background);
   padding: 0 0.75rem;
-  color: rgb(255 255 255 / 0.45);
+  color: var(--muted-foreground);
 }
 
 .sgw-event-query-input {
@@ -529,12 +535,12 @@
 }
 
 .sgw-event-filter-button {
-  color: #649ef5;
+  color: var(--sidebar-primary);
   font-weight: 700;
 }
 
 .sgw-event-filter-button[aria-expanded="true"] {
-  background: rgb(100 158 245 / 0.12);
+  background: var(--accent);
 }
 
 .sgw-event-filter-row {
@@ -546,34 +552,34 @@
 
 .sgw-event-filter-select {
   width: 12rem;
-  border-color: rgb(255 255 255 / 0.16);
-  background: rgb(0 0 0 / 0.22);
+  border-color: var(--input);
+  background: var(--background);
 }
 
 .sgw-event-filter-input {
   width: min(22rem, 100%);
-  border-color: rgb(255 255 255 / 0.16);
-  background: rgb(0 0 0 / 0.22);
+  border-color: var(--input);
+  background: var(--background);
 }
 
 .sgw-event-range {
   width: 10.5rem;
   border-width: 2px;
-  border-color: rgb(126 134 143 / 0.95);
-  background: #373c42;
+  border-color: color-mix(in oklab, var(--foreground) 38%, transparent);
+  background: var(--secondary);
 }
 
 .sgw-event-count {
   flex: 0 0 auto;
-  color: rgb(255 255 255 / 0.72);
+  color: var(--muted-foreground);
   font-size: 0.82rem;
 }
 
 .sgw-event-export {
   margin-left: auto;
   border-width: 2px;
-  border-color: #649ef5;
-  color: #649ef5;
+  border-color: var(--sidebar-primary);
+  color: var(--sidebar-primary);
   font-weight: 700;
 }
 
@@ -591,8 +597,8 @@
   align-items: center;
   gap: 0.38rem;
   border-radius: 999px;
-  background: #384452;
-  color: rgb(255 255 255 / 0.82);
+  background: var(--secondary);
+  color: var(--secondary-foreground);
   font-size: 0.72rem;
   font-weight: 700;
   padding: 0.25rem 0.62rem;
@@ -605,7 +611,7 @@
   justify-content: center;
   border: 0;
   background: transparent;
-  color: #649ef5;
+  color: var(--sidebar-primary);
   font: inherit;
   font-weight: 700;
   padding: 0;
@@ -613,7 +619,7 @@
 
 .sgw-event-column-filter-chip {
   max-width: min(24rem, 100%);
-  background: #273b55;
+  background: var(--accent);
 }
 
 .sgw-event-table-wrap {
@@ -631,8 +637,8 @@
 
 .sgw-event-table [data-slot="table-head"] {
   height: 2.75rem;
-  border-bottom: 2px solid rgb(255 255 255 / 0.68);
-  color: rgb(255 255 255 / 0.86);
+  border-bottom: 2px solid color-mix(in oklab, var(--foreground) 58%, transparent);
+  color: var(--foreground);
   font-size: 0.74rem;
   font-weight: 800;
 }
@@ -653,16 +659,16 @@
 
 .sgw-event-sort-button svg {
   flex: 0 0 auto;
-  color: rgb(255 255 255 / 0.36);
+  color: var(--muted-foreground);
   transition: color 120ms ease, transform 120ms ease;
 }
 
 .sgw-event-sort-button.is-active {
-  color: #cfe4ff;
+  color: var(--foreground);
 }
 
 .sgw-event-sort-button.is-active svg {
-  color: #649ef5;
+  color: var(--sidebar-primary);
 }
 
 .sgw-event-sort-button svg.is-desc {
@@ -671,13 +677,13 @@
 
 .sgw-event-row {
   cursor: pointer;
-  border-color: rgb(255 255 255 / 0.18);
-  color: rgb(255 255 255 / 0.72);
+  border-color: var(--border);
+  color: color-mix(in oklab, var(--foreground) 82%, transparent);
 }
 
 .sgw-event-row:hover,
 .sgw-event-row[aria-expanded="true"] {
-  background: rgb(255 255 255 / 0.025);
+  background: color-mix(in oklab, var(--muted) 72%, transparent);
 }
 
 .sgw-event-row [data-slot="table-cell"] {
@@ -724,7 +730,7 @@
   display: inline-flex;
   align-items: center;
   gap: 0.36rem;
-  color: rgb(255 255 255 / 0.76);
+  color: var(--foreground);
   font-size: 0.78rem;
 }
 
@@ -736,15 +742,15 @@
 }
 
 .sgw-event-status.is-success {
-  color: #56e6ad;
+  color: var(--status-success);
 }
 
 .sgw-event-status.is-pending {
-  color: #f0c243;
+  color: var(--status-pending);
 }
 
 .sgw-event-status.is-failure {
-  color: #ff5f6d;
+  color: var(--status-failure);
 }
 
 .sgw-event-expanded-row,
@@ -760,7 +766,7 @@
 .sgw-event-detail-stage {
   min-height: 13.8rem;
   overflow: hidden;
-  background: #090d0e;
+  background: var(--background);
   padding: 1.6rem 1.15rem;
 }
 
@@ -778,10 +784,10 @@
   align-content: start;
   justify-items: center;
   gap: 0.34rem;
-  border: 1px solid rgb(213 235 255 / 0.055);
+  border: 1px solid var(--border);
   border-radius: 0.5rem;
-  background: #131c26;
-  box-shadow: 0 12px 26px rgb(0 0 0 / 0.28);
+  background: var(--card);
+  box-shadow: 0 12px 26px rgb(0 0 0 / 0.14);
   padding: 0.92rem 0.72rem 0.82rem;
   text-align: center;
 }
@@ -830,7 +836,7 @@
 .sgw-event-flow-title {
   max-width: 100%;
   overflow: hidden;
-  color: rgb(255 255 255 / 0.86);
+  color: var(--foreground);
   font-size: 0.72rem;
   font-weight: 800;
   text-overflow: ellipsis;
@@ -840,7 +846,7 @@
 .sgw-event-flow-subtitle {
   max-width: 100%;
   overflow: hidden;
-  color: rgb(255 255 255 / 0.5);
+  color: var(--muted-foreground);
   font-size: 0.66rem;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -858,13 +864,13 @@
   display: grid;
   grid-template-columns: auto minmax(0, 1fr);
   gap: 0.3rem;
-  color: rgb(255 255 255 / 0.62);
+  color: var(--muted-foreground);
   font-size: 0.65rem;
   line-height: 1.35;
 }
 
 .sgw-event-flow-line span {
-  color: rgb(255 255 255 / 0.88);
+  color: var(--foreground);
   font-weight: 800;
 }
 
@@ -889,12 +895,12 @@
 }
 
 .sgw-event-flow-link.is-failure span {
-  border-color: #b83e4c;
+  border-color: var(--status-failure);
   border-top-style: dashed;
 }
 
 .sgw-event-flow-link.is-pending span {
-  border-color: #f0c243;
+  border-color: var(--status-pending);
 }
 
 .sgw-event-detail-stage.is-compact {
@@ -950,15 +956,15 @@
   align-items: center;
   justify-content: space-between;
   gap: 0.75rem;
-  color: rgb(255 255 255 / 0.58);
+  color: var(--muted-foreground);
   font-size: 0.72rem;
 }
 
 .sgw-recent-event-list {
-  border: 1px solid rgb(213 235 255 / 0.1);
+  border: 1px solid var(--border);
   border-radius: 0.62rem;
-  background: #131a23;
-  box-shadow: 0 12px 30px rgb(0 0 0 / 0.22), 0 1px 0 rgb(255 255 255 / 0.03) inset;
+  background: var(--card);
+  box-shadow: 0 12px 30px rgb(0 0 0 / 0.12), 0 1px 0 color-mix(in oklab, var(--foreground) 3%, transparent) inset;
 }
 
 .sgw-recent-event-table {
@@ -976,16 +982,16 @@
 
 .sgw-recent-event-head {
   height: 2.35rem;
-  border-bottom: 2px solid rgb(255 255 255 / 0.62);
-  color: rgb(255 255 255 / 0.86);
+  border-bottom: 2px solid color-mix(in oklab, var(--foreground) 54%, transparent);
+  color: var(--foreground);
   font-size: 0.68rem;
   font-weight: 800;
 }
 
 .sgw-recent-event-row {
   height: 44px;
-  border-bottom: 1px solid rgb(255 255 255 / 0.18);
-  color: rgb(255 255 255 / 0.72);
+  border-bottom: 1px solid var(--border);
+  color: color-mix(in oklab, var(--foreground) 82%, transparent);
   font-size: 0.72rem;
 }
 
@@ -1219,15 +1225,15 @@
 }
 
 .sgw-sidebar-titlebar-trigger:hover {
-  border-color: rgb(213 235 255 / 0.12);
-  background: rgb(213 235 255 / 0.055);
+  border-color: var(--sidebar-border);
+  background: var(--sidebar-accent);
 }
 
 .sgw-sidebar-expand-button {
   height: 2.5rem;
   width: 2.5rem;
-  border: 1px solid rgb(213 235 255 / 0.11);
-  background: rgb(213 235 255 / 0.035);
+  border: 1px solid var(--sidebar-border);
+  background: color-mix(in oklab, var(--sidebar-accent) 60%, transparent);
   box-shadow: none;
 }
 
@@ -1238,22 +1244,21 @@
 }
 
 .sgw-sidebar-nav-button {
-  border-color: rgb(213 235 255 / 0.105);
-  background: rgb(213 235 255 / 0.035);
-  color: rgb(237 246 255 / 0.86);
+  border-color: var(--sidebar-border);
+  background: color-mix(in oklab, var(--sidebar-accent) 60%, transparent);
+  color: color-mix(in oklab, var(--sidebar-foreground) 86%, transparent);
   box-shadow: none;
 }
 
 .sgw-sidebar-nav-button:hover {
-  border-color: rgb(213 235 255 / 0.16);
-  background: rgb(213 235 255 / 0.058);
-  color: rgb(247 251 255 / 0.96);
+  border-color: color-mix(in oklab, var(--sidebar-border) 82%, var(--sidebar-foreground));
+  background: var(--sidebar-accent);
+  color: var(--sidebar-accent-foreground);
 }
 
 .sgw-sidebar-nav-button[data-active="true"] {
-  border-color: rgb(213 235 255 / 0.17);
-  background:
-    linear-gradient(180deg, rgb(213 235 255 / 0.08), rgb(213 235 255 / 0.045));
+  border-color: color-mix(in oklab, var(--sidebar-border) 82%, var(--sidebar-primary));
+  background: var(--sidebar-accent);
   color: var(--sidebar-foreground);
 }
 
@@ -1362,7 +1367,7 @@
 }
 
 [data-slot="table-header"] {
-  background: rgb(255 255 255 / 0.035);
+  background: color-mix(in oklab, var(--foreground) 3.5%, transparent);
 }
 
 .sankey-wrap {
@@ -1430,6 +1435,13 @@
 .light [data-slot="input"] {
   border-color: rgb(7 17 28 / 0.12);
   background: rgb(255 255 255 / 0.66);
+}
+
+.light [data-slot="button"][data-variant="outline"]:hover,
+.light [data-slot="button"][data-variant="secondary"]:hover,
+.light [data-slot="button"][data-variant="ghost"]:hover,
+.light [data-slot="select-trigger"]:hover {
+  background: var(--muted);
 }
 
 .light .sankey-wrap {

--- a/src/console-ui/src/lib/sample-data.ts
+++ b/src/console-ui/src/lib/sample-data.ts
@@ -104,7 +104,7 @@ export const sampleState: ConsoleState = {
         service: "com.s-gw.sgw.secret",
         account: "local",
         provider: "macOS Keychain",
-        helperPath: "dist/native/s-gw-keychain-helper",
+        helperPath: "dist/native/darwin-arm64/s-gw-keychain-helper",
         configured: true
       }
     }

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { existsSync } from "node:fs";
+import { accessSync, constants, existsSync, readFileSync } from "node:fs";
 import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { assertActionAllowed, type SecretStore } from "./store.js";
@@ -45,7 +45,24 @@ async function runEnvCommand(
   const engine = executionEngine(options.engine);
   const coreBinary = options.coreBinary || rustCoreBinary();
   if (engine !== "typescript" && existsSync(coreBinary)) {
-    return runRustEnvCommand(coreBinary, request, secretRecord, secretValue, extraSecrets);
+    if (!nativeCoreIsCompatible(coreBinary)) {
+      if (engine === "rust") {
+        throw new Error(`Rust execution core is not compatible with ${process.platform}-${process.arch}: ${coreBinary}`);
+      }
+      return runTypeScriptEnvCommand(request, secretRecord, secretValue, extraSecrets);
+    }
+
+    try {
+      return await runRustEnvCommand(coreBinary, request, secretRecord, secretValue, extraSecrets);
+    } catch (error) {
+      if (engine === "auto" && isNativeLaunchError(error)) {
+        return runTypeScriptEnvCommand(request, secretRecord, secretValue, extraSecrets);
+      }
+      if (engine === "rust" && isNativeLaunchError(error)) {
+        throw new Error(`Rust execution core could not be launched: ${coreBinary}. ${errorMessage(error)}`);
+      }
+      throw error;
+    }
   }
   if (engine === "rust") {
     throw new Error(`Rust execution core is unavailable: ${coreBinary}`);
@@ -160,7 +177,95 @@ function executionEngine(override?: ExecutionOptions["engine"]): "auto" | "rust"
 
 function rustCoreBinary(): string {
   const extension = process.platform === "win32" ? ".exe" : "";
-  return fileURLToPath(new URL(`../dist/native/s-gw-core${extension}`, import.meta.url));
+  return fileURLToPath(new URL(
+    `../dist/native/${process.platform}-${process.arch}/s-gw-core${extension}`,
+    import.meta.url
+  ));
+}
+
+function nativeCoreIsCompatible(coreBinary: string): boolean {
+  try {
+    if (process.platform !== "win32") accessSync(coreBinary, constants.X_OK);
+    const header = readFileSync(coreBinary).subarray(0, 4096);
+    if (header[0] === 0x23 && header[1] === 0x21) return true;
+    if (process.platform === "darwin") return compatibleMachO(header);
+    if (process.platform === "win32") return compatiblePe(header);
+    return compatibleElf(header);
+  } catch {
+    return false;
+  }
+}
+
+function compatibleElf(header: Buffer): boolean {
+  if (header.length < 20 || !header.subarray(0, 4).equals(Buffer.from([0x7f, 0x45, 0x4c, 0x46]))) {
+    return false;
+  }
+  const littleEndian = header[5] === 1;
+  if (!littleEndian && header[5] !== 2) return false;
+  const machine = littleEndian ? header.readUInt16LE(18) : header.readUInt16BE(18);
+  const expected: Partial<Record<NodeJS.Architecture, number>> = {
+    arm: 40,
+    arm64: 183,
+    ia32: 3,
+    x64: 62
+  };
+  return expected[process.arch] === machine;
+}
+
+function compatibleMachO(header: Buffer): boolean {
+  if (header.length < 8) return false;
+  const magic = header.subarray(0, 4).toString("hex");
+  const thinLittle = magic === "cefaedfe" || magic === "cffaedfe";
+  const thinBig = magic === "feedface" || magic === "feedfacf";
+  if (thinLittle || thinBig) {
+    const cpu = thinLittle ? header.readUInt32LE(4) : header.readUInt32BE(4);
+    return cpu === machCpuType();
+  }
+
+  const fatBig = magic === "cafebabe" || magic === "cafebabf";
+  const fatLittle = magic === "bebafeca" || magic === "bfbafeca";
+  if (!fatBig && !fatLittle) return false;
+  const read32 = fatLittle
+    ? (offset: number) => header.readUInt32LE(offset)
+    : (offset: number) => header.readUInt32BE(offset);
+  const count = read32(4);
+  const entrySize = magic === "cafebabf" || magic === "bfbafeca" ? 32 : 20;
+  if (count > 64 || header.length < 8 + count * entrySize) return false;
+  for (let index = 0; index < count; index += 1) {
+    if (read32(8 + index * entrySize) === machCpuType()) return true;
+  }
+  return false;
+}
+
+function machCpuType(): number {
+  if (process.arch === "arm64") return 0x0100000c;
+  if (process.arch === "x64") return 0x01000007;
+  if (process.arch === "arm") return 12;
+  if (process.arch === "ia32") return 7;
+  return -1;
+}
+
+function compatiblePe(header: Buffer): boolean {
+  if (header.length < 64 || header[0] !== 0x4d || header[1] !== 0x5a) return false;
+  const offset = header.readUInt32LE(0x3c);
+  if (offset + 6 > header.length || header.subarray(offset, offset + 4).toString("hex") !== "50450000") {
+    return false;
+  }
+  const expected: Partial<Record<NodeJS.Architecture, number>> = {
+    arm64: 0xaa64,
+    ia32: 0x014c,
+    x64: 0x8664
+  };
+  return header.readUInt16LE(offset + 4) === expected[process.arch];
+}
+
+function isNativeLaunchError(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException | undefined)?.code;
+  return code === "EACCES" || code === "ENOENT" || code === "ENOEXEC";
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 function buildCoreEnv(): NodeJS.ProcessEnv {

--- a/src/install.ts
+++ b/src/install.ts
@@ -88,15 +88,29 @@ export interface WindowsOpenResult {
   pid?: number;
 }
 
+export interface WindowsStoppedSurfaces {
+  pids: number[];
+  console: boolean;
+  helper: boolean;
+  client: boolean;
+}
+
+export interface WindowsRestartResult {
+  console?: WindowsOpenResult;
+  helper?: WindowsOpenResult;
+  client?: WindowsOpenResult;
+}
+
 export function getPackageLayout(): PackageLayout {
   const here = path.dirname(fileURLToPath(import.meta.url));
   const packageRoot = path.basename(here) === "dist" ? path.dirname(here) : path.dirname(here);
+  const nativeTarget = `${process.platform}-${process.arch}`;
 
   return {
     packageRoot,
     cliPath: path.join(packageRoot, "dist", "cli.js"),
     mcpPath: path.join(packageRoot, "dist", "mcp-server.js"),
-    keychainHelperPath: path.join(packageRoot, "dist", "native", "s-gw-keychain-helper"),
+    keychainHelperPath: path.join(packageRoot, "dist", "native", nativeTarget, "s-gw-keychain-helper"),
     macAppPath: path.join(packageRoot, "dist", "s-gw.app"),
     macAppBinaryPath: path.join(packageRoot, "dist", "s-gw.app", "Contents", "MacOS", "s-gw"),
     menuBarAppPath: path.join(packageRoot, "dist", "s-gw Menu Bar.app"),
@@ -287,17 +301,19 @@ export function stopMacApp(): MacAppProcessInfo | undefined {
   };
 }
 
-export function stopWindowsSurfaces(): number[] {
+export function stopWindowsSurfaces(): WindowsStoppedSurfaces {
   requireWindows("Windows surface stop");
   const script = [
     "$stopped = @()",
     "Get-CimInstance Win32_Process | ForEach-Object {",
     "  $line = [string]$_.CommandLine",
-    "  $helper = $line -match '(?i)s-gw-(helper|client)\\.ps1'",
+    "  $helper = $line -match '(?i)s-gw-helper\\.ps1'",
+    "  $client = $line -match '(?i)s-gw-client\\.ps1'",
     "  $console = $line -match '(?i)[\\\\/]dist[\\\\/]cli\\.js' -and $line -match '(?i)\\sconsole(?:\\s|$)' -and $line -match '(?i)s-gw'",
-    "  if ($_.ProcessId -ne $PID -and ($helper -or $console)) {",
+    "  if ($_.ProcessId -ne $PID -and ($helper -or $client -or $console)) {",
+    "    $kind = if ($helper) { 'helper' } elseif ($client) { 'client' } else { 'console' }",
     "    Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue",
-    "    $stopped += [int]$_.ProcessId",
+    "    $stopped += [PSCustomObject]@{ pid = [int]$_.ProcessId; kind = $kind }",
     "  }",
     "}",
     "$stopped | ConvertTo-Json -Compress"
@@ -309,9 +325,104 @@ export function stopWindowsSurfaces(): number[] {
   if (result.status !== 0) {
     throw new Error(result.stderr.trim() || "Could not stop the running s-gw Windows surfaces.");
   }
-  if (!result.stdout.trim()) return [];
-  const parsed = JSON.parse(result.stdout) as number | number[];
-  return (Array.isArray(parsed) ? parsed : [parsed]).filter((pid) => Number.isInteger(pid) && pid > 0);
+  if (!result.stdout.trim()) return { pids: [], console: false, helper: false, client: false };
+  const parsed = JSON.parse(result.stdout) as unknown;
+  const entries = (Array.isArray(parsed) ? parsed : [parsed]).filter((entry): entry is { pid: number; kind: string } => {
+    if (!entry || typeof entry !== "object") return false;
+    const item = entry as { pid?: unknown; kind?: unknown };
+    return typeof item.pid === "number" && Number.isInteger(item.pid) && item.pid > 0 && typeof item.kind === "string";
+  });
+  return {
+    pids: entries.map((entry) => entry.pid),
+    console: entries.some((entry) => entry.kind === "console"),
+    helper: entries.some((entry) => entry.kind === "helper"),
+    client: entries.some((entry) => entry.kind === "client")
+  };
+}
+
+export function startWindowsConsole(options: MenuBarOptions = {}): WindowsOpenResult {
+  requireWindows("Windows console start");
+  const layout = getPackageLayout();
+  const port = options.port || 8718;
+  const url = options.consoleUrl || consoleUrl(port);
+  const child = spawn(process.execPath, [
+    layout.cliPath,
+    "console",
+    "--host",
+    "127.0.0.1",
+    "--port",
+    String(port),
+    "--no-open"
+  ], {
+    detached: true,
+    env: windowsEnvironment(url),
+    stdio: "ignore",
+    windowsHide: true
+  });
+  child.unref();
+  return {
+    scriptPath: layout.cliPath,
+    launcherPath: process.execPath,
+    consoleUrl: url,
+    pid: child.pid
+  };
+}
+
+export async function restartWindowsSurfaces(
+  stopped: WindowsStoppedSurfaces,
+  options: MenuBarOptions = {}
+): Promise<WindowsRestartResult> {
+  requireWindows("Windows surface restart");
+  const result: WindowsRestartResult = {};
+  const failures: string[] = [];
+  try {
+    if (stopped.client) {
+      result.client = openWindowsClient(options);
+    } else if (stopped.console) {
+      result.console = startWindowsConsole(options);
+    }
+  } catch (error) {
+    failures.push(`console/client: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  if (stopped.helper) {
+    try {
+      result.helper = openWindowsHelper(options);
+    } catch (error) {
+      failures.push(`helper: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  if ((stopped.console || stopped.client) && (result.console || result.client)) {
+    try {
+      await waitForWindowsConsole(options.consoleUrl || consoleUrl(options.port || 8718));
+    } catch (error) {
+      failures.push(`console health: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+  if (result.helper) {
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    if (!result.helper.pid || !isPidAlive(result.helper.pid)) {
+      failures.push("helper: process exited during startup");
+    }
+  }
+  if (failures.length > 0) {
+    throw new Error(failures.join("; "));
+  }
+  return result;
+}
+
+async function waitForWindowsConsole(url: string): Promise<void> {
+  const healthUrl = new URL("/api/health", url).toString();
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    try {
+      const response = await fetch(healthUrl, { signal: AbortSignal.timeout(500) });
+      if (response.ok) return;
+    } catch {
+      // The restored process can take a moment to bind after npm finishes.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`s-gw console did not become healthy at ${healthUrl}`);
 }
 
 export function launchAgentStatus(kind: "console" | "menubar"): LaunchAgentStatus {
@@ -843,6 +954,7 @@ function assertMenuBarExists(): void {
   if (!existsSync(layout.menuBarAppPath) || !existsSync(layout.menuBarBinaryPath)) {
     throw new Error(`Menu-bar helper is missing. Expected app bundle at ${layout.menuBarAppPath}`);
   }
+  assertMacExecutableCompatible(layout.menuBarBinaryPath, "menu-bar helper");
 }
 
 function assertMacAppExists(): void {
@@ -850,6 +962,21 @@ function assertMacAppExists(): void {
   if (!existsSync(layout.macAppPath) || !existsSync(layout.macAppBinaryPath)) {
     throw new Error(`macOS app is missing. Expected app bundle at ${layout.macAppPath}`);
   }
+  assertMacExecutableCompatible(layout.macAppBinaryPath, "macOS app");
+}
+
+function assertMacExecutableCompatible(binaryPath: string, label: string): void {
+  if (process.platform !== "darwin") return;
+  const arch = process.arch === "x64" ? "x86_64" : process.arch;
+  const check = spawnSync("/usr/bin/lipo", [binaryPath, "-verify_arch", arch], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"]
+  });
+  if (check.status === 0) return;
+  throw new Error(
+    `The packaged ${label} is not compatible with darwin-${process.arch}. ` +
+    "Public npm and DMG releases currently include Apple Silicon native surfaces; Intel Macs must build them from source."
+  );
 }
 
 function assertWindowsClientExists(): void {

--- a/src/package-update.ts
+++ b/src/package-update.ts
@@ -34,6 +34,7 @@ export interface PackageInstallOptions extends PackageUpdateOptions {
   dryRun?: boolean;
   servicesAlreadyStopped?: boolean;
   stopServices?: () => Promise<void>;
+  restartServices?: () => Promise<void>;
 }
 
 export interface InstalledNpmPackage {
@@ -99,6 +100,7 @@ interface PreparedRollback {
 export class PackageUpdateError extends Error {
   readonly phase: string;
   readonly recoveryCommands: string[];
+  readonly summary: string;
 
   constructor(message: string, phase: string, recoveryCommands: string[] = []) {
     const recovery = recoveryCommands.length > 0
@@ -108,6 +110,7 @@ export class PackageUpdateError extends Error {
     this.name = "PackageUpdateError";
     this.phase = phase;
     this.recoveryCommands = recoveryCommands;
+    this.summary = message;
   }
 }
 
@@ -212,83 +215,119 @@ export async function installPackageUpdate(options: PackageInstallOptions = {}):
     );
   }
 
-  if (options.stopServices) {
-    try {
-      await options.stopServices();
-    } catch (error) {
-      throw new PackageUpdateError(
-        `Could not stop s-gw cleanly: ${errorMessage(error)}`,
-        "stop-services",
-        ["s-gw stop"]
-      );
-    }
-  }
-
   const npm = npmContext(options);
   const dataExisted = await pathExists(plan.dataHome);
   let removedLegacy = false;
   let rollback: PreparedRollback | null = null;
+  let stopAttempted = false;
 
-  if (plan.installed.legacy) {
-    rollback = await prepareLegacyRollback(plan, npm);
-    const removed = await npm.run(uninstallArgs(plan.installed.npmPrefix, LEGACY_PACKAGE_NAME));
-    if (removed.status !== 0) {
-      await discardRollback(rollback);
-      throw npmFailure(
-        `Could not remove legacy ${LEGACY_PACKAGE_NAME}@${plan.installed.legacy.version}. The scoped package was not installed.`,
-        "remove-legacy",
-        removed,
-        []
-      );
+  try {
+    if (options.stopServices) {
+      stopAttempted = true;
+      try {
+        await options.stopServices();
+      } catch (error) {
+        throw new PackageUpdateError(
+          `Could not stop s-gw cleanly: ${errorMessage(error)}`,
+          "stop-services"
+        );
+      }
     }
-    removedLegacy = true;
 
-    const afterRemove = await inspectGlobalSgwInstall(options);
-    if (afterRemove.legacy) {
-      await discardRollback(rollback);
+    if (plan.installed.legacy) {
+      rollback = await prepareLegacyRollback(plan, npm);
+      const removed = await npm.run(uninstallArgs(plan.installed.npmPrefix, LEGACY_PACKAGE_NAME));
+      if (removed.status !== 0) {
+        await discardRollback(rollback);
+        rollback = null;
+        throw npmFailure(
+          `Could not remove legacy ${LEGACY_PACKAGE_NAME}@${plan.installed.legacy.version}. The scoped package was not installed.`,
+          "remove-legacy",
+          removed,
+          []
+        );
+      }
+      removedLegacy = true;
+
+      const afterRemove = await inspectGlobalSgwInstall(options);
+      if (afterRemove.legacy) {
+        throw new PackageUpdateError(
+          `npm still reports ${LEGACY_PACKAGE_NAME}@${afterRemove.legacy.version} under ${afterRemove.npmPrefix}. The scoped package was not installed.`,
+          "remove-legacy",
+          recoveryFor(plan, rollback)
+        );
+      }
+    }
+
+    const installed = await npm.run(installArgs(plan.installed.npmPrefix, plan.target.installSpec));
+    if (installed.status !== 0) {
+      const message = removedLegacy
+        ? `Could not install ${plan.target.name}@${plan.target.version} after removing the legacy package. Your s-gw data at ${plan.dataHome} was not intentionally changed.`
+        : `Could not install ${plan.target.name}@${plan.target.version}.`;
+      throw npmFailure(message, "install-scoped", installed, recoveryFor(plan, rollback));
+    }
+
+    const finalInstall = await inspectGlobalSgwInstall(options);
+    if (!finalInstall.scoped || finalInstall.legacy || finalInstall.scoped.version !== plan.target.version) {
       throw new PackageUpdateError(
-        `npm still reports ${LEGACY_PACKAGE_NAME}@${afterRemove.legacy.version} under ${afterRemove.npmPrefix}. The scoped package was not installed.`,
-        "remove-legacy",
-        []
+        `npm completed, but the global package state is invalid: expected scoped=${plan.target.version}, found scoped=${finalInstall.scoped?.version || "missing"}, legacy=${finalInstall.legacy?.version || "absent"}.`,
+        "verify-install",
+        recoveryFor(plan, rollback)
       );
     }
+
+    const dataHomePreserved = !dataExisted || await pathExists(plan.dataHome);
+    if (!dataHomePreserved) {
+      throw new PackageUpdateError(
+        `The package installed, but the existing s-gw data directory is no longer present at ${plan.dataHome}. Do not run setup until the data is restored from backup. Services remain stopped to avoid initializing an empty store.`,
+        "verify-data",
+        recoveryFor(plan, rollback, false)
+      );
+    }
+
+    await discardRollback(rollback);
+
+    return {
+      changed: true,
+      dryRun: false,
+      plan,
+      installed: finalInstall,
+      dataHomePreserved,
+      nextCommands: plan.nextCommands
+    };
+  } catch (error) {
+    let failure = packageUpdateFailure(error, plan, rollback, removedLegacy);
+    if (removedLegacy && rollback) {
+      try {
+        await restoreLegacyPackage(plan, rollback, npm);
+        await discardRollback(rollback);
+        rollback = null;
+        removedLegacy = false;
+        failure = new PackageUpdateError(
+          `${failure.summary}\nThe previous ${LEGACY_PACKAGE_NAME}@${plan.installed.legacy?.version} package was restored before services restarted.`,
+          failure.phase
+        );
+      } catch (rollbackError) {
+        failure = new PackageUpdateError(
+          `${failure.summary}\nAutomatic rollback failed: ${errorMessage(rollbackError)}`,
+          failure.phase,
+          recoveryFor(plan, rollback, failure.phase !== "verify-data")
+        );
+      }
+    }
+    if (stopAttempted && options.restartServices && failure.phase !== "verify-data") {
+      try {
+        await options.restartServices();
+      } catch (restartError) {
+        failure = new PackageUpdateError(
+          `${failure.summary}\nCould not restart the stopped s-gw services: ${errorMessage(restartError)}`,
+          failure.phase,
+          uniqueCommands([...failure.recoveryCommands, "s-gw start --no-open-app"])
+        );
+      }
+    }
+    throw failure;
   }
-
-  const installed = await npm.run(installArgs(plan.installed.npmPrefix, plan.target.installSpec));
-  if (installed.status !== 0) {
-    const message = removedLegacy
-      ? `Could not install ${plan.target.name}@${plan.target.version} after removing the legacy package. Your s-gw data at ${plan.dataHome} was not intentionally changed.`
-      : `Could not install ${plan.target.name}@${plan.target.version}.`;
-    throw npmFailure(message, "install-scoped", installed, recoveryFor(plan, rollback));
-  }
-
-  const finalInstall = await inspectGlobalSgwInstall(options);
-  if (!finalInstall.scoped || finalInstall.legacy || finalInstall.scoped.version !== plan.target.version) {
-    throw new PackageUpdateError(
-      `npm completed, but the global package state is invalid: expected scoped=${plan.target.version}, found scoped=${finalInstall.scoped?.version || "missing"}, legacy=${finalInstall.legacy?.version || "absent"}.`,
-      "verify-install",
-      recoveryFor(plan, rollback)
-    );
-  }
-
-  const dataHomePreserved = !dataExisted || await pathExists(plan.dataHome);
-  if (!dataHomePreserved) {
-    throw new PackageUpdateError(
-      `The package installed, but the existing s-gw data directory is no longer present at ${plan.dataHome}. Do not run setup until the data is restored from backup.`,
-      "verify-data"
-    );
-  }
-
-  await discardRollback(rollback);
-
-  return {
-    changed: true,
-    dryRun: false,
-    plan,
-    installed: finalInstall,
-    dataHomePreserved,
-    nextCommands: plan.nextCommands
-  };
 }
 
 export function selectReleasePackageAssets(
@@ -565,13 +604,78 @@ function npmOutput(result: NpmCommandResult): string {
   return (result.stderr.trim() || result.stdout.trim()).split(/\r?\n/).slice(-8).join("\n");
 }
 
-function recoveryFor(plan: PackageUpdatePlan, rollback: PreparedRollback | null): string[] {
+function recoveryFor(
+  plan: PackageUpdatePlan,
+  rollback: PreparedRollback | null,
+  includeSetup = true
+): string[] {
   if (!rollback || !plan.installed.legacy) return [];
-  return [
+  const commands = [
     commandText("npm", uninstallArgs(plan.installed.npmPrefix, SCOPED_PACKAGE_NAME)),
-    commandText("npm", installArgs(plan.installed.npmPrefix, rollback.target)),
-    "s-gw setup"
+    commandText("npm", installArgs(plan.installed.npmPrefix, rollback.target))
   ];
+  if (includeSetup) commands.push("s-gw setup");
+  return commands;
+}
+
+function packageUpdateFailure(
+  error: unknown,
+  plan: PackageUpdatePlan,
+  rollback: PreparedRollback | null,
+  removedLegacy: boolean
+): PackageUpdateError {
+  const failure = error instanceof PackageUpdateError
+    ? error
+    : new PackageUpdateError(errorMessage(error), "install");
+  if (!removedLegacy) return failure;
+
+  const recoveryCommands = uniqueCommands([
+    ...failure.recoveryCommands,
+    ...recoveryFor(plan, rollback, failure.phase !== "verify-data")
+  ]);
+  if (recoveryCommands.length === failure.recoveryCommands.length) return failure;
+  return new PackageUpdateError(failure.summary, failure.phase, recoveryCommands);
+}
+
+async function restoreLegacyPackage(
+  plan: PackageUpdatePlan,
+  rollback: PreparedRollback,
+  npm: { run: (args: string[]) => Promise<NpmCommandResult> }
+): Promise<void> {
+  const removedScoped = await npm.run(uninstallArgs(plan.installed.npmPrefix, SCOPED_PACKAGE_NAME));
+  if (removedScoped.status !== 0) {
+    throw new Error(npmOutput(removedScoped) || `Could not remove ${SCOPED_PACKAGE_NAME}.`);
+  }
+
+  const restored = await npm.run(installArgs(plan.installed.npmPrefix, rollback.target));
+  if (restored.status !== 0) {
+    throw new Error(npmOutput(restored) || `Could not restore ${LEGACY_PACKAGE_NAME}.`);
+  }
+
+  const expected = plan.installed.legacy;
+  if (!expected) throw new Error("Legacy package metadata is unavailable after rollback.");
+  try {
+    const manifest = JSON.parse(await readFile(path.join(expected.packageRoot, "package.json"), "utf8")) as {
+      name?: unknown;
+      version?: unknown;
+    };
+    if (manifest.name !== LEGACY_PACKAGE_NAME || manifest.version !== expected.version) {
+      throw new Error("restored package identity does not match the previous installation");
+    }
+    if (!await pathExists(path.join(expected.packageRoot, "dist", "cli.js"))) {
+      throw new Error("restored package is missing dist/cli.js");
+    }
+    const scopedRoot = path.join(plan.installed.npmRoot, ...SCOPED_PACKAGE_NAME.split("/"));
+    if (await pathExists(path.join(scopedRoot, "package.json"))) {
+      throw new Error(`restored package still conflicts with ${SCOPED_PACKAGE_NAME}`);
+    }
+  } catch (error) {
+    throw new Error(`Could not verify the restored ${LEGACY_PACKAGE_NAME}@${expected.version}: ${errorMessage(error)}`);
+  }
+}
+
+function uniqueCommands(commands: string[]): string[] {
+  return [...new Set(commands)];
 }
 
 async function prepareLegacyRollback(

--- a/src/unlock.ts
+++ b/src/unlock.ts
@@ -164,7 +164,7 @@ function ensureNativeCredentialStore(info: KeychainInfo): void {
   }
 
   if ((info.provider !== "native-helper" && info.provider !== "windows-helper") || !info.helperPath) {
-    throw new Error("OS credential-store secret storage requires the native s-gw helper. Run `npm run build:native`.");
+    throw missingCredentialStoreError();
   }
 }
 
@@ -220,9 +220,10 @@ function findNativeHelper(): string | undefined {
   }
 
   const here = path.dirname(fileURLToPath(import.meta.url));
+  const nativeTarget = `${process.platform}-${process.arch}`;
   const candidates = [
-    path.resolve(here, "native", nativeHelperName),
-    path.resolve(process.cwd(), "dist", "native", nativeHelperName)
+    path.resolve(here, "native", nativeTarget, nativeHelperName),
+    path.resolve(process.cwd(), "dist", "native", nativeTarget, nativeHelperName)
   ];
 
   return candidates.find((candidate) => existsSync(candidate));
@@ -263,7 +264,7 @@ function runKeychainGet(info: KeychainInfo): string {
     return runWindowsCredentialHelper(info.helperPath, ["get", "-Service", info.service, "-Account", info.account]);
   }
 
-  throw new Error("No local OS credential-store provider is available. Run `npm run build:native`.");
+  throw missingCredentialStoreError();
 }
 
 function runKeychainSet(info: KeychainInfo, passphrase: string, label = "s-gw local unlock passphrase"): void {
@@ -297,7 +298,7 @@ function runKeychainSet(info: KeychainInfo, passphrase: string, label = "s-gw lo
     return;
   }
 
-  throw new Error("No local OS credential-store provider is available. Run `npm run build:native`.");
+  throw missingCredentialStoreError();
 }
 
 function runKeychainDelete(info: KeychainInfo): void {
@@ -316,7 +317,17 @@ function runKeychainDelete(info: KeychainInfo): void {
     return;
   }
 
-  throw new Error("No local OS credential-store provider is available. Run `npm run build:native`.");
+  throw missingCredentialStoreError();
+}
+
+function missingCredentialStoreError(): Error {
+  if (process.platform === "darwin") {
+    return new Error(
+      `No compatible macOS Keychain helper is available for darwin-${process.arch}. ` +
+      "Public npm and DMG releases currently include Apple Silicon native surfaces; Intel Macs must build them from source."
+    );
+  }
+  return new Error("No local OS credential-store provider is available. Run `npm run build:native`.");
 }
 
 function runNativeHelper(helperPath: string, args: string[], input?: string): string {

--- a/src/update-check.ts
+++ b/src/update-check.ts
@@ -30,6 +30,11 @@ interface UpdateCache {
   result: UpdateCheckResult;
 }
 
+interface SemanticVersion {
+  core: [string, string, string];
+  prerelease: string[];
+}
+
 interface ReleaseCheckerOptions {
   cachePath?: string;
   currentVersion?: string;
@@ -41,18 +46,10 @@ interface ReleaseCheckerOptions {
 }
 
 export function isNewerVersion(candidate: string, current: string): boolean {
-  const left = versionParts(candidate);
-  const right = versionParts(current);
-  const count = Math.max(left.length, right.length);
-
-  for (let index = 0; index < count; index += 1) {
-    const a = left[index] ?? 0;
-    const b = right[index] ?? 0;
-    if (a > b) return true;
-    if (a < b) return false;
-  }
-
-  return false;
+  const left = parseSemanticVersion(candidate);
+  const right = parseSemanticVersion(current);
+  if (!left || !right) return false;
+  return compareSemanticVersions(left, right) > 0;
 }
 
 export class ReleaseChecker {
@@ -196,7 +193,7 @@ export const releaseChecker = new ReleaseChecker();
 function newestRelease(releases: GitHubRelease[]): GitHubRelease | null {
   let newest: GitHubRelease | null = null;
   for (const release of releases) {
-    if (release.draft || !cleanVersion(release.tag_name)) continue;
+    if (release.draft || !parseSemanticVersion(release.tag_name)) continue;
     if (!newest || isNewerVersion(release.tag_name, newest.tag_name)) {
       newest = release;
     }
@@ -213,13 +210,14 @@ function releaseFromAtom(xml: string): GitHubRelease | null {
   const tagFromLink = link?.match(/\/releases\/tag\/([^/?#"]+)/i)?.[1];
   const tagFromId = id?.split("/").at(-1);
   const tag = decodeXml(tagFromLink || tagFromId || "").trim();
-  if (!tag) return null;
+  const parsed = parseSemanticVersion(tag);
+  if (!parsed) return null;
 
   return {
     tag_name: tag,
     html_url: decodeXml(link || `https://github.com/${UPDATE_REPOSITORY}/releases/tag/${tag}`),
     draft: false,
-    prerelease: cleanVersion(tag).includes("-"),
+    prerelease: parsed.prerelease.length > 0,
     published_at: entry.match(/<updated>([^<]+)<\/updated>/i)?.[1] || null
   };
 }
@@ -250,11 +248,60 @@ function cleanVersion(version: string): string {
   return version.trim().replace(/^v/i, "");
 }
 
-function versionParts(version: string): number[] {
-  return cleanVersion(version).split(".").map((part) => {
-    const match = part.match(/^\d+/);
-    return match ? Number(match[0]) : 0;
-  });
+function parseSemanticVersion(version: string): SemanticVersion | null {
+  const match = cleanVersion(version).match(
+    /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/
+  );
+  if (!match) return null;
+
+  const prerelease = match[4]?.split(".") ?? [];
+  if (prerelease.some((identifier) => /^\d+$/.test(identifier) && identifier.length > 1 && identifier.startsWith("0"))) {
+    return null;
+  }
+
+  return {
+    core: [match[1], match[2], match[3]],
+    prerelease
+  };
+}
+
+function compareSemanticVersions(left: SemanticVersion, right: SemanticVersion): number {
+  for (let index = 0; index < left.core.length; index += 1) {
+    const compared = compareNumericIdentifier(left.core[index], right.core[index]);
+    if (compared !== 0) return compared;
+  }
+
+  if (left.prerelease.length === 0 || right.prerelease.length === 0) {
+    if (left.prerelease.length === right.prerelease.length) return 0;
+    return left.prerelease.length === 0 ? 1 : -1;
+  }
+
+  const count = Math.max(left.prerelease.length, right.prerelease.length);
+  for (let index = 0; index < count; index += 1) {
+    const a = left.prerelease[index];
+    const b = right.prerelease[index];
+    if (a === undefined || b === undefined) {
+      if (a === b) return 0;
+      return a === undefined ? -1 : 1;
+    }
+
+    const aNumeric = /^\d+$/.test(a);
+    const bNumeric = /^\d+$/.test(b);
+    if (aNumeric && bNumeric) {
+      const compared = compareNumericIdentifier(a, b);
+      if (compared !== 0) return compared;
+      continue;
+    }
+    if (aNumeric !== bNumeric) return aNumeric ? -1 : 1;
+    if (a !== b) return a < b ? -1 : 1;
+  }
+  return 0;
+}
+
+function compareNumericIdentifier(left: string, right: string): number {
+  if (left.length !== right.length) return left.length < right.length ? -1 : 1;
+  if (left === right) return 0;
+  return left < right ? -1 : 1;
 }
 
 function cacheIsFresh(result: UpdateCheckResult, now: number): boolean {

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const CURRENT_VERSION = "0.1.2";
+export const CURRENT_VERSION = "0.1.3";

--- a/tests/agent-install.test.ts
+++ b/tests/agent-install.test.ts
@@ -1,6 +1,6 @@
-import { execFileSync, spawnSync } from "node:child_process";
+import { execFileSync, spawn, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { chmodSync, existsSync, mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync, utimesSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { parse as parseJsonc } from "jsonc-parser";
@@ -66,6 +66,24 @@ function vscodeConfigPath(homeDir: string): string {
     return path.join(homeDir, "Library", "Application Support", "Code", "User", "mcp.json");
   }
   return path.join(homeDir, ".config", "Code", "User", "mcp.json");
+}
+
+function runAgentCli(args: string[], env: NodeJS.ProcessEnv): Promise<{ status: number; stderr: string; stdout: string }> {
+  const tsxCli = path.join(process.cwd(), "node_modules", "tsx", "dist", "cli.mjs");
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [tsxCli, "src/cli.ts", ...args], {
+      cwd: process.cwd(),
+      env,
+      stdio: ["ignore", "pipe", "pipe"]
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => { stdout += chunk; });
+    child.stderr.on("data", (chunk: string) => { stderr += chunk; });
+    child.on("close", (code) => resolve({ status: code ?? 1, stdout, stderr }));
+  });
 }
 
 describe("agent integration installation", () => {
@@ -773,6 +791,100 @@ describe("agent integration installation", () => {
     expect(conflict.status).toBe(1);
     expect(JSON.parse(conflict.stdout)).toMatchObject({ ok: false, results: [{ state: "conflict" }] });
   });
+
+  it("recovers an agent integration lock left by a dead process", () => {
+    const homeDir = testHome();
+    const binDir = fakeCommand(homeDir, "codex");
+    const lockPath = path.join(homeDir, ".s-gw-agent-integrations.lock");
+    const deadProcess = spawnSync(process.execPath, ["-e", ""]);
+    expect(deadProcess.status).toBe(0);
+    const owner = {
+      pid: deadProcess.pid,
+      startedAt: Date.now(),
+      token: "abandoned-test-lock"
+    };
+    mkdirSync(lockPath, { mode: 0o700 });
+    writeFileSync(path.join(lockPath, `owner-${owner.token}.json`), `${JSON.stringify(owner)}\n`, { mode: 0o600 });
+
+    const installed = installAgentIntegrations(opts(homeDir, binDir, ["codex"]));
+
+    expect(installed[0]).toMatchObject({ state: "installed", changed: true });
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  it("recovers stale agent integration lock metadata", () => {
+    const homeDir = testHome();
+    const binDir = fakeCommand(homeDir, "codex");
+    const lockPath = path.join(homeDir, ".s-gw-agent-integrations.lock");
+    const markerPath = path.join(lockPath, "owner-unfinished.json");
+    mkdirSync(lockPath, { mode: 0o700 });
+    writeFileSync(markerPath, "unfinished owner metadata", { mode: 0o600 });
+    const stale = new Date(Date.now() - 60_000);
+    utimesSync(markerPath, stale, stale);
+    utimesSync(lockPath, stale, stale);
+
+    const installed = installAgentIntegrations(opts(homeDir, binDir, ["codex"]));
+
+    expect(installed[0]).toMatchObject({ state: "installed", changed: true });
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  it("serializes concurrent stale recovery installs and uninstalls without losing ownership", async () => {
+    const agentIds = ["codex", "claudecode", "cursor", "geminicli"];
+    const commands = ["codex", "claude", "cursor", "gemini"];
+
+    for (let round = 0; round < 3; round += 1) {
+      const homeDir = testHome();
+      let binDir = "";
+      for (const command of commands) binDir = fakeCommand(homeDir, command);
+      const env = {
+        ...process.env,
+        HOME: homeDir,
+        USERPROFILE: homeDir,
+        PATH: `${binDir}${path.delimiter}${process.env.PATH || ""}`,
+        SGW_HOME: path.join(homeDir, ".s-gw"),
+        SGW_DISABLE_UPDATE_CHECK: "1"
+      };
+      const deadProcess = spawnSync(process.execPath, ["-e", ""]);
+      expect(deadProcess.status).toBe(0);
+      const lockPath = path.join(homeDir, ".s-gw-agent-integrations.lock");
+      const owner = {
+        pid: deadProcess.pid,
+        startedAt: Date.now(),
+        token: `concurrent-dead-owner-${round}`
+      };
+      mkdirSync(lockPath, { mode: 0o700 });
+      writeFileSync(path.join(lockPath, `owner-${owner.token}.json`), `${JSON.stringify(owner)}\n`, { mode: 0o600 });
+
+      const staleCandidate = `${lockPath}.tmp-${deadProcess.pid}-stale-recovery-${round}`;
+      mkdirSync(staleCandidate, { mode: 0o700 });
+      const staleMarker = path.join(staleCandidate, "owner-stale-recovery.json");
+      writeFileSync(staleMarker, "unfinished owner metadata", { mode: 0o600 });
+      const stale = new Date(Date.now() - 60_000);
+      utimesSync(staleMarker, stale, stale);
+      utimesSync(staleCandidate, stale, stale);
+
+      const installed = await Promise.all(
+        agentIds.map((agentId) => runAgentCli(["agent", "install", agentId], env))
+      );
+      expect(installed.every((result) => result.status === 0), installed.map((item) => item.stderr).join("\n")).toBe(true);
+
+      const manifestPath = path.join(homeDir, ".s-gw", "agent-integrations.json");
+      const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+      expect(Object.keys(manifest.agents).sort()).toEqual([...agentIds].sort());
+      expect(agentIntegrationStatus(opts(homeDir, binDir, agentIds)).every((item) => item.state === "installed")).toBe(true);
+
+      const removed = await Promise.all(
+        agentIds.map((agentId) => runAgentCli(["agent", "uninstall", agentId], env))
+      );
+      expect(removed.every((result) => result.status === 0), removed.map((item) => item.stderr).join("\n")).toBe(true);
+      expect(JSON.parse(readFileSync(manifestPath, "utf8")).agents).toEqual({});
+      const afterRemoval = agentIntegrationStatus(opts(homeDir, binDir, agentIds));
+      expect(afterRemoval.every((item) => item.mcp.state === "missing" && item.skill.state === "missing")).toBe(true);
+      expect(existsSync(lockPath)).toBe(false);
+      expect(existsSync(staleCandidate)).toBe(true);
+    }
+  }, 45_000);
 
   it("setup connects detected agents unless --no-agents is set", () => {
     const tsxCli = path.join(process.cwd(), "node_modules", "tsx", "dist", "cli.mjs");

--- a/tests/console-browser-e2e.test.ts
+++ b/tests/console-browser-e2e.test.ts
@@ -432,6 +432,239 @@ describeBrowser("React local console (real headless Chrome)", () => {
     expect(tallPanel.contentHeight).toBeLessThanOrEqual(tallPanel.availableHeight + 1);
   }, 45_000);
 
+  it("keeps native-shell navigation and activity surfaces readable in light mode", async () => {
+    process.env.SGW_MASTER_PASSPHRASE = "browser light theme passphrase";
+    running = await startConsoleServer({ port: 0 });
+
+    const created = await api<{ handle: string }>("api/secrets", {
+      name: "react-light-theme",
+      type: "api-token",
+      value: "react-light-theme-secret-value-1234567890",
+      injectEnv: "SGW_REACT_LIGHT_THEME_TOKEN",
+      allowedCommands: [process.execPath]
+    });
+    await api("api/requests", {
+      handle: created.handle,
+      command: process.execPath,
+      args: ["-e", "1"],
+      injectEnv: "SGW_REACT_LIGHT_THEME_TOKEN",
+      reason: "Codex light theme regression"
+    });
+
+    const launched = await launchChrome(new URL("overview?native-shell=1", running.url).toString());
+    cdp = launched.cdp;
+    await cdp.eval("localStorage.setItem('sgw.theme', 'light'); location.reload()");
+    await waitFor(
+      () => cdp!.eval<boolean>("document.documentElement.classList.contains('light') && Boolean(document.querySelector('[data-recent-activity-list]'))"),
+      "light overview"
+    );
+
+    const overviewTheme = await cdp.eval<{
+      navText: number[][];
+      recentBackground: number[];
+      recentHeadText: number[];
+      recentText: number[];
+      recentStatusText: number[];
+    }>(`(() => {
+      const channels = (value) => (value.match(/[\\d.]+/g) || []).slice(0, 3).map(Number);
+      const inactiveNav = [...document.querySelectorAll('.sgw-sidebar-nav-button')]
+        .filter((node) => node.getAttribute('data-active') !== 'true');
+      const recent = document.querySelector('.sgw-recent-event-list');
+      const row = document.querySelector('[data-overview-event-row]');
+      return {
+        navText: inactiveNav.map((node) => channels(getComputedStyle(node).color)),
+        recentBackground: channels(getComputedStyle(recent).backgroundColor),
+        recentHeadText: channels(getComputedStyle(document.querySelector('.sgw-recent-event-head')).color),
+        recentText: channels(getComputedStyle(row).color),
+        recentStatusText: channels(getComputedStyle(row.querySelector('.sgw-event-status')).color)
+      };
+    })()`);
+    expect(overviewTheme.navText.length).toBeGreaterThan(0);
+    expect(overviewTheme.navText.every((color) => Math.max(...color) < 100)).toBe(true);
+    expect(Math.min(...overviewTheme.recentBackground)).toBeGreaterThan(230);
+    expect(Math.max(...overviewTheme.recentHeadText)).toBeLessThan(100);
+    expect(Math.max(...overviewTheme.recentText)).toBeLessThan(100);
+    expect(Math.max(...overviewTheme.recentStatusText)).toBeLessThan(210);
+
+    await cdp.send("Page.navigate", { url: new URL("activity?native-shell=1", running.url).toString() });
+    await waitFor(
+      () => cdp!.eval<boolean>("document.documentElement.classList.contains('light') && Boolean(document.querySelector('[data-event-log-card] .sgw-event-flow-card'))"),
+      "light activity"
+    );
+    const activityTheme = await cdp.eval<{
+      cardBackground: number[];
+      detailBackground: number[];
+      detailCardBackground: number[];
+      detailTitle: number[];
+      queryBackground: number[];
+      rowText: number[];
+      rowStatusText: number[];
+    }>(`(() => {
+      const channels = (value) => (value.match(/[\\d.]+/g) || []).slice(0, 3).map(Number);
+      return {
+        cardBackground: channels(getComputedStyle(document.querySelector('[data-event-log-card]')).backgroundColor),
+        detailBackground: channels(getComputedStyle(document.querySelector('.sgw-event-detail-stage')).backgroundColor),
+        detailCardBackground: channels(getComputedStyle(document.querySelector('.sgw-event-flow-card')).backgroundColor),
+        detailTitle: channels(getComputedStyle(document.querySelector('.sgw-event-flow-title')).color),
+        queryBackground: channels(getComputedStyle(document.querySelector('.sgw-event-query')).backgroundColor),
+        rowText: channels(getComputedStyle(document.querySelector('[data-event-row]')).color),
+        rowStatusText: channels(getComputedStyle(document.querySelector('[data-event-row] .sgw-event-status')).color)
+      };
+    })()`);
+    expect(Math.min(...activityTheme.cardBackground)).toBeGreaterThan(230);
+    expect(Math.min(...activityTheme.detailBackground)).toBeGreaterThan(230);
+    expect(Math.min(...activityTheme.detailCardBackground)).toBeGreaterThan(230);
+    expect(Math.max(...activityTheme.detailTitle)).toBeLessThan(100);
+    expect(Math.min(...activityTheme.queryBackground)).toBeGreaterThan(230);
+    expect(Math.max(...activityTheme.rowText)).toBeLessThan(100);
+    expect(Math.max(...activityTheme.rowStatusText)).toBeLessThan(210);
+  }, 45_000);
+
+  it("uses a compact settings switcher and saves readable duration choices", async () => {
+    process.env.SGW_MASTER_PASSPHRASE = "browser settings passphrase";
+    running = await startConsoleServer({ port: 0 });
+
+    await api("api/approval", { mode: "per-transaction", durationMs: 42 * 60 * 1000 });
+    const created = await api<{ handle: string }>("api/secrets", {
+      name: "react-settings-grant",
+      type: "api-token",
+      value: "react-settings-secret-value-1234567890",
+      injectEnv: "SGW_REACT_SETTINGS_TOKEN",
+      allowedCommands: [process.execPath]
+    });
+    const request = await api<{ id: string }>("api/requests", {
+      handle: created.handle,
+      command: process.execPath,
+      args: ["-e", "1"],
+      injectEnv: "SGW_REACT_SETTINGS_TOKEN",
+      reason: "Codex settings reusable grant",
+      agentName: "Codex"
+    });
+    await api(`api/requests/${request.id}/approve`, {
+      mode: "timed-session",
+      durationMs: 15 * 60 * 1000,
+      agentScope: "any-agent"
+    });
+
+    const launched = await launchChrome(new URL("settings?native-shell=1", running.url).toString());
+    cdp = launched.cdp;
+    await waitFor(
+      () => cdp!.eval<boolean>("Boolean(document.querySelector('[data-settings-panel=\"approvals\"]'))"),
+      "settings approval panel"
+    );
+
+    const desktop = await cdp.eval<{
+      durationDisabled: boolean;
+      nav: { bottom: number; height: number; left: number; width: number };
+      panel: { left: number; top: number; width: number };
+      rawMillisecondsVisible: boolean;
+      selected: string[];
+      tabTops: number[];
+      tabs: number;
+      warning: string;
+    }>(`(() => {
+      const nav = document.querySelector('[data-settings-nav]').getBoundingClientRect();
+      const panelNode = document.querySelector('[data-settings-panel="approvals"]');
+      const panel = panelNode.getBoundingClientRect();
+      const tabs = [...document.querySelectorAll('[data-settings-tab]')];
+      return {
+        durationDisabled: document.querySelector('[data-settings-duration]').disabled,
+        nav: { bottom: nav.bottom, height: nav.height, left: nav.left, width: nav.width },
+        panel: { left: panel.left, top: panel.top, width: panel.width },
+        rawMillisecondsVisible: document.body.innerText.includes(String(42 * 60 * 1000)),
+        selected: tabs.filter((tab) => tab.getAttribute('aria-selected') === 'true').map((tab) => tab.getAttribute('data-settings-tab')),
+        tabTops: tabs.map((tab) => Math.round(tab.getBoundingClientRect().top)),
+        tabs: tabs.length,
+        warning: panelNode.querySelector('[data-slot="card-footer"]').innerText
+      };
+    })()`);
+    expect(desktop.tabs).toBe(3);
+    expect(new Set(desktop.tabTops).size).toBe(1);
+    expect(desktop.nav.height).toBeLessThan(100);
+    expect(desktop.panel.top).toBeGreaterThan(desktop.nav.bottom);
+    expect(Math.abs(desktop.panel.left - desktop.nav.left)).toBeLessThan(2);
+    expect(Math.abs(desktop.panel.width - desktop.nav.width)).toBeLessThan(2);
+    expect(desktop.durationDisabled).toBe(true);
+    expect(desktop.rawMillisecondsVisible).toBe(false);
+    expect(desktop.selected).toEqual(["approvals"]);
+    expect(desktop.warning).toContain("Saving clears 1 active reusable grant");
+
+    await clickElement(cdp, '[data-settings-tab="grants"]');
+    await waitFor(
+      () => cdp!.eval<boolean>("Boolean(document.querySelector('[data-settings-panel=\"grants\"]'))"),
+      "settings grants panel"
+    );
+    expect(await cdp.eval<string>("document.querySelector('[data-settings-tab=\"grants\"]').getAttribute('aria-selected')")).toBe("true");
+    const grantsText = await cdp.eval<string>("document.querySelector('[data-settings-panel=\"grants\"]').innerText");
+    expect(grantsText).toContain("1 active");
+    expect(grantsText).toContain("Reuse for a time window");
+
+    await clickElement(cdp, '[data-settings-tab="about"]');
+    await waitFor(
+      () => cdp!.eval<boolean>("Boolean(document.querySelector('[data-settings-panel=\"about\"]'))"),
+      "settings about panel"
+    );
+    expect(await cdp.eval<string>("document.querySelector('[data-settings-panel=\"about\"]').innerText")).toContain("Store location");
+
+    await clickElement(cdp, '[data-settings-tab="approvals"]');
+    await waitFor(
+      () => cdp!.eval<boolean>("Boolean(document.querySelector('[data-settings-panel=\"approvals\"]'))"),
+      "settings approval panel restored"
+    );
+    await chooseSelectOption(cdp, "[data-settings-mode]", "Reuse for a time window");
+    await waitFor(
+      () => cdp!.eval<boolean>("!document.querySelector('[data-settings-duration]').disabled"),
+      "settings duration enabled"
+    );
+    await chooseSelectOption(cdp, "[data-settings-duration]", "1 hour");
+    await chooseSelectOption(cdp, "[data-settings-duration]", "Current setting · 42 minutes");
+    expect(await cdp.eval<string>("document.querySelector('[data-settings-duration]').innerText.trim()")).toBe("Current setting · 42 minutes");
+    await chooseSelectOption(cdp, "[data-settings-duration]", "1 hour");
+    await chooseSelectOption(cdp, "[data-settings-mode]", "Reuse for this login session");
+    expect(await cdp.eval<boolean>("document.querySelector('[data-settings-duration]').disabled")).toBe(true);
+    expect(await cdp.eval<string>("document.querySelector('[data-settings-duration]').innerText.trim()")).toBe("1 hour");
+    await chooseSelectOption(cdp, "[data-settings-mode]", "Reuse for a time window");
+    expect(await cdp.eval<boolean>("document.querySelector('[data-settings-duration]').disabled")).toBe(false);
+    expect(await cdp.eval<string>("document.querySelector('[data-settings-duration]').innerText.trim()")).toBe("1 hour");
+
+    await clickElement(cdp, "[data-settings-save]");
+    await waitFor(async () => {
+      const saved = await api<{
+        approvalGrants: unknown[];
+        approvalSettings: { durationMs: number; mode: string };
+      }>("api/state");
+      return saved.approvalSettings.mode === "timed-session"
+        && saved.approvalSettings.durationMs === 60 * 60 * 1000
+        && saved.approvalGrants.length === 0;
+    }, "settings saved");
+
+    await cdp.send("Emulation.setDeviceMetricsOverride", {
+      width: 390,
+      height: 844,
+      deviceScaleFactor: 1,
+      mobile: false
+    });
+    await waitFor(
+      () => cdp!.eval<boolean>("document.documentElement.clientWidth === 390"),
+      "settings mobile viewport"
+    );
+    const mobile = await cdp.eval<{ descriptionsHidden: boolean; navHeight: number; overflow: number; tabTops: number[] }>(`(() => {
+      const nav = document.querySelector('[data-settings-nav]');
+      const tabs = [...document.querySelectorAll('[data-settings-tab]')];
+      const descriptions = tabs.map((tab) => tab.querySelector('.text-xs'));
+      return {
+        descriptionsHidden: descriptions.every((node) => getComputedStyle(node).display === 'none'),
+        navHeight: nav.getBoundingClientRect().height,
+        overflow: document.documentElement.scrollWidth - document.documentElement.clientWidth,
+        tabTops: tabs.map((tab) => Math.round(tab.getBoundingClientRect().top))
+      };
+    })()`);
+    expect(new Set(mobile.tabTops).size).toBe(1);
+    expect(mobile.navHeight).toBeLessThan(130);
+    expect(mobile.descriptionsHidden).toBe(true);
+    expect(mobile.overflow).toBeLessThanOrEqual(1);
+  }, 45_000);
+
   it("sorts, searches, and filters activity and audit columns", async () => {
     process.env.SGW_MASTER_PASSPHRASE = "browser react passphrase";
     running = await startConsoleServer({ port: 0 });
@@ -759,6 +992,61 @@ async function api<T = unknown>(pathName: string, body?: unknown): Promise<T> {
     throw new Error((payload as { error?: string }).error || `HTTP ${response.status}`);
   }
   return payload as T;
+}
+
+async function clickElement(client: Cdp, selector: string): Promise<void> {
+  const point = await client.eval<{ x: number; y: number }>(`(() => {
+    const rect = document.querySelector(${JSON.stringify(selector)}).getBoundingClientRect();
+    return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+  })()`);
+  await client.send("Input.dispatchMouseEvent", {
+    type: "mousePressed",
+    x: point.x,
+    y: point.y,
+    button: "left",
+    clickCount: 1
+  });
+  await client.send("Input.dispatchMouseEvent", {
+    type: "mouseReleased",
+    x: point.x,
+    y: point.y,
+    button: "left",
+    clickCount: 1
+  });
+}
+
+async function chooseSelectOption(client: Cdp, triggerSelector: string, label: string): Promise<void> {
+  await clickElement(client, triggerSelector);
+
+  await waitFor(
+    () => client.eval<boolean>(`[...document.querySelectorAll('[role="option"]')]
+      .some((option) => option.textContent.trim() === ${JSON.stringify(label)})`),
+    `select option ${label}`
+  );
+  const optionPoint = await client.eval<{ x: number; y: number }>(`(() => {
+    const option = [...document.querySelectorAll('[role="option"]')]
+      .find((node) => node.textContent.trim() === ${JSON.stringify(label)});
+    const rect = option.getBoundingClientRect();
+    return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+  })()`);
+  await client.send("Input.dispatchMouseEvent", {
+    type: "mousePressed",
+    x: optionPoint.x,
+    y: optionPoint.y,
+    button: "left",
+    clickCount: 1
+  });
+  await client.send("Input.dispatchMouseEvent", {
+    type: "mouseReleased",
+    x: optionPoint.x,
+    y: optionPoint.y,
+    button: "left",
+    clickCount: 1
+  });
+  await waitFor(
+    () => client.eval<boolean>(`document.querySelector(${JSON.stringify(triggerSelector)}).innerText.trim() === ${JSON.stringify(label)}`),
+    `selected ${label}`
+  );
 }
 
 async function setEventSearch(client: Cdp, value: string): Promise<void> {

--- a/tests/console-ui-source.test.ts
+++ b/tests/console-ui-source.test.ts
@@ -122,6 +122,27 @@ describe("React console source contracts", () => {
     expect(app).not.toContain("PolicyEnabledStatus");
   });
 
+  it("keeps settings sections compact and approval durations readable", async () => {
+    const [app, tabs] = await Promise.all([
+      readFile(path.join(repoRoot, "src/console-ui/src/App.tsx"), "utf8"),
+      readFile(path.join(repoRoot, "src/console-ui/src/components/ui/tabs.tsx"), "utf8")
+    ]);
+
+    expect(app).toContain("data-settings-nav");
+    expect(app).toContain('data-settings-tab="approvals"');
+    expect(app).toContain('data-settings-tab="grants"');
+    expect(app).toContain('data-settings-tab="about"');
+    expect(app).toContain("Reusable duration");
+    expect(app).toContain('{ value: 15 * 60 * 1000, label: "15 minutes" }');
+    expect(app).toContain('{ value: 60 * 60 * 1000, label: "1 hour" }');
+    expect(app).toContain("Saving clears ${state.approvalGrants.length} active reusable");
+    expect(app).not.toContain('placeholder="Duration ms"');
+    expect(tabs).toContain("data-[orientation=horizontal]:flex-col");
+    expect(tabs).toContain("data-[state=active]:bg-background");
+    expect(tabs).not.toContain("data-horizontal:");
+    expect(tabs).not.toContain("data-active:");
+  });
+
   it("makes agent integration cards actionable", async () => {
     const [app, server] = await Promise.all([
       readFile(path.join(repoRoot, "src/console-ui/src/App.tsx"), "utf8"),

--- a/tests/install.test.ts
+++ b/tests/install.test.ts
@@ -21,7 +21,9 @@ describe("customer package layout", () => {
 
     expect(layout.cliPath).toMatch(/dist\/cli\.js$/);
     expect(layout.mcpPath).toMatch(/dist\/mcp-server\.js$/);
-    expect(layout.keychainHelperPath).toMatch(/dist\/native\/s-gw-keychain-helper$/);
+    expect(layout.keychainHelperPath).toBe(
+      path.join(layout.packageRoot, "dist", "native", `${process.platform}-${process.arch}`, "s-gw-keychain-helper")
+    );
     expect(layout.macAppPath).toContain("s-gw.app");
     expect(layout.macAppBinaryPath).toContain("s-gw.app/Contents/MacOS/s-gw");
     expect(layout.menuBarAppPath).toContain("s-gw Menu Bar.app");
@@ -52,6 +54,9 @@ describe("customer package layout", () => {
     expect(stopSource).toContain("pids.push(Number(app.processIdentifier))");
     expect(stopSource).not.toContain("valueForKey");
     expect(stopSource).not.toContain("macAppBinaryPath");
+    expect(installSource).toContain("assertMacExecutableCompatible");
+    expect(installSource).toContain('"-verify_arch", arch');
+    expect(installSource).toContain("Intel Macs must build them from source");
   });
 
   it("reports install health without exposing unlock passphrases", () => {

--- a/tests/installers.test.ts
+++ b/tests/installers.test.ts
@@ -18,10 +18,15 @@ describe("platform installers", () => {
     expect(pkg.scripts["build:installers"]).toContain("node scripts/build-installers.mjs");
     expect(pkg.scripts["build:installers"]).toContain("npm run validate:release-assets");
     expect(pkg.scripts["validate:release-assets"]).toBe("node scripts/validate-release-assets.mjs dist/installers");
+    expect(pkg.scripts["validate:npm-package"]).toBe("node scripts/validate-npm-package.mjs");
     expect(pkg.scripts["build:rust-core"]).toBe("node scripts/build-rust-core.mjs");
     expect(pkg.files).toContain("dist");
     expect(pkg.files).toContain("!dist/installers");
+    expect(pkg.files).toContain("!dist/native/s-gw-core");
+    expect(pkg.files).toContain("!dist/native/s-gw-core.exe");
+    expect(pkg.files).toContain("!dist/native/s-gw-keychain-helper");
     expect(pkg.files).toContain("!dist/**/*.map");
+    expect(pkg.scripts.prepublishOnly).toBe("npm run validate:npm-package");
     expect(pkg.files).not.toContain("scripts");
     expect(pkg.files).not.toContain("native/macos-app/Sources");
     expect(pkg.files).not.toContain("native/menu-bar-helper/Sources");
@@ -45,11 +50,23 @@ describe("platform installers", () => {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"]
     });
-    const manifest = JSON.parse(raw)[0] as { files: Array<{ path: string }> };
+    const manifest = JSON.parse(raw)[0] as { files: Array<{ path: string; mode: number }> };
     const files = manifest.files.map((item) => item.path);
-    const coreName = process.platform === "win32" ? "dist/native/s-gw-core.exe" : "dist/native/s-gw-core";
+    const target = `${process.platform}-${process.arch}`;
+    const coreName = process.platform === "win32"
+      ? `dist/native/${target}/s-gw-core.exe`
+      : `dist/native/${target}/s-gw-core`;
 
     expect(files).toContain(coreName);
+    expect(files).not.toContain("dist/native/s-gw-core");
+    expect(files).not.toContain("dist/native/s-gw-core.exe");
+    if (process.platform === "darwin") {
+      expect(files).toContain(`dist/native/${target}/s-gw-keychain-helper`);
+      expect(files).toContain("dist/s-gw.app/Contents/MacOS/s-gw");
+      expect(files).toContain("dist/s-gw Menu Bar.app/Contents/MacOS/s-gw-menu-bar-helper");
+    }
+    const nativeCore = manifest.files.find((item) => item.path === coreName);
+    expect((nativeCore?.mode || 0) & 0o111).not.toBe(0);
     expect(files.some((file) => file.endsWith(".map"))).toBe(false);
     expect(files.some((file) => file.startsWith("native/"))).toBe(false);
     expect(files.some((file) => file.startsWith("scripts/"))).toBe(false);
@@ -139,5 +156,30 @@ describe("platform installers", () => {
     expect(builder).toContain("buildLegacyBridge");
     expect(builder).toContain("0-s-gw-legacy-${version}.tgz");
     expect(validator).toContain('bridgeMetadata.name !== "s-gw"');
+  });
+
+  it("publishes the native npm package on Apple Silicon and keeps Registry publishing on Linux", async () => {
+    const workflow = await readFile(path.join(root, ".github/workflows/publish.yml"), "utf8");
+    const npmJob = workflow.slice(
+      workflow.indexOf("  publish-npm:"),
+      workflow.indexOf("  publish-registry:")
+    );
+    const registryJob = workflow.slice(
+      workflow.indexOf("  publish-registry:"),
+      workflow.indexOf("  release-assets:")
+    );
+
+    expect(npmJob).toContain("runs-on: macos-15");
+    expect(npmJob).toContain("npm run validate:npm-package");
+    expect(npmJob).toContain("npm publish --access public --ignore-scripts");
+    expect(npmJob).toContain("-verify_arch arm64");
+    expect(npmJob).toContain('npm install --global --prefix "$prefix"');
+    expect(npmJob).toContain('"@s-gw/s-gw@${package_version}"');
+    expect(npmJob).toContain('s-gw-core" --version');
+    expect(npmJob).toContain('test ! -e "$package_root/dist/native/s-gw-core"');
+    expect(registryJob).toContain("needs: publish-npm");
+    expect(registryJob).toContain("runs-on: ubuntu-latest");
+    expect(registryJob).toContain("mcp-publisher_linux_amd64.tar.gz");
+    expect(registryJob).not.toContain("npm publish --access public");
   });
 });

--- a/tests/installers.test.ts
+++ b/tests/installers.test.ts
@@ -66,7 +66,9 @@ describe("platform installers", () => {
       expect(files).toContain("dist/s-gw Menu Bar.app/Contents/MacOS/s-gw-menu-bar-helper");
     }
     const nativeCore = manifest.files.find((item) => item.path === coreName);
-    expect((nativeCore?.mode || 0) & 0o111).not.toBe(0);
+    if (process.platform !== "win32") {
+      expect((nativeCore?.mode || 0) & 0o111).not.toBe(0);
+    }
     expect(files.some((file) => file.endsWith(".map"))).toBe(false);
     expect(files.some((file) => file.startsWith("native/"))).toBe(false);
     expect(files.some((file) => file.startsWith("scripts/"))).toBe(false);

--- a/tests/native-update.test.ts
+++ b/tests/native-update.test.ts
@@ -5,14 +5,21 @@ import { describe, expect, it } from "vitest";
 const root = process.cwd();
 
 describe("native macOS update lifecycle", () => {
-  it("starts polling with the app process instead of a visible window", async () => {
-    const app = await readFile(
-      path.join(root, "native/macos-app/Sources/SgwMac/App/SgwApp.swift"),
-      "utf8"
-    );
+  it("keeps recurring update polling in the login-started menu helper", async () => {
+    const [app, state, helper, install] = await Promise.all([
+      readFile(path.join(root, "native/macos-app/Sources/SgwMac/App/SgwApp.swift"), "utf8"),
+      readFile(path.join(root, "native/macos-app/Sources/SgwMac/App/AppState.swift"), "utf8"),
+      readFile(path.join(root, "native/menu-bar-helper/Sources/UpdateMonitor.swift"), "utf8"),
+      readFile(path.join(root, "src/install.ts"), "utf8")
+    ]);
 
     expect(app).toContain("state.start()\n  }");
     expect(app).not.toContain(".onAppear { appState.start() }");
+    expect(state).not.toContain("private var updateTask");
+    expect(helper).toContain("final class UpdateMonitor");
+    expect(helper).toContain("pollInterval: TimeInterval = 15 * 60");
+    expect(helper).toContain('["update", "check"]');
+    expect(install).toContain("runAtLoad: true");
   });
 
   it("delivers foreground system notifications and keeps an in-app fallback", async () => {
@@ -45,11 +52,12 @@ describe("native macOS update lifecycle", () => {
     const persistedCheck = updateMethod.indexOf("UpdateChecker.lastCheckDefaultsKey");
     expect(persistedCheck).toBeGreaterThan(failedFetch);
     expect(updateMethod).toContain("if !release.canInstallPackage");
-    expect(state).toContain("updateRetryInterval: TimeInterval = 15 * 60");
+    expect(state).not.toContain("updateRetryInterval");
     expect(checker).toContain('"sha256sums.txt"');
     expect(checker).toContain("entry.fileName == assetName");
     expect(checker).toContain('"update", "install", "--package", downloadURL.path');
     expect(checker).toContain("s-gw setup --no-open-app");
+    expect(checker).toContain("s-gw start --no-open-app");
     expect(checker).not.toContain('npmCommand()');
   });
 });

--- a/tests/package-update.test.ts
+++ b/tests/package-update.test.ts
@@ -212,7 +212,201 @@ describe("scoped package migration", () => {
     await rm(path.dirname(rollbackTarget || ""), { recursive: true, force: true });
     const uninstall = calls.find((args) => args[0] === "uninstall");
     expect(uninstall?.at(-1)).toBe("s-gw");
-    expect(calls.some((args) => args[0] === "uninstall" && args.includes("@s-gw/s-gw"))).toBe(false);
+    expect(calls.some((args) => args[0] === "uninstall" && args.includes("@s-gw/s-gw"))).toBe(true);
+  });
+
+  it("restores the legacy package before restarting services when post-remove inspection fails", async () => {
+    const tmp = await tempDir("sgw-package-post-remove-");
+    const prefix = path.join(tmp, "prefix");
+    let listCalls = 0;
+    const calls: string[][] = [];
+    const runNpm = async (args: string[]): Promise<NpmCommandResult> => {
+      calls.push(args);
+      if (args[0] === "root") return ok(path.join(prefix, "lib", "node_modules"));
+      if (args[0] === "list") {
+        listCalls += 1;
+        if (listCalls === 1) {
+          return ok(JSON.stringify({ dependencies: { "s-gw": { version: "0.1.0" } } }));
+        }
+        return { status: 1, stdout: "", stderr: "simulated post-remove inspection failure" };
+      }
+      if (args[0] === "pack" && args.includes("--dry-run")) {
+        return ok(JSON.stringify([{ name: "@s-gw/s-gw", version: CURRENT_VERSION }]));
+      }
+      if (args[0] === "pack") {
+        const backupDir = args[args.indexOf("--pack-destination") + 1];
+        await writeFile(path.join(backupDir, "s-gw-0.1.0.tgz"), "rollback copy");
+        return ok(JSON.stringify([{ name: "s-gw", version: "0.1.0", filename: "s-gw-0.1.0.tgz" }]));
+      }
+      if (args[0] === "uninstall") return ok("");
+      if (args[0] === "install") {
+        const packageRoot = path.join(prefix, "lib", "node_modules", "s-gw");
+        await mkdir(path.join(packageRoot, "dist"), { recursive: true });
+        await writeFile(path.join(packageRoot, "package.json"), JSON.stringify({ name: "s-gw", version: "0.1.0" }));
+        await writeFile(path.join(packageRoot, "dist", "cli.js"), "restored CLI");
+        return ok("");
+      }
+      return ok("");
+    };
+    let restarted = 0;
+
+    let thrown: unknown;
+    try {
+      await installPackageUpdate({
+        npmPrefix: prefix,
+        runNpm,
+        stopServices: async () => undefined,
+        restartServices: async () => { restarted += 1; }
+      });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(PackageUpdateError);
+    expect(thrown).toMatchObject({ phase: "inspect" });
+    expect((thrown as PackageUpdateError).message).toContain("simulated post-remove inspection failure");
+    expect((thrown as PackageUpdateError).message).toContain("previous s-gw@0.1.0 package was restored");
+    expect((thrown as PackageUpdateError).recoveryCommands).toEqual([]);
+    const restore = calls.find((args) => args[0] === "install");
+    const rollbackTarget = restore?.at(-1) || "";
+    expect(rollbackTarget).toContain("sgw-legacy-rollback-");
+    await expect(readFile(rollbackTarget, "utf8")).rejects.toThrow();
+    expect(restarted).toBe(1);
+  });
+
+  it("never suggests setup when missing data still needs to be restored", async () => {
+    const tmp = await tempDir("sgw-package-missing-data-");
+    const prefix = path.join(tmp, "prefix");
+    const sgwHome = path.join(tmp, "home");
+    await mkdir(sgwHome, { recursive: true });
+    await writeFile(path.join(sgwHome, "store.json"), "existing data");
+    let listCalls = 0;
+    const runNpm = async (args: string[]): Promise<NpmCommandResult> => {
+      if (args[0] === "root") return ok(path.join(prefix, "lib", "node_modules"));
+      if (args[0] === "list") {
+        listCalls += 1;
+        if (listCalls === 1) return ok(JSON.stringify({ dependencies: { "s-gw": { version: "0.1.0" } } }));
+        if (listCalls === 2) return ok(JSON.stringify({ dependencies: {} }));
+        return ok(JSON.stringify({ dependencies: { "@s-gw/s-gw": { version: CURRENT_VERSION } } }));
+      }
+      if (args[0] === "pack" && args.includes("--dry-run")) {
+        return ok(JSON.stringify([{ name: "@s-gw/s-gw", version: CURRENT_VERSION }]));
+      }
+      if (args[0] === "pack") {
+        const backupDir = args[args.indexOf("--pack-destination") + 1];
+        await writeFile(path.join(backupDir, "s-gw-0.1.0.tgz"), "rollback copy");
+        return ok(JSON.stringify([{ name: "s-gw", version: "0.1.0", filename: "s-gw-0.1.0.tgz" }]));
+      }
+      if (args[0] === "uninstall") return ok("");
+      if (args[0] === "install" && args.at(-1) === `@s-gw/s-gw@${CURRENT_VERSION}`) {
+        await rm(sgwHome, { recursive: true, force: true });
+        return ok("");
+      }
+      if (args[0] === "install") {
+        return { status: 1, stdout: "", stderr: "simulated rollback failure" };
+      }
+      return ok("");
+    };
+    let restarted = 0;
+
+    let thrown: unknown;
+    try {
+      await installPackageUpdate({
+        npmPrefix: prefix,
+        sgwHome,
+        runNpm,
+        stopServices: async () => undefined,
+        restartServices: async () => { restarted += 1; }
+      });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toMatchObject({ phase: "verify-data" });
+    expect((thrown as Error).message).toContain("Do not run setup until the data is restored");
+    expect((thrown as Error).message).toContain("Services remain stopped");
+    expect((thrown as Error).message).toContain("Automatic rollback failed");
+    expect((thrown as PackageUpdateError).recoveryCommands).toHaveLength(2);
+    expect((thrown as PackageUpdateError).recoveryCommands.join("\n")).not.toContain("s-gw setup");
+    expect((thrown as PackageUpdateError).recoveryCommands.join("\n")).not.toContain("s-gw start");
+    expect(restarted).toBe(0);
+    const rollbackTarget = (thrown as PackageUpdateError).recoveryCommands[1]
+      .split(" -- ").at(-1)?.replace(/^'|'$/g, "");
+    await rm(path.dirname(rollbackTarget || ""), { recursive: true, force: true });
+  });
+
+  it("restarts services after stop, rollback preparation, and install failures", async () => {
+    const scenarios = ["stop", "backup", "install"] as const;
+
+    for (const scenario of scenarios) {
+      const tmp = await tempDir(`sgw-package-restart-${scenario}-`);
+      const prefix = path.join(tmp, "prefix");
+      let restarted = 0;
+      const runNpm = async (args: string[]): Promise<NpmCommandResult> => {
+        if (args[0] === "root") return ok(path.join(prefix, "lib", "node_modules"));
+        if (args[0] === "list") {
+          const dependencies = scenario === "backup" ? { "s-gw": { version: "0.1.0" } } : {};
+          return ok(JSON.stringify({ dependencies }));
+        }
+        if (args[0] === "pack" && args.includes("--dry-run")) {
+          return ok(JSON.stringify([{ name: "@s-gw/s-gw", version: CURRENT_VERSION }]));
+        }
+        if (args[0] === "pack") {
+          return { status: 1, stdout: "", stderr: "simulated backup failure" };
+        }
+        if (args[0] === "install") {
+          return { status: 1, stdout: "", stderr: "simulated install failure" };
+        }
+        return ok("");
+      };
+
+      await expect(installPackageUpdate({
+        npmPrefix: prefix,
+        runNpm,
+        stopServices: async () => {
+          if (scenario === "stop") throw new Error("simulated partial stop failure");
+        },
+        restartServices: async () => { restarted += 1; }
+      })).rejects.toBeInstanceOf(PackageUpdateError);
+      expect(restarted, scenario).toBe(1);
+    }
+  });
+
+  it("preserves the update failure when restarting services also fails", async () => {
+    const prefix = "/tmp/sgw-restart-failure";
+    const runNpm = async (args: string[]): Promise<NpmCommandResult> => {
+      if (args[0] === "root") return ok(`${prefix}/lib/node_modules`);
+      if (args[0] === "list") return ok(JSON.stringify({ dependencies: {} }));
+      if (args[0] === "pack") return ok(JSON.stringify([{ name: "@s-gw/s-gw", version: CURRENT_VERSION }]));
+      if (args[0] === "install") return { status: 1, stdout: "", stderr: "original install failure" };
+      return ok("");
+    };
+
+    let thrown: unknown;
+    try {
+      await installPackageUpdate({
+        npmPrefix: prefix,
+        runNpm,
+        stopServices: async () => undefined,
+        restartServices: async () => { throw new Error("restart also failed"); }
+      });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toMatchObject({ phase: "install-scoped" });
+    expect((thrown as Error).message).toContain("original install failure");
+    expect((thrown as Error).message).toContain("restart also failed");
+    expect((thrown as PackageUpdateError).recoveryCommands).toContain("s-gw start --no-open-app");
+  });
+
+  it("wires CLI update failures back to the previously loaded local services", async () => {
+    const cli = await readFile(path.join(process.cwd(), "src", "cli.ts"), "utf8");
+    expect(cli).toContain("restartServices: services.restart");
+    expect(cli).toContain('restartLaunchAgent("console", serviceWasLoaded');
+    expect(cli).toContain('restartLaunchAgent("menubar", menuBarWasLoaded');
+    expect(cli).toContain("verifyRestoredLaunchAgents(serviceWasLoaded, menuBarWasLoaded");
+    expect(cli).toContain("await restartWindowsSurfaces(windowsStopped)");
   });
 
   it("refuses an unrelated target before removing the legacy package", async () => {

--- a/tests/rust-core.test.ts
+++ b/tests/rust-core.test.ts
@@ -170,6 +170,90 @@ describe("Rust execution core", () => {
     expect(summary.stdout).toContain(tokenForHandle(record.handle));
     expect(summary.stdout).not.toContain(secret);
   });
+
+  it("falls back before launch when automatic mode finds an incompatible core", async () => {
+    const incompatibleCore = path.join(tmpHome, process.platform === "win32" ? "foreign-core.exe" : "foreign-core");
+    await writeFile(incompatibleCore, Buffer.from([0x7f, 0x45, 0x4c, 0x46, 2, 1, 1, 0]), { mode: 0o700 });
+    await chmod(incompatibleCore, 0o700);
+
+    const store = new SecretStore();
+    const secret = "incompatible-core-secret-value-123456789";
+    const record = await addCredential(store, "incompatible core", secret);
+    const request = await createRequest(
+      store,
+      record.handle,
+      "SGW_INCOMPATIBLE_CORE",
+      "console.log(process.env.SGW_INCOMPATIBLE_CORE)"
+    );
+    await store.approveRequest(request.id);
+
+    const summary = await executeApprovedRequest(store, request.id, {
+      engine: "auto",
+      coreBinary: incompatibleCore
+    });
+    expect(summary.exitCode).toBe(0);
+    expect(summary.stdout).toContain(tokenForHandle(record.handle));
+    expect(summary.stdout).not.toContain(secret);
+  });
+
+  it("fails closed when an incompatible core is explicitly required", async () => {
+    const incompatibleCore = path.join(tmpHome, process.platform === "win32" ? "required-foreign.exe" : "required-foreign");
+    await writeFile(incompatibleCore, Buffer.from([0x7f, 0x45, 0x4c, 0x46, 2, 1, 1, 0]), { mode: 0o700 });
+    await chmod(incompatibleCore, 0o700);
+
+    const store = new SecretStore();
+    const record = await addCredential(store, "required incompatible core", "required-incompatible-secret-value-123456789");
+    const request = await createRequest(store, record.handle, "SGW_REQUIRED_CORE", "console.log('must-not-run')");
+    await store.approveRequest(request.id);
+
+    await expect(executeApprovedRequest(store, request.id, {
+      engine: "rust",
+      coreBinary: incompatibleCore
+    })).rejects.toThrow(/not compatible|could not be launched/i);
+    expect((await store.getRequest(request.id)).state).toBe("failed");
+  });
+
+  it("falls back only when an automatic core cannot be launched", async () => {
+    if (process.platform === "win32") return;
+    const brokenCore = path.join(tmpHome, "missing-interpreter-core");
+    await writeFile(brokenCore, "#!/definitely/missing/s-gw-interpreter\n", { mode: 0o700 });
+    await chmod(brokenCore, 0o700);
+
+    const store = new SecretStore();
+    const record = await addCredential(store, "launch fallback", "launch-fallback-secret-value-123456789");
+    const request = await createRequest(
+      store,
+      record.handle,
+      "SGW_LAUNCH_FALLBACK",
+      "console.log(process.env.SGW_LAUNCH_FALLBACK)"
+    );
+    await store.approveRequest(request.id);
+
+    const summary = await executeApprovedRequest(store, request.id, {
+      engine: "auto",
+      coreBinary: brokenCore
+    });
+    expect(summary.stdout).toContain(tokenForHandle(record.handle));
+    expect(summary.stdout).not.toContain("launch-fallback-secret-value");
+  });
+
+  it("does not retry an already launched core failure through TypeScript", async () => {
+    if (process.platform === "win32") return;
+    const failingCore = path.join(tmpHome, "failing-core");
+    await writeFile(failingCore, "#!/bin/sh\necho 'core rejected request' >&2\nexit 23\n", { mode: 0o700 });
+    await chmod(failingCore, 0o700);
+
+    const store = new SecretStore();
+    const record = await addCredential(store, "no retry", "no-retry-secret-value-123456789");
+    const request = await createRequest(store, record.handle, "SGW_NO_RETRY", "console.log('must-not-run')");
+    await store.approveRequest(request.id);
+
+    await expect(executeApprovedRequest(store, request.id, {
+      engine: "auto",
+      coreBinary: failingCore
+    })).rejects.toThrow("core rejected request");
+    expect((await store.getRequest(request.id)).state).toBe("failed");
+  });
 });
 
 async function addCredential(store: SecretStore, name: string, value: string) {

--- a/tests/update-check.test.ts
+++ b/tests/update-check.test.ts
@@ -111,8 +111,37 @@ describe("release update checks", () => {
   it("compares tagged release versions numerically", () => {
     expect(isNewerVersion("v0.10.0", "0.9.9")).toBe(true);
     expect(isNewerVersion("v0.1.1-preview.1", "0.1.0")).toBe(true);
+    expect(isNewerVersion("0.2.0-preview.1", "0.2.0")).toBe(false);
+    expect(isNewerVersion("0.2.0", "0.2.0-preview.1")).toBe(true);
+    expect(isNewerVersion("0.2.0-preview.10", "0.2.0-preview.2")).toBe(true);
+    expect(isNewerVersion("0.2.0-preview.2", "0.2.0-preview.10")).toBe(false);
+    expect(isNewerVersion("0.2.0-beta", "0.2.0-alpha")).toBe(true);
+    expect(isNewerVersion("0.2.0-1", "0.2.0-alpha")).toBe(false);
+    expect(isNewerVersion("0.2.0-preview", "0.2.0-preview.1")).toBe(false);
+    expect(isNewerVersion("0.2.0+build.2", "0.2.0+build.1")).toBe(false);
     expect(isNewerVersion("v0.1.0", "0.1.0")).toBe(false);
     expect(isNewerVersion("v0.0.9", "0.1.0")).toBe(false);
+    expect(isNewerVersion("not-a-version", "0.1.0")).toBe(false);
+  });
+
+  it("offers the stable release to users running its preview", async () => {
+    tmpDir = await mkdtemp(path.join(os.tmpdir(), "sgw-update-stable-"));
+    const checker = new ReleaseChecker({
+      cachePath: path.join(tmpDir, "update.json"),
+      currentVersion: "0.2.0-preview.1",
+      enabled: true,
+      fetcher: async () => new Response(JSON.stringify([
+        release("v0.2.0-preview.2", { prerelease: true }),
+        release("v0.2.0"),
+        release("not-a-version")
+      ]), { status: 200 })
+    });
+
+    await expect(checker.check(true)).resolves.toMatchObject({
+      available: true,
+      latestVersion: "0.2.0",
+      prerelease: false
+    });
   });
 
   it("keeps the updater version aligned with the package", async () => {
@@ -132,8 +161,13 @@ describe("release update checks", () => {
     expect(swiftChecker).toContain("/releases?per_page=20");
     expect(swiftChecker).toContain("releases.atom");
     expect(swiftChecker).toContain(".filter({ !$0.draft })");
-    expect(appState).toContain("private var updateTask");
-    expect(appState).toContain("updateRetryInterval: TimeInterval = 15 * 60");
+    const helper = await readFile(
+      path.join(process.cwd(), "native/menu-bar-helper/Sources/UpdateMonitor.swift"),
+      "utf8"
+    );
+    expect(appState).not.toContain("private var updateTask");
+    expect(helper).toContain("update check");
+    expect(helper).toContain("15 * 60");
   });
 });
 

--- a/tests/windows-client.test.ts
+++ b/tests/windows-client.test.ts
@@ -1,9 +1,16 @@
 import { execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";
-import { readFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { createServer } from "node:net";
+import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { getPackageLayout } from "../src/install.js";
+import {
+  getPackageLayout,
+  restartWindowsSurfaces,
+  startWindowsConsole,
+  stopWindowsSurfaces
+} from "../src/install.js";
 
 const repoRoot = process.cwd();
 
@@ -43,4 +50,66 @@ describe("Windows client packaging", () => {
     const combined = `${client}\n${helper}\n${credential}`;
     expect(combined).not.toContain("SGW_MASTER_PASSPHRASE");
   });
+
+  it("restores a running console after an update failure", async () => {
+    if (process.platform !== "win32") return;
+    const home = await mkdtemp(path.join(os.tmpdir(), "sgw-windows-restart-"));
+    const port = await freePort();
+    const oldHome = process.env.SGW_HOME;
+    const oldPassphrase = process.env.SGW_MASTER_PASSPHRASE;
+    const oldUpdateCheck = process.env.SGW_DISABLE_UPDATE_CHECK;
+    process.env.SGW_HOME = home;
+    process.env.SGW_MASTER_PASSPHRASE = "windows restart test passphrase";
+    process.env.SGW_DISABLE_UPDATE_CHECK = "1";
+
+    try {
+      startWindowsConsole({ port });
+      await waitForHealth(port);
+      const stopped = stopWindowsSurfaces();
+      expect(stopped.console).toBe(true);
+      expect(stopped.pids.length).toBeGreaterThan(0);
+
+      await restartWindowsSurfaces(stopped, { port });
+      await waitForHealth(port);
+    } finally {
+      stopWindowsSurfaces();
+      restoreEnv("SGW_HOME", oldHome);
+      restoreEnv("SGW_MASTER_PASSPHRASE", oldPassphrase);
+      restoreEnv("SGW_DISABLE_UPDATE_CHECK", oldUpdateCheck);
+      await rm(home, { recursive: true, force: true });
+    }
+  }, 30_000);
 });
+
+async function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      const port = typeof address === "object" && address ? address.port : 0;
+      server.close((error) => error ? reject(error) : resolve(port));
+    });
+  });
+}
+
+async function waitForHealth(port: number): Promise<void> {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    try {
+      const response = await fetch(`http://127.0.0.1:${port}/api/health`);
+      if (response.ok) return;
+    } catch {
+      // The background process can take a moment to bind its port on Windows runners.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`s-gw console did not become healthy on port ${port}.`);
+}
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+  process.env[name] = value;
+}


### PR DESCRIPTION
## Summary

- publish a platform-safe Apple Silicon npm package with native compatibility checks and TypeScript fallback
- make update comparison SemVer-correct and move recurring macOS checks into the login helper
- restore stopped services on update failures and make legacy migration rollback verifiable
- serialize concurrent agent integration changes without lost manifest ownership
- complete light mode styling and redesign the Settings section switcher

## Verification

- npm run verify (31 test files, 256 tests)
- npm run validate:npm-package
- native arm64 checks with lipo
- release installer build and checksum validation
- disposable global npm install smoke test
- actionlint and gitleaks