### PR TITLE
Restore app services after successful updates

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "s-gw",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Local s-gw plugin that lets coding agents use typed secret handles without receiving raw credentials.",
   "author": {
     "name": "Barry Yuan"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ Notable changes to s-gw are documented here. The project follows [Semantic Versi
 
 ## Unreleased
 
+## 0.1.8 - 2026-07-13
+
+### Fixed
+
+- Successful CLI updates now restore the console, menu helper, and native app state that was running before installation instead of leaving every surface stopped.
+- Update restart snapshots now require both an installed LaunchAgent plist and a loaded launchd job, avoiding false restart attempts from unrelated user environments.
+
 ## 0.1.7 - 2026-07-13
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,7 +143,7 @@ dependencies = [
 
 [[package]]
 name = "sgw-core"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "base64",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/sgw-core"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.7"
+version = "0.1.8"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/sgateway/s-gw"

--- a/native/macos-app/Sources/SgwMac/Services/UpdateChecker.swift
+++ b/native/macos-app/Sources/SgwMac/Services/UpdateChecker.swift
@@ -64,7 +64,7 @@ actor UpdateChecker: UpdateChecking {
     private let cli = CLIRunner()
 
     static var currentVersion: String {
-        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.1.7"
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.1.8"
     }
 
     static func isNewer(_ candidate: String, than current: String) -> Bool {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@s-gw/s-gw",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@s-gw/s-gw",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-gw/s-gw",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "mcpName": "io.github.sgateway/s-gw",
   "description": "Local credential control for AI coding agents.",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -15,13 +15,13 @@
     "url": "https://github.com/sgateway/s-gw",
     "source": "github"
   },
-  "version": "0.1.7",
+  "version": "0.1.8",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@s-gw/s-gw",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "runtimeHint": "npx",
       "runtimeArguments": [
         {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1044,8 +1044,10 @@ function updateServiceLifecycle(keepAppRunning: boolean): {
   stop: () => Promise<void>;
   restart: () => Promise<void>;
 } {
-  const serviceWasLoaded = process.platform === "darwin" && launchAgentStatus("console").loaded;
-  const menuBarWasLoaded = process.platform === "darwin" && launchAgentStatus("menubar").loaded;
+  const serviceBefore = launchAgentStatus("console");
+  const menuBarBefore = launchAgentStatus("menubar");
+  const serviceWasLoaded = process.platform === "darwin" && serviceBefore.installed && serviceBefore.loaded;
+  const menuBarWasLoaded = process.platform === "darwin" && menuBarBefore.installed && menuBarBefore.loaded;
   let macAppWasRunning = false;
   let windowsStopped: WindowsStoppedSurfaces | undefined;
 

--- a/src/package-update.ts
+++ b/src/package-update.ts
@@ -220,6 +220,7 @@ export async function installPackageUpdate(options: PackageInstallOptions = {}):
   let removedLegacy = false;
   let rollback: PreparedRollback | null = null;
   let stopAttempted = false;
+  let restartAttempted = false;
 
   try {
     if (options.stopServices) {
@@ -286,6 +287,21 @@ export async function installPackageUpdate(options: PackageInstallOptions = {}):
     }
 
     await discardRollback(rollback);
+    rollback = null;
+    removedLegacy = false;
+
+    if (stopAttempted && options.restartServices) {
+      restartAttempted = true;
+      try {
+        await options.restartServices();
+      } catch (error) {
+        throw new PackageUpdateError(
+          `${plan.target.name}@${plan.target.version} installed, but s-gw could not restart: ${errorMessage(error)}`,
+          "restart-services",
+          plan.nextCommands
+        );
+      }
+    }
 
     return {
       changed: true,
@@ -315,7 +331,8 @@ export async function installPackageUpdate(options: PackageInstallOptions = {}):
         );
       }
     }
-    if (stopAttempted && options.restartServices && failure.phase !== "verify-data") {
+    if (stopAttempted && !restartAttempted && options.restartServices && failure.phase !== "verify-data") {
+      restartAttempted = true;
       try {
         await options.restartServices();
       } catch (restartError) {

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const CURRENT_VERSION = "0.1.7";
+export const CURRENT_VERSION = "0.1.8";

--- a/tests/package-update.test.ts
+++ b/tests/package-update.test.ts
@@ -62,14 +62,17 @@ describe("scoped package migration", () => {
     expect((await inspectGlobalSgwInstall({ npmPrefix })).legacy?.version).toBe("0.1.0");
 
     let stopped = 0;
+    let restarted = 0;
     const result = await installPackageUpdate({
       target: scopedTarball,
       npmPrefix,
       sgwHome,
-      stopServices: async () => { stopped += 1; }
+      stopServices: async () => { stopped += 1; },
+      restartServices: async () => { restarted += 1; }
     });
 
     expect(stopped).toBe(1);
+    expect(restarted).toBe(1);
     expect(result.installed.legacy).toBeNull();
     expect(result.installed.scoped?.version).toBe(CURRENT_VERSION);
     expect(result.dataHomePreserved).toBe(true);
@@ -372,6 +375,55 @@ describe("scoped package migration", () => {
     }
   });
 
+  it("reports a successful install that cannot restart without retrying the restart", async () => {
+    const tmp = await tempDir("sgw-package-success-restart-failure-");
+    const prefix = path.join(tmp, "prefix");
+    const sgwHome = path.join(tmp, "home");
+    await mkdir(sgwHome, { recursive: true });
+
+    let listCalls = 0;
+    const runNpm = async (args: string[]): Promise<NpmCommandResult> => {
+      if (args[0] === "root") return ok(path.join(prefix, "lib", "node_modules"));
+      if (args[0] === "list") {
+        listCalls += 1;
+        const version = listCalls === 1 ? "0.1.6" : CURRENT_VERSION;
+        return ok(JSON.stringify({ dependencies: { "@s-gw/s-gw": { version } } }));
+      }
+      if (args[0] === "pack") {
+        return ok(JSON.stringify([{ name: "@s-gw/s-gw", version: CURRENT_VERSION }]));
+      }
+      if (args[0] === "install") return ok("");
+      return ok("");
+    };
+    let restarted = 0;
+
+    let thrown: unknown;
+    try {
+      await installPackageUpdate({
+        npmPrefix: prefix,
+        sgwHome,
+        runNpm,
+        stopServices: async () => undefined,
+        restartServices: async () => {
+          restarted += 1;
+          throw new Error("simulated restart failure");
+        }
+      });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toMatchObject({ phase: "restart-services" });
+    expect((thrown as Error).message).toContain("installed, but s-gw could not restart");
+    expect((thrown as Error).message).toContain("simulated restart failure");
+    expect((thrown as PackageUpdateError).recoveryCommands).toEqual([
+      "s-gw setup",
+      "s-gw doctor",
+      "s-gw app open"
+    ]);
+    expect(restarted).toBe(1);
+  });
+
   it("preserves the update failure when restarting services also fails", async () => {
     const prefix = "/tmp/sgw-restart-failure";
     const runNpm = async (args: string[]): Promise<NpmCommandResult> => {
@@ -403,6 +455,8 @@ describe("scoped package migration", () => {
   it("wires CLI update failures back to the previously loaded local services", async () => {
     const cli = await readFile(path.join(process.cwd(), "src", "cli.ts"), "utf8");
     expect(cli).toContain("restartServices: services.restart");
+    expect(cli).toContain("serviceBefore.installed && serviceBefore.loaded");
+    expect(cli).toContain("menuBarBefore.installed && menuBarBefore.loaded");
     expect(cli).toContain('restartLaunchAgent("console", serviceWasLoaded');
     expect(cli).toContain('restartLaunchAgent("menubar", menuBarWasLoaded');
     expect(cli).toContain("verifyRestoredLaunchAgents(serviceWasLoaded, menuBarWasLoaded");


### PR DESCRIPTION
## Summary
- restart previously running console, menu helper, and native app after a successful package update
- avoid false launchd restart snapshots when a matching plist is not installed
- report relaunch failures once without retrying or rolling back a successful package install
- prepare the 0.1.8 hotfix release

## Verification
- npm run verify
- 263 Vitest tests passed
- Rust format, Clippy, and tests passed
- npm audit found 0 vulnerabilities
- repaired and verified the local 0.1.7 app, console, and menu helper