### PR TITLE
Fix menu helper notification startup

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "s-gw",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Local s-gw plugin that lets coding agents use typed secret handles without receiving raw credentials.",
   "author": {
     "name": "Barry Yuan"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Notable changes to s-gw are documented here. The project follows [Semantic Versi
 
 ## Unreleased
 
+## 0.1.6 - 2026-07-12
+
+### Fixed
+
+- The macOS menu helper now requests and reads notification authorization through actor-safe async APIs instead of crashing when UserNotifications calls a main-actor completion handler on its own queue.
+
 ## 0.1.5 - 2026-07-12
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,7 +143,7 @@ dependencies = [
 
 [[package]]
 name = "sgw-core"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "base64",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/sgw-core"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.5"
+version = "0.1.6"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/sgateway/s-gw"

--- a/native/macos-app/Sources/SgwMac/Services/UpdateChecker.swift
+++ b/native/macos-app/Sources/SgwMac/Services/UpdateChecker.swift
@@ -64,7 +64,7 @@ actor UpdateChecker: UpdateChecking {
     private let cli = CLIRunner()
 
     static var currentVersion: String {
-        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.1.5"
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.1.6"
     }
 
     static func isNewer(_ candidate: String, than current: String) -> Bool {

--- a/native/menu-bar-helper/Sources/AppDelegate.swift
+++ b/native/menu-bar-helper/Sources/AppDelegate.swift
@@ -471,7 +471,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
   }
 
   private func requestNotificationPermission() {
-    UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { _, _ in }
+    guard notificationsEnabled else { return }
+    Task {
+      _ = try? await UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound])
+    }
   }
 
   private func sendNotification(title: String, body: String) {
@@ -521,11 +524,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
   }
 
   private func notificationAuthorizationStatus(_ center: UNUserNotificationCenter) async -> UNAuthorizationStatus {
-    await withCheckedContinuation { continuation in
-      center.getNotificationSettings { settings in
-        continuation.resume(returning: settings.authorizationStatus)
-      }
-    }
+    await center.notificationSettings().authorizationStatus
   }
 
   nonisolated func userNotificationCenter(

--- a/native/menu-bar-helper/Sources/AppDelegate.swift
+++ b/native/menu-bar-helper/Sources/AppDelegate.swift
@@ -53,6 +53,9 @@ final class HelperLaunchGuard {
   }
 
   static func lockPath() -> String {
+    if let override = ProcessInfo.processInfo.environment["SGW_MENU_BAR_LOCK_PATH"], !override.isEmpty {
+      return override
+    }
     let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
       ?? FileManager.default.temporaryDirectory
     let dir = base.appendingPathComponent("s-gw", isDirectory: true)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@s-gw/s-gw",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@s-gw/s-gw",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-gw/s-gw",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "mcpName": "io.github.sgateway/s-gw",
   "description": "Local credential control for AI coding agents.",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -15,13 +15,13 @@
     "url": "https://github.com/sgateway/s-gw",
     "source": "github"
   },
-  "version": "0.1.5",
+  "version": "0.1.6",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@s-gw/s-gw",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "runtimeHint": "npx",
       "runtimeArguments": [
         {

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const CURRENT_VERSION = "0.1.5";
+export const CURRENT_VERSION = "0.1.6";

--- a/tests/install-macos.test.ts
+++ b/tests/install-macos.test.ts
@@ -1,8 +1,9 @@
+import { spawn } from "node:child_process";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { installMacAppBundle } from "../src/install.js";
+import { getPackageLayout, installMacAppBundle } from "../src/install.js";
 
 describe("macOS app installation", () => {
   it.skipIf(process.platform !== "darwin")("installs the app bundle once and replaces a changed copy", async () => {
@@ -27,4 +28,42 @@ describe("macOS app installation", () => {
       await rm(applicationsDir, { recursive: true, force: true });
     }
   });
+
+  it.skipIf(process.platform !== "darwin")("keeps the menu helper alive through notification startup", async () => {
+    const layout = getPackageLayout();
+    const tmp = await mkdtemp(path.join(os.tmpdir(), "sgw-menu-startup-"));
+    let stderr = "";
+    const helper = spawn(layout.menuBarBinaryPath, [], {
+      env: {
+        ...process.env,
+        SGW_REPO_ROOT: layout.packageRoot,
+        SGW_CLI_PATH: "/usr/bin/true",
+        SGW_NODE_PATH: "/usr/bin/true",
+        SGW_CONSOLE_URL: "http://127.0.0.1:9/",
+        SGW_MENU_BAR_LOCK_PATH: path.join(tmp, "menu-helper.lock")
+      },
+      stdio: ["ignore", "ignore", "pipe"]
+    });
+    helper.stderr.setEncoding("utf8");
+    helper.stderr.on("data", (chunk: string) => { stderr += chunk; });
+
+    const earlyExit = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolve) => {
+      helper.once("error", () => resolve({ code: -1, signal: null }));
+      helper.once("exit", (code, signal) => resolve({ code, signal }));
+    });
+
+    try {
+      const result = await Promise.race([
+        earlyExit,
+        new Promise<null>((resolve) => setTimeout(() => resolve(null), 1_500))
+      ]);
+      expect(result, stderr || "menu helper exited during startup").toBeNull();
+    } finally {
+      if (helper.exitCode === null && helper.signalCode === null) {
+        helper.kill();
+        await earlyExit;
+      }
+      await rm(tmp, { recursive: true, force: true });
+    }
+  }, 10_000);
 });

--- a/tests/native-menubar.test.ts
+++ b/tests/native-menubar.test.ts
@@ -151,6 +151,15 @@ describe("menu-bar helper approval surface contract", () => {
     expect(source).toContain('userInfo: ["view": route.rawValue]');
     expect(source).toContain("let openApp: (HelperRoute) -> Void");
   });
+
+  it("uses actor-safe async notification APIs", () => {
+    const source = helperSource();
+
+    expect(source).toContain("try? await UNUserNotificationCenter.current().requestAuthorization");
+    expect(source).toContain("await center.notificationSettings().authorizationStatus");
+    expect(source).not.toMatch(/requestAuthorization\(options: \[\.alert, \.sound\]\) \{/);
+    expect(source).not.toContain("withCheckedContinuation");
+  });
 });
 
 describeNative("menu-bar helper DecisionController (real Swift source)", () => {


### PR DESCRIPTION
## Summary
- replace UserNotifications completion callbacks with actor-safe async APIs
- prevent the login-started menu helper from trapping during notification permission setup
- prepare version 0.1.6

## Verification
- reproduced the 0.1.5 SIGTRAP from the macOS crash report
- rebuilt helper stayed alive with notifications enabled
- npm run verify (32 files, 260 tests)