### PR TITLE
Recover the macOS app when services stop

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "s-gw",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Local s-gw plugin that lets coding agents use typed secret handles without receiving raw credentials.",
   "author": {
     "name": "Barry Yuan"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ Notable changes to s-gw are documented here. The project follows [Semantic Versi
 
 ## Unreleased
 
+## 0.1.5 - 2026-07-12
+
+### Fixed
+
+- The macOS app now shows its native recovery screen when the local console service is stopped instead of opening a blank white web view.
+- The embedded console retries transient startup failures and uses a dark loading background while the local service becomes available.
+- macOS setup tests now install into isolated temporary folders without changing the user's Applications folder or app preferences.
+
 ## 0.1.4 - 2026-07-12
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,7 +143,7 @@ dependencies = [
 
 [[package]]
 name = "sgw-core"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "base64",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/sgw-core"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/sgateway/s-gw"

--- a/native/macos-app/Sources/SgwMac/Services/UpdateChecker.swift
+++ b/native/macos-app/Sources/SgwMac/Services/UpdateChecker.swift
@@ -64,7 +64,7 @@ actor UpdateChecker: UpdateChecking {
     private let cli = CLIRunner()
 
     static var currentVersion: String {
-        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.1.4"
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.1.5"
     }
 
     static func isNewer(_ candidate: String, than current: String) -> Bool {

--- a/native/macos-app/Sources/SgwMac/Views/ConsoleWebAppView.swift
+++ b/native/macos-app/Sources/SgwMac/Views/ConsoleWebAppView.swift
@@ -1,22 +1,80 @@
+import AppKit
 import SwiftUI
 import WebKit
 
 struct ConsoleWebAppView: NSViewRepresentable {
   let url: URL
 
+  func makeCoordinator() -> Coordinator {
+    Coordinator()
+  }
+
   func makeNSView(context: Context) -> WKWebView {
     let configuration = WKWebViewConfiguration()
     configuration.websiteDataStore = .nonPersistent()
     let webView = WKWebView(frame: .zero, configuration: configuration)
+    webView.navigationDelegate = context.coordinator
     webView.allowsBackForwardNavigationGestures = true
-    webView.load(URLRequest(url: url))
+    webView.underPageBackgroundColor = NSColor(red: 0.02, green: 0.04, blue: 0.07, alpha: 1)
+    context.coordinator.load(url, in: webView)
     return webView
   }
 
   func updateNSView(_ webView: WKWebView, context: Context) {
-    if webView.url?.absoluteString == url.absoluteString {
-      return
+    context.coordinator.load(url, in: webView)
+  }
+
+  @MainActor
+  final class Coordinator: NSObject, WKNavigationDelegate {
+    private var requestedURL: URL?
+    private var retryTask: Task<Void, Never>?
+
+    func load(_ url: URL, in webView: WKWebView) {
+      if requestedURL == url {
+        if webView.isLoading || webView.url == url || retryTask != nil {
+          return
+        }
+      } else {
+        retryTask?.cancel()
+        retryTask = nil
+        requestedURL = url
+      }
+      webView.load(URLRequest(url: url))
     }
-    webView.load(URLRequest(url: url))
+
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+      retryTask?.cancel()
+      retryTask = nil
+    }
+
+    func webView(
+      _ webView: WKWebView,
+      didFail navigation: WKNavigation!,
+      withError error: any Error
+    ) {
+      retry(webView)
+    }
+
+    func webView(
+      _ webView: WKWebView,
+      didFailProvisionalNavigation navigation: WKNavigation!,
+      withError error: any Error
+    ) {
+      retry(webView)
+    }
+
+    private func retry(_ webView: WKWebView) {
+      guard retryTask == nil else { return }
+      retryTask = Task { @MainActor [weak self, weak webView] in
+        do {
+          try await Task.sleep(for: .milliseconds(500))
+        } catch {
+          return
+        }
+        guard let self, let webView, let requestedURL else { return }
+        retryTask = nil
+        webView.load(URLRequest(url: requestedURL))
+      }
+    }
   }
 }

--- a/native/macos-app/Sources/SgwMac/Views/MainWindow.swift
+++ b/native/macos-app/Sources/SgwMac/Views/MainWindow.swift
@@ -7,7 +7,7 @@ struct MainWindow: View {
   var body: some View {
     @Bindable var state = appState
     ZStack {
-      if let url = appState.consoleURL() {
+      if appState.daemonRunning, let url = appState.consoleURL() {
         ConsoleWebAppView(url: url)
           .frame(maxWidth: .infinity, maxHeight: .infinity)
       } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@s-gw/s-gw",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@s-gw/s-gw",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-gw/s-gw",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "mcpName": "io.github.sgateway/s-gw",
   "description": "Local credential control for AI coding agents.",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -15,13 +15,13 @@
     "url": "https://github.com/sgateway/s-gw",
     "source": "github"
   },
-  "version": "0.1.4",
+  "version": "0.1.5",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@s-gw/s-gw",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "runtimeHint": "npx",
       "runtimeArguments": [
         {

--- a/src/install.ts
+++ b/src/install.ts
@@ -542,14 +542,16 @@ export function installMacAppBundle(options: MacAppInstallOptions = {}): MacAppI
 
   const applicationsDir = path.resolve(options.applicationsDir || macApplicationsDirectory());
   const appPath = path.join(applicationsDir, "s-gw.app");
+  const registerCliPath = options.registerCliPath !== false
+    && process.env.SGW_SKIP_MAC_APP_CLI_REGISTRATION !== "1";
   if (path.resolve(sourcePath) === path.resolve(appPath)) {
-    if (options.registerCliPath !== false) registerMacAppCliPath(layout.cliPath);
+    if (registerCliPath) registerMacAppCliPath(layout.cliPath);
     return { appPath, sourcePath, changed: false };
   }
 
   mkdirSync(applicationsDir, { recursive: true });
   if (sameMacAppBundle(sourcePath, appPath)) {
-    if (options.registerCliPath !== false) registerMacAppCliPath(layout.cliPath);
+    if (registerCliPath) registerMacAppCliPath(layout.cliPath);
     return { appPath, sourcePath, changed: false };
   }
 
@@ -585,7 +587,7 @@ export function installMacAppBundle(options: MacAppInstallOptions = {}): MacAppI
     throw new Error(`Could not install s-gw in ${applicationsDir}: ${error instanceof Error ? error.message : String(error)}`);
   }
 
-  if (options.registerCliPath !== false) registerMacAppCliPath(layout.cliPath);
+  if (registerCliPath) registerMacAppCliPath(layout.cliPath);
   return { appPath, sourcePath, changed: true };
 }
 

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const CURRENT_VERSION = "0.1.4";
+export const CURRENT_VERSION = "0.1.5";

--- a/tests/agent-install.test.ts
+++ b/tests/agent-install.test.ts
@@ -902,7 +902,9 @@ describe("agent integration installation", () => {
         SGW_HOME: path.join(homeDir, ".s-gw"),
         SGW_MASTER_PASSPHRASE: "test-only-passphrase",
         SGW_DISABLE_KEYCHAIN: "1",
-        SGW_DISABLE_UPDATE_CHECK: "1"
+        SGW_DISABLE_UPDATE_CHECK: "1",
+        SGW_APPLICATIONS_DIR: path.join(homeDir, "Applications"),
+        SGW_SKIP_MAC_APP_CLI_REGISTRATION: "1"
       };
       return JSON.parse(execFileSync(
         process.execPath,

--- a/tests/native-readiness-ui.test.ts
+++ b/tests/native-readiness-ui.test.ts
@@ -38,4 +38,17 @@ describe("native readiness UI contract", () => {
     expect(appState).toContain('arguments: ["agent", "uninstall", agent.id]');
     expect(models).toContain("struct AgentIntegrationStatus");
   });
+
+  it("shows native recovery UI while the console is stopped and retries transient web failures", async () => {
+    const [mainWindow, consoleWebApp] = await Promise.all([
+      readFile(path.join(appRoot, "Views/MainWindow.swift"), "utf8"),
+      readFile(path.join(appRoot, "Views/ConsoleWebAppView.swift"), "utf8")
+    ]);
+
+    expect(mainWindow).toContain("if appState.daemonRunning, let url = appState.consoleURL()");
+    expect(mainWindow).toContain("SetupView()");
+    expect(consoleWebApp).toContain("webView.navigationDelegate = context.coordinator");
+    expect(consoleWebApp).toContain("didFailProvisionalNavigation");
+    expect(consoleWebApp).toContain("try await Task.sleep(for: .milliseconds(500))");
+  });
 });


### PR DESCRIPTION
## Summary
- show the native Setup screen instead of a white web view when the local console is stopped
- retry transient embedded-console startup failures against a dark loading background
- isolate macOS setup tests from the real Applications folder and app preferences
- prepare version 0.1.5

## Verification
- npm run verify (32 files, 259 tests)
- npm run build:installers
- hdiutil verify dist/installers/s-gw-0.1.5-macos.dmg
- Windows ZIP integrity and all release checksums
- runtime: stopped service shows Setup; starting service transitions to Overview without reopening