### PR TITLE
Fix stale approval actions

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "s-gw",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Local s-gw plugin that lets coding agents use typed secret handles without receiving raw credentials.",
   "author": {
     "name": "Barry Yuan"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ Notable changes to s-gw are documented here. The project follows [Semantic Versi
 
 ## Unreleased
 
+## 0.1.9 - 2026-07-13
+
+### Fixed
+
+- Repeated approval is now idempotent when another app surface or policy already approved the request.
+- Approval sheets now close and report the current decision instead of leaving an obsolete pending request on screen.
+
 ## 0.1.8 - 2026-07-13
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,7 +143,7 @@ dependencies = [
 
 [[package]]
 name = "sgw-core"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "base64",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/sgw-core"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.8"
+version = "0.1.9"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/sgateway/s-gw"

--- a/native/macos-app/Sources/SgwMac/Services/UpdateChecker.swift
+++ b/native/macos-app/Sources/SgwMac/Services/UpdateChecker.swift
@@ -64,7 +64,7 @@ actor UpdateChecker: UpdateChecking {
     private let cli = CLIRunner()
 
     static var currentVersion: String {
-        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.1.8"
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.1.9"
     }
 
     static func isNewer(_ candidate: String, than current: String) -> Bool {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@s-gw/s-gw",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@s-gw/s-gw",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-gw/s-gw",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "mcpName": "io.github.sgateway/s-gw",
   "description": "Local credential control for AI coding agents.",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -15,13 +15,13 @@
     "url": "https://github.com/sgateway/s-gw",
     "source": "github"
   },
-  "version": "0.1.8",
+  "version": "0.1.9",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@s-gw/s-gw",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "runtimeHint": "npx",
       "runtimeArguments": [
         {

--- a/src/console-ui/src/App.tsx
+++ b/src/console-ui/src/App.tsx
@@ -332,6 +332,22 @@ function ConsoleShell({ ctx, theme, setTheme }: { ctx: ConsoleContext; theme: st
   }, []);
 
   React.useEffect(() => {
+    if (!approval || !ctx.state) return;
+    const current = ctx.state.requests.find((request) => request.id === approval.id);
+    if (current?.state === "pending") {
+      if (current !== approval) setApproval(current);
+      return;
+    }
+
+    setApproval(null);
+    if (current?.state === "approved" || current?.state === "executing" || current?.state === "executed") {
+      toast.success("Request already approved");
+      return;
+    }
+    toast.info(current ? `Request is already ${current.state}` : "Request is no longer pending");
+  }, [approval, ctx.state]);
+
+  React.useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
       if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
         event.preventDefault();

--- a/src/store.ts
+++ b/src/store.ts
@@ -715,6 +715,9 @@ export class SecretStore {
 
   async approveRequest(id: string, options: ApproveRequestOptions = {}): Promise<RequestRecord> {
     return this.updateRequest(id, (request, store) => {
+      if (request.state === "approved" || request.state === "executing" || request.state === "executed") {
+        return;
+      }
       if (request.state !== "pending") {
         throw new Error(`Only pending requests can be approved. Current state: ${request.state}`);
       }

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const CURRENT_VERSION = "0.1.8";
+export const CURRENT_VERSION = "0.1.9";

--- a/tests/console-browser-e2e.test.ts
+++ b/tests/console-browser-e2e.test.ts
@@ -209,6 +209,48 @@ describeBrowser("React local console (real headless Chrome)", () => {
     expect(launched.approvePostCount()).toBe(1);
   }, 45_000);
 
+  it("closes an approval sheet when another surface already approved the request", async () => {
+    process.env.SGW_MASTER_PASSPHRASE = "browser stale approval passphrase";
+    running = await startConsoleServer({ port: 0 });
+    const created = await api<{ handle: string }>("api/secrets", {
+      name: "browser-stale-approval",
+      type: "api-token",
+      value: "browser-stale-approval-secret-value-1234567890",
+      injectEnv: "SGW_BROWSER_STALE_TOKEN",
+      allowedCommands: [process.execPath]
+    });
+    const request = await api<{ id: string; state: string }>("api/requests", {
+      handle: created.handle,
+      command: process.execPath,
+      args: ["-e", "0"],
+      injectEnv: "SGW_BROWSER_STALE_TOKEN",
+      reason: "Codex stale approval browser e2e"
+    });
+    expect(request.state).toBe("pending");
+
+    const launched = await launchChrome(new URL("approvals", running.url).toString());
+    cdp = launched.cdp;
+    await waitFor(
+      () => cdp!.eval<boolean>("document.querySelectorAll('tbody tr').length > 0"),
+      "pending request row"
+    );
+    await cdp.eval("document.querySelector('tbody tr').dispatchEvent(new MouseEvent('click', { bubbles: true }))");
+    await waitFor(
+      () => cdp!.eval<boolean>(`Boolean(document.querySelector('[data-approve="${request.id}"]'))`),
+      "approval sheet button"
+    );
+
+    await api(`api/requests/${request.id}/approve`, {});
+    await cdp.eval(`document.querySelector('[data-approve="${request.id}"]').click()`);
+
+    await waitFor(
+      () => cdp!.eval<boolean>(`!document.querySelector('[data-approve="${request.id}"]')`),
+      "stale approval sheet closes"
+    );
+    const state = await api<{ requests: Array<{ id: string; state: string }> }>("api/state");
+    expect(state.requests.find((item) => item.id === request.id)?.state).toBe("approved");
+  }, 45_000);
+
   it("renders a real d3 Sankey chart and opens a shadcn Sheet for flow drill-in", async () => {
     process.env.SGW_MASTER_PASSPHRASE = "browser react passphrase";
     running = await startConsoleServer({ port: 0 });

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -171,6 +171,43 @@ describe("SecretStore", () => {
     expect(summary.proof).toMatch(/^s-gw-proof:/);
   });
 
+  it("treats repeated approval as the same decision", async () => {
+    const store = new SecretStore();
+    const record = await store.addSecret({
+      name: "repeat approval token",
+      type: "api-token",
+      value: "repeat-approval-secret-value-123456789",
+      policy: {
+        injectEnv: "SGW_REPEAT_APPROVAL_TOKEN",
+        allowedCommands: [process.execPath]
+      }
+    });
+    const request = await store.createRequest(
+      record.handle,
+      buildEnvCommandAction({
+        command: process.execPath,
+        args: ["-e", "0"],
+        injectEnv: "SGW_REPEAT_APPROVAL_TOKEN"
+      }),
+      "repeat approval test"
+    );
+
+    const first = await store.approveRequest(request.id, {
+      mode: "timed-session",
+      durationMs: 60 * 60 * 1000,
+      agentScope: "same-agent"
+    });
+    const repeated = await store.approveRequest(request.id, {
+      mode: "per-transaction",
+      agentScope: "same-agent"
+    });
+
+    expect(repeated.state).toBe("approved");
+    expect(repeated.approvalGrantId).toBe(first.approvalGrantId);
+    expect(await store.listApprovalGrants()).toHaveLength(1);
+    expect((await store.auditLog()).filter((event) => event.type === "request.approved")).toHaveLength(1);
+  });
+
   it("records the runtime agent for generic local CLI requests", async () => {
     const oldCodexShell = process.env.CODEX_SHELL;
     process.env.CODEX_SHELL = "1";


### PR DESCRIPTION
## Summary
- make repeated approvals idempotent when another surface has already approved the request
- close stale approval sheets when the request is no longer pending
- add store and real-Chrome regression coverage

## Verification
- `npm run verify` (32 files, 265 tests, Rust checks, npm audit, package dry-run)