### PR TITLE
Stabilize browser test startup

### DIFF
--- a/tests/console-browser-e2e.test.ts
+++ b/tests/console-browser-e2e.test.ts
@@ -932,7 +932,7 @@ async function launchChrome(url: string): Promise<{ cdp: Cdp; approvePostCount: 
   );
 
   const wsUrl = await new Promise<string>((resolve, reject) => {
-    const timer = setTimeout(() => reject(new Error("timeout waiting for DevTools endpoint")), 15_000);
+    const timer = setTimeout(() => reject(new Error("timeout waiting for DevTools endpoint")), 30_000);
     let buf = "";
     chrome!.stderr?.on("data", (chunk: Buffer) => {
       buf += chunk.toString();


### PR DESCRIPTION
## Summary
- allow cold Chrome starts up to 30 seconds on CI runners
- keep every browser test overall timeout unchanged

## Verification
- npm run check
- npx vitest run tests/console-browser-e2e.test.ts