### PR TITLE
Keep macOS Keychain helper identity stable

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "s-gw",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Local s-gw plugin that lets coding agents use typed secret handles without receiving raw credentials.",
   "author": {
     "name": "Barry Yuan"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ Notable changes to s-gw are documented here. The project follows [Semantic Versi
 
 ## Unreleased
 
+## 0.1.10 - 2026-07-13
+
+### Fixed
+
+- macOS setup now pins the first working Keychain helper under `~/.s-gw`, and package upgrades preserve that exact binary so credential access does not acquire a new requester identity.
+- Direct credential-store enrollment and redemption also establish the persistent helper before touching Keychain, covering users who do not rerun setup.
+
 ## 0.1.9 - 2026-07-13
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,7 +143,7 @@ dependencies = [
 
 [[package]]
 name = "sgw-core"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "base64",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/sgw-core"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.9"
+version = "0.1.10"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/sgateway/s-gw"

--- a/docs/keychain.md
+++ b/docs/keychain.md
@@ -24,6 +24,8 @@ The raw credential is written through the bundled helper on stdin. The encrypted
 
 Use `--service SERVICE` or `SGW_SECRET_KEYCHAIN_SERVICE` when you want a separate credential-store namespace for testing, work, or isolated profiles.
 
+On macOS, setup copies the first working Keychain helper to `~/.s-gw/native/darwin-arm64/s-gw-keychain-helper` with owner-only permissions. s-gw keeps using that exact helper across npm and desktop upgrades because Keychain authorization is tied to the helper's code identity. The updater preserves the existing helper before replacing a package, and later releases do not overwrite it silently.
+
 Automatic capture paths, including guard mode and the local console API, prefer the OS credential store on macOS and Windows. Set `SGW_SECRET_BACKEND=local` only for compatibility testing or environments without the native helper.
 
 ## Local Execution Flow
@@ -33,6 +35,8 @@ Automatic capture paths, including guard mode and the local console API, prefer 
 3. s-gw applies policy and asks for approval when required.
 4. During approved execution, s-gw reads the credential from the local store and injects it into the local child process.
 5. Command output is sanitized back to handles before it is returned.
+
+Routine status, dashboard, and menu refreshes inspect only Keychain metadata. They do not read the unlock passphrase or credential values and should not open a macOS password prompt. A prompt during an approved execution means macOS does not recognize the helper that originally created the item; choosing `Always Allow` authorizes that helper for the item, while current s-gw installations avoid future identity changes by retaining the persistent helper above.
 
 ## 1Password Migration Later
 

--- a/native/macos-app/Sources/SgwMac/Services/UpdateChecker.swift
+++ b/native/macos-app/Sources/SgwMac/Services/UpdateChecker.swift
@@ -64,7 +64,7 @@ actor UpdateChecker: UpdateChecking {
     private let cli = CLIRunner()
 
     static var currentVersion: String {
-        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.1.9"
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.1.10"
     }
 
     static func isNewer(_ candidate: String, than current: String) -> Bool {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@s-gw/s-gw",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@s-gw/s-gw",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-gw/s-gw",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "mcpName": "io.github.sgateway/s-gw",
   "description": "Local credential control for AI coding agents.",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -15,13 +15,13 @@
     "url": "https://github.com/sgateway/s-gw",
     "source": "github"
   },
-  "version": "0.1.9",
+  "version": "0.1.10",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@s-gw/s-gw",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "runtimeHint": "npx",
       "runtimeArguments": [
         {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -42,7 +42,12 @@ import { listOnePasswordSecretReferences, onePasswordStatus, readOnePasswordRefe
 import { installPackageUpdate, planPackageUpdate } from "./package-update.js";
 import { SGW_SSH_SESSION_COMMAND, closeOwnedSshSession, defaultSshInjectEnv } from "./ssh.js";
 import { SecretStore } from "./store.js";
-import { deleteKeychainPassphrase, setKeychainPassphrase, unlockStatus } from "./unlock.js";
+import {
+  deleteKeychainPassphrase,
+  installPersistentKeychainHelper,
+  setKeychainPassphrase,
+  unlockStatus
+} from "./unlock.js";
 import { releaseChecker } from "./update-check.js";
 import type {
   ApprovalAgentScope,
@@ -952,6 +957,7 @@ async function handleSetupCommand(
   flags: Record<string, string | boolean | string[]>
 ): Promise<void> {
   const port = numericFlag(flags, "port", 8718);
+  const keychainHelper = process.platform === "darwin" ? installPersistentKeychainHelper() : undefined;
   const beforeUnlock = unlockStatus();
   let unlockAction = beforeUnlock.activeSource === "none" ? "not-configured" : `existing-${beforeUnlock.activeSource}`;
 
@@ -1003,6 +1009,7 @@ async function handleSetupCommand(
     service,
     menuBar,
     windowsHelper,
+    keychainHelper,
     appInstall,
     agents,
     nextSteps: [

--- a/src/package-update.ts
+++ b/src/package-update.ts
@@ -5,6 +5,10 @@ import { mkdtemp, readdir, readFile, rm, stat } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { getSgwHome } from "./paths.js";
+import {
+  installPersistentKeychainHelper,
+  type PersistentKeychainHelperInstall
+} from "./unlock.js";
 
 export const LEGACY_PACKAGE_NAME = "s-gw";
 export const SCOPED_PACKAGE_NAME = "@s-gw/s-gw";
@@ -89,6 +93,7 @@ export interface PackageUpdateResult {
   plan: PackageUpdatePlan;
   installed: GlobalSgwInstall;
   dataHomePreserved: boolean;
+  keychainHelper?: PersistentKeychainHelperInstall;
   nextCommands: string[];
 }
 
@@ -221,6 +226,7 @@ export async function installPackageUpdate(options: PackageInstallOptions = {}):
   let rollback: PreparedRollback | null = null;
   let stopAttempted = false;
   let restartAttempted = false;
+  let keychainHelper: PersistentKeychainHelperInstall | undefined;
 
   try {
     if (options.stopServices) {
@@ -234,6 +240,8 @@ export async function installPackageUpdate(options: PackageInstallOptions = {}):
         );
       }
     }
+
+    keychainHelper = preserveInstalledKeychainHelper(plan);
 
     if (plan.installed.legacy) {
       rollback = await prepareLegacyRollback(plan, npm);
@@ -309,6 +317,7 @@ export async function installPackageUpdate(options: PackageInstallOptions = {}):
       plan,
       installed: finalInstall,
       dataHomePreserved,
+      keychainHelper,
       nextCommands: plan.nextCommands
     };
   } catch (error) {
@@ -345,6 +354,35 @@ export async function installPackageUpdate(options: PackageInstallOptions = {}):
     }
     throw failure;
   }
+}
+
+function preserveInstalledKeychainHelper(
+  plan: PackageUpdatePlan
+): PersistentKeychainHelperInstall | undefined {
+  if (process.platform !== "darwin") {
+    return undefined;
+  }
+
+  const current = plan.installed.scoped || plan.installed.legacy;
+  if (!current) {
+    return undefined;
+  }
+
+  const target = `${process.platform}-${process.arch}`;
+  const candidates = [
+    path.join(current.packageRoot, "dist", "native", target, "s-gw-keychain-helper"),
+    path.join(current.packageRoot, "dist", "native", "s-gw-keychain-helper"),
+    path.join(current.packageRoot, "dist", "native", "sgw-keychain-helper")
+  ];
+  const sourcePath = candidates.find((candidate) => existsSync(candidate));
+  if (!sourcePath) {
+    return undefined;
+  }
+
+  return installPersistentKeychainHelper({
+    sourcePath,
+    sgwHome: plan.dataHome
+  });
 }
 
 export function selectReleasePackageAssets(

--- a/src/unlock.ts
+++ b/src/unlock.ts
@@ -1,8 +1,19 @@
 import { execFileSync, spawnSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import {
+  accessSync,
+  chmodSync,
+  constants,
+  copyFileSync,
+  existsSync,
+  linkSync,
+  mkdirSync,
+  rmSync,
+  statSync
+} from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { getSgwHome } from "./paths.js";
 
 const defaultService = "com.s-gw.sgw.master-passphrase";
 const defaultSecretService = "com.s-gw.sgw.secret";
@@ -29,6 +40,17 @@ export interface MacKeychainItemRef {
   service: string;
   account: string;
   label?: string;
+}
+
+export interface PersistentKeychainHelperInstall {
+  helperPath: string;
+  sourcePath: string;
+  changed: boolean;
+}
+
+export interface PersistentKeychainHelperOptions {
+  sourcePath?: string;
+  sgwHome?: string;
 }
 
 export function requireUnlockPassphrase(): string {
@@ -75,11 +97,13 @@ export function setKeychainPassphrase(passphrase: string): void {
   }
 
   ensureLocalCredentialStore();
+  preparePersistentMacHelper();
   runKeychainSet(keychainInfo(), passphrase);
 }
 
 export function deleteKeychainPassphrase(): boolean {
   ensureLocalCredentialStore();
+  preparePersistentMacHelper();
   try {
     runKeychainDelete(keychainInfo());
     return true;
@@ -119,12 +143,14 @@ export function setMacKeychainItem(ref: MacKeychainItemRef, value: string): void
     throw new Error("Cannot store an empty Keychain item.");
   }
 
+  preparePersistentMacHelper();
   const info = keychainInfoForItem(ref);
   ensureNativeCredentialStore(info);
   runKeychainSet(info, value, ref.label || "s-gw local secret");
 }
 
 export function getMacKeychainItem(ref: MacKeychainItemRef): string {
+  preparePersistentMacHelper();
   const info = keychainInfoForItem(ref);
   ensureNativeCredentialStore(info);
   return runKeychainGet(info).replace(/\r?\n$/, "");
@@ -132,6 +158,7 @@ export function getMacKeychainItem(ref: MacKeychainItemRef): string {
 
 export function deleteMacKeychainItem(ref: MacKeychainItemRef): boolean {
   try {
+    preparePersistentMacHelper();
     const info = keychainInfoForItem(ref);
     ensureNativeCredentialStore(info);
     runKeychainDelete(info);
@@ -142,11 +169,12 @@ export function deleteMacKeychainItem(ref: MacKeychainItemRef): boolean {
 }
 
 function readKeychainPassphrase(): string | undefined {
-  const info = keychainInfo();
-  if (!info.supported || process.env.SGW_DISABLE_KEYCHAIN === "1") {
+  if (!supportsLocalCredentialStore() || process.env.SGW_DISABLE_KEYCHAIN === "1") {
     return undefined;
   }
 
+  preparePersistentMacHelper();
+  const info = keychainInfo();
   try {
     const output = runKeychainGet(info);
 
@@ -223,14 +251,94 @@ function findNativeHelper(): string | undefined {
     return fromEnv;
   }
 
+  const persistent = persistentKeychainHelperPath();
+  if (existsSync(persistent)) {
+    return persistent;
+  }
+
+  return findPackagedNativeHelper();
+}
+
+function findPackagedNativeHelper(): string | undefined {
+  if (process.platform !== "darwin") {
+    return undefined;
+  }
+
   const here = path.dirname(fileURLToPath(import.meta.url));
   const nativeTarget = `${process.platform}-${process.arch}`;
   const candidates = [
     path.resolve(here, "native", nativeTarget, nativeHelperName),
-    path.resolve(process.cwd(), "dist", "native", nativeTarget, nativeHelperName)
+    path.resolve(process.cwd(), "dist", "native", nativeTarget, nativeHelperName),
+    path.resolve(here, "native", nativeHelperName),
+    path.resolve(process.cwd(), "dist", "native", nativeHelperName)
   ];
 
   return candidates.find((candidate) => existsSync(candidate));
+}
+
+export function persistentKeychainHelperPath(sgwHome = getSgwHome()): string {
+  const nativeTarget = `${process.platform}-${process.arch}`;
+  return path.join(path.resolve(sgwHome), "native", nativeTarget, nativeHelperName);
+}
+
+export function installPersistentKeychainHelper(
+  options: PersistentKeychainHelperOptions = {}
+): PersistentKeychainHelperInstall {
+  if (process.platform !== "darwin") {
+    throw new Error("The persistent Keychain helper is only available on macOS.");
+  }
+
+  const source = options.sourcePath || findPackagedNativeHelper();
+  if (!source) {
+    throw missingCredentialStoreError();
+  }
+  const sourcePath = path.resolve(source);
+  if (!existsSync(sourcePath)) throw missingCredentialStoreError();
+  assertUsableHelper(sourcePath);
+
+  const helperPath = persistentKeychainHelperPath(options.sgwHome);
+  if (existsSync(helperPath)) {
+    assertUsableHelper(helperPath);
+    chmodSync(helperPath, 0o700);
+    return { helperPath, sourcePath, changed: false };
+  }
+
+  const helperDir = path.dirname(helperPath);
+  mkdirSync(helperDir, { recursive: true, mode: 0o700 });
+  chmodSync(helperDir, 0o700);
+  const staging = `${helperPath}.install-${process.pid}-${Date.now()}`;
+
+  try {
+    copyFileSync(sourcePath, staging);
+    chmodSync(staging, 0o700);
+    try {
+      linkSync(staging, helperPath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+    }
+  } finally {
+    rmSync(staging, { force: true });
+  }
+
+  assertUsableHelper(helperPath);
+  return { helperPath, sourcePath, changed: true };
+}
+
+function preparePersistentMacHelper(): void {
+  if (process.platform !== "darwin" || process.env.SGW_KEYCHAIN_HELPER) {
+    return;
+  }
+  if (!existsSync(persistentKeychainHelperPath())) {
+    installPersistentKeychainHelper();
+  }
+}
+
+function assertUsableHelper(helperPath: string): void {
+  const info = statSync(helperPath);
+  if (!info.isFile() || info.size === 0) {
+    throw new Error(`Keychain helper is not a usable file: ${helperPath}`);
+  }
+  accessSync(helperPath, constants.X_OK);
 }
 
 function findWindowsCredentialHelper(): string | undefined {

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const CURRENT_VERSION = "0.1.9";
+export const CURRENT_VERSION = "0.1.10";

--- a/tests/install.test.ts
+++ b/tests/install.test.ts
@@ -49,6 +49,7 @@ describe("customer package layout", () => {
     expect(menuBarHandler).not.toContain("installMacAppBundle");
     expect(appHandler).toContain("installMacAppBundle");
     expect(cliSource).toContain("const appInstall = process.platform === \"darwin\" ? installMacAppBundle() : undefined");
+    expect(cliSource).toContain("installPersistentKeychainHelper()");
   });
 
   it("tracks a running native app so open focuses instead of relaunching", async () => {

--- a/tests/package-update.test.ts
+++ b/tests/package-update.test.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
-import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -85,6 +85,50 @@ describe("scoped package migration", () => {
       ? await execFileAsync(process.env.ComSpec || "cmd.exe", ["/d", "/s", "/c", `"${command}"`])
       : await execFileAsync(command);
     expect(output.stdout.trim()).toBe(`@s-gw/s-gw ${CURRENT_VERSION}`);
+  }, 30_000);
+
+  it("preserves the installed macOS helper before replacing a scoped package", async () => {
+    if (process.platform !== "darwin") {
+      return;
+    }
+
+    const tmp = await tempDir("sgw-helper-upgrade-");
+    const npmPrefix = path.join(tmp, "npm-prefix");
+    const sgwHome = path.join(tmp, "sgw-home");
+    const tarballs = path.join(tmp, "tarballs");
+    await mkdir(tarballs, { recursive: true });
+    const oldTarball = await packageFixture(tmp, tarballs, "old-scoped", "@s-gw/s-gw", "0.1.8");
+    const nextTarball = await packageFixture(tmp, tarballs, "next-scoped", "@s-gw/s-gw", CURRENT_VERSION);
+    await npm(["install", "--global", "--prefix", npmPrefix, "--ignore-scripts", "--", oldTarball]);
+
+    const before = await inspectGlobalSgwInstall({ npmPrefix });
+    const oldHelper = path.join(
+      before.scoped?.packageRoot || "",
+      "dist",
+      "native",
+      `${process.platform}-${process.arch}`,
+      "s-gw-keychain-helper"
+    );
+    await mkdir(path.dirname(oldHelper), { recursive: true });
+    await writeFile(oldHelper, "trusted helper identity\n");
+    await chmod(oldHelper, 0o755);
+
+    await installPackageUpdate({
+      target: nextTarball,
+      npmPrefix,
+      sgwHome,
+      stopServices: async () => undefined,
+      restartServices: async () => undefined
+    });
+
+    const persistent = path.join(
+      sgwHome,
+      "native",
+      `${process.platform}-${process.arch}`,
+      "s-gw-keychain-helper"
+    );
+    expect(await readFile(persistent, "utf8")).toBe("trusted helper identity\n");
+    expect((await stat(persistent)).mode & 0o777).toBe(0o700);
   }, 30_000);
 
   it("exposes the migration plan and top-level install result through the CLI", async () => {

--- a/tests/unlock.test.ts
+++ b/tests/unlock.test.ts
@@ -1,9 +1,15 @@
-import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { requirePassphrase } from "../src/crypto.js";
-import { setKeychainPassphrase, unlockStatus } from "../src/unlock.js";
+import {
+  installPersistentKeychainHelper,
+  keychainInfo,
+  persistentKeychainHelperPath,
+  setKeychainPassphrase,
+  unlockStatus
+} from "../src/unlock.js";
 
 let tmpDir = "";
 
@@ -26,6 +32,7 @@ afterEach(async () => {
   delete process.env.SGW_FAKE_KEYCHAIN_CAPTURE;
   delete process.env.SGW_FAKE_KEYCHAIN_GET_DENIED;
   delete process.env.SGW_FAKE_SECURITY_CAPTURE;
+  delete process.env.SGW_HOME;
   if (tmpDir) {
     await rm(tmpDir, { recursive: true, force: true });
   }
@@ -93,6 +100,32 @@ describe("unlock passphrase provider", () => {
       "com.s-gw.test"
     ]);
     expect(args).not.toContain("-w");
+  });
+
+  it("keeps the first installed helper identity in the s-gw data directory", async () => {
+    if (process.platform !== "darwin") {
+      return;
+    }
+
+    const sgwHome = path.join(tmpDir, "home");
+    const original = path.join(tmpDir, "original-helper");
+    const replacement = path.join(tmpDir, "replacement-helper");
+    await writeFile(original, "trusted helper\n");
+    await writeFile(replacement, "new helper\n");
+    await chmod(original, 0o755);
+    await chmod(replacement, 0o755);
+
+    const first = installPersistentKeychainHelper({ sourcePath: original, sgwHome });
+    const second = installPersistentKeychainHelper({ sourcePath: replacement, sgwHome });
+    const helperPath = persistentKeychainHelperPath(sgwHome);
+
+    expect(first).toMatchObject({ helperPath, sourcePath: original, changed: true });
+    expect(second).toMatchObject({ helperPath, changed: false });
+    expect(await readFile(helperPath, "utf8")).toBe("trusted helper\n");
+    expect((await stat(helperPath)).mode & 0o777).toBe(0o700);
+
+    process.env.SGW_HOME = sgwHome;
+    expect(keychainInfo().helperPath).toBe(helperPath);
   });
 
   it("reports a clear unlock error when no provider is configured", async () => {


### PR DESCRIPTION
## Summary

- retain the first working macOS Keychain helper under the s-gw data home
- preserve that helper before package upgrades replace npm files
- make setup and direct Keychain operations use the persistent helper

## Verification

- `npm run verify` (32 files, 267 tests, Rust checks, npm audit, package dry-run)
- `npm run build:installers`
- installed 0.1.10 locally and executed the affected Keychain-backed credential without a macOS authorization prompt