### PR TITLE
Stabilize agent setup test

### DIFF
--- a/tests/agent-install.test.ts
+++ b/tests/agent-install.test.ts
@@ -929,5 +929,5 @@ describe("agent integration installation", () => {
     expect(existsSync(path.join(skippedHome, ".codex", "config.toml"))).toBe(false);
     expect(existsSync(path.join(skippedHome, ".config", "opencode", "opencode.jsonc"))).toBe(false);
     expect(existsSync(vscodeConfigPath(skippedHome))).toBe(false);
-  });
+  }, 20_000);
 });


### PR DESCRIPTION
## Summary
- allow the setup integration test enough time on loaded macOS runners
- keep the timeout scoped to the two-process setup test

## Verification
- npm run check
- npx vitest run tests/agent-install.test.ts