### PR TITLE
Avoid Keychain prompts during status checks

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "s-gw",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Local s-gw plugin that lets coding agents use typed secret handles without receiving raw credentials.",
   "author": {
     "name": "Barry Yuan"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Notable changes to s-gw are documented here. The project follows [Semantic Versi
 
 ## Unreleased
 
+## 0.1.7 - 2026-07-13
+
+### Fixed
+
+- Routine macOS status and menu refreshes now check Keychain item metadata without reading the stored unlock passphrase, preventing authorization prompts when no credential is being used.
+
 ## 0.1.6 - 2026-07-12
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,7 +143,7 @@ dependencies = [
 
 [[package]]
 name = "sgw-core"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "base64",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/sgw-core"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.6"
+version = "0.1.7"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/sgateway/s-gw"

--- a/native/macos-app/Sources/SgwMac/Services/UpdateChecker.swift
+++ b/native/macos-app/Sources/SgwMac/Services/UpdateChecker.swift
@@ -64,7 +64,7 @@ actor UpdateChecker: UpdateChecking {
     private let cli = CLIRunner()
 
     static var currentVersion: String {
-        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.1.6"
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.1.7"
     }
 
     static func isNewer(_ candidate: String, than current: String) -> Bool {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@s-gw/s-gw",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@s-gw/s-gw",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-gw/s-gw",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "mcpName": "io.github.sgateway/s-gw",
   "description": "Local credential control for AI coding agents.",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -15,13 +15,13 @@
     "url": "https://github.com/sgateway/s-gw",
     "source": "github"
   },
-  "version": "0.1.6",
+  "version": "0.1.7",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@s-gw/s-gw",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "runtimeHint": "npx",
       "runtimeArguments": [
         {

--- a/src/unlock.ts
+++ b/src/unlock.ts
@@ -89,12 +89,16 @@ export function deleteKeychainPassphrase(): boolean {
 }
 
 export function hasKeychainPassphrase(): boolean {
-  if (!keychainInfo().supported || process.env.SGW_DISABLE_KEYCHAIN === "1") {
+  const info = keychainInfo();
+  if (!info.supported || info.provider === "none" || process.env.SGW_DISABLE_KEYCHAIN === "1") {
     return false;
   }
 
-  const passphrase = readKeychainPassphrase();
-  return validPassphrase(passphrase);
+  try {
+    return keychainItemExists(info);
+  } catch {
+    return false;
+  }
 }
 
 export function keychainInfo(): KeychainInfo {
@@ -267,6 +271,38 @@ function runKeychainGet(info: KeychainInfo): string {
   throw missingCredentialStoreError();
 }
 
+function keychainItemExists(info: KeychainInfo): boolean {
+  if (process.platform === "darwin") {
+    const result = spawnSync(
+      keychainStatusCliPath(),
+      ["find-generic-password", "-a", info.account, "-s", info.service],
+      { encoding: "utf8", stdio: ["ignore", "ignore", "pipe"] }
+    );
+
+    if (result.error) {
+      throw result.error;
+    }
+    if (result.status === 0) {
+      return true;
+    }
+    if (result.status === 44) {
+      return false;
+    }
+    throw new Error(result.stderr.trim() || `Keychain status check failed with status ${result.status}`);
+  }
+
+  if (info.provider === "windows-helper" && info.helperPath) {
+    const output = runWindowsCredentialHelper(
+      info.helperPath,
+      ["status", "-Service", info.service, "-Account", info.account]
+    );
+    const status = JSON.parse(output) as { configured?: unknown };
+    return status.configured === true;
+  }
+
+  return false;
+}
+
 function runKeychainSet(info: KeychainInfo, passphrase: string, label = "s-gw local unlock passphrase"): void {
   if (info.provider === "native-helper" && info.helperPath) {
     runNativeHelper(info.helperPath, ["set", "--service", info.service, "--account", info.account, "--label", label], passphrase);
@@ -345,10 +381,14 @@ function runNativeHelper(helperPath: string, args: string[], input?: string): st
 }
 
 function runSecurity(args: string[]): string {
-  return execFileSync("security", args, {
+  return execFileSync("/usr/bin/security", args, {
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"]
   });
+}
+
+function keychainStatusCliPath(): string {
+  return process.env.SGW_KEYCHAIN_STATUS_CLI || "/usr/bin/security";
 }
 
 function runWindowsCredentialHelper(helperPath: string, args: string[], input?: string): string {

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const CURRENT_VERSION = "0.1.6";
+export const CURRENT_VERSION = "0.1.7";

--- a/tests/unlock.test.ts
+++ b/tests/unlock.test.ts
@@ -21,8 +21,11 @@ afterEach(async () => {
   delete process.env.SGW_KEYCHAIN_SERVICE;
   delete process.env.SGW_KEYCHAIN_ACCOUNT;
   delete process.env.SGW_KEYCHAIN_HELPER;
+  delete process.env.SGW_KEYCHAIN_STATUS_CLI;
   delete process.env.SGW_FAKE_KEYCHAIN_VALUE;
   delete process.env.SGW_FAKE_KEYCHAIN_CAPTURE;
+  delete process.env.SGW_FAKE_KEYCHAIN_GET_DENIED;
+  delete process.env.SGW_FAKE_SECURITY_CAPTURE;
   if (tmpDir) {
     await rm(tmpDir, { recursive: true, force: true });
   }
@@ -67,6 +70,31 @@ describe("unlock passphrase provider", () => {
     expect(captured.args.join(" ")).not.toContain("native helper passphrase");
   });
 
+  it("checks Keychain status without asking the helper to reveal the passphrase", async () => {
+    if (process.platform !== "darwin") {
+      return;
+    }
+
+    const capturePath = path.join(tmpDir, "security-args.json");
+    process.env.SGW_FAKE_SECURITY_CAPTURE = capturePath;
+    process.env.SGW_FAKE_KEYCHAIN_GET_DENIED = "1";
+    await installFakeHelper("configured keychain passphrase");
+
+    const status = unlockStatus();
+    expect(status.activeSource).toBe("macos-keychain");
+    expect(status.keychain.configured).toBe(true);
+
+    const args = JSON.parse(await readText(capturePath)) as string[];
+    expect(args).toEqual([
+      "find-generic-password",
+      "-a",
+      "unit-test",
+      "-s",
+      "com.s-gw.test"
+    ]);
+    expect(args).not.toContain("-w");
+  });
+
   it("reports a clear unlock error when no provider is configured", async () => {
     if (process.platform === "darwin") {
       await installFakeHelper("");
@@ -86,6 +114,7 @@ const fs = require("fs");
 const passphrase = process.env.SGW_FAKE_KEYCHAIN_VALUE || "";
 const command = process.argv[2];
 if (command === "get") {
+  if (process.env.SGW_FAKE_KEYCHAIN_GET_DENIED === "1") process.exit(70);
   if (!passphrase) process.exit(44);
   process.stdout.write(passphrase + "\\n");
   process.exit(0);
@@ -112,6 +141,22 @@ process.exit(2);
   );
   await chmod(fakePath, 0o700);
   process.env.SGW_KEYCHAIN_HELPER = fakePath;
+
+  const fakeSecurity = path.join(tmpDir, "security");
+  await writeFile(
+    fakeSecurity,
+    `#!/usr/bin/env node
+const fs = require("fs");
+const args = process.argv.slice(2);
+if (process.env.SGW_FAKE_SECURITY_CAPTURE) {
+  fs.writeFileSync(process.env.SGW_FAKE_SECURITY_CAPTURE, JSON.stringify(args));
+}
+if (args[0] !== "find-generic-password" || args.includes("-w")) process.exit(2);
+process.exit(process.env.SGW_FAKE_KEYCHAIN_VALUE ? 0 : 44);
+`
+  );
+  await chmod(fakeSecurity, 0o700);
+  process.env.SGW_KEYCHAIN_STATUS_CLI = fakeSecurity;
 }
 
 async function readText(filePath: string): Promise<string> {


### PR DESCRIPTION
## Summary
- check macOS Keychain item metadata without reading the stored passphrase
- preserve secret access through the native helper for real credential operations
- use the existing Credential Manager status path on Windows
- add a regression test that fails if status tries to reveal the passphrase

## Verification
- npm run verify
- 262 Vitest tests passed
- repeated live status checks did not launch macOS authorization UI