### PR TITLE
Stabilize Windows package test

### DIFF
--- a/tests/installers.test.ts
+++ b/tests/installers.test.ts
@@ -72,7 +72,7 @@ describe("platform installers", () => {
     expect(files.some((file) => file.endsWith(".map"))).toBe(false);
     expect(files.some((file) => file.startsWith("native/"))).toBe(false);
     expect(files.some((file) => file.startsWith("scripts/"))).toBe(false);
-  });
+  }, 20_000);
 
   it("keeps installer setup local and does not embed credential material", async () => {
     const [mac, windows] = await Promise.all([


### PR DESCRIPTION
## Summary
- allow the npm package manifest test enough time on Windows runners
- keep the timeout scoped to the packaging test

## Verification
- npm run check
- npx vitest run tests/installers.test.ts