### PR TITLE
Prevent Keychain prompts after upgrades

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "s-gw",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Local s-gw plugin that lets coding agents use typed secret handles without receiving raw credentials.",
   "author": {
     "name": "Barry Yuan"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,6 +45,7 @@ jobs:
           for binary in \
             dist/native/darwin-arm64/s-gw-core \
             dist/native/darwin-arm64/s-gw-keychain-helper \
+            dist/native/darwin-arm64/s-gw-keychain-inspector \
             dist/s-gw.app/Contents/MacOS/s-gw \
             "dist/s-gw Menu Bar.app/Contents/MacOS/s-gw-menu-bar-helper"; do
             lipo "$binary" -verify_arch arm64
@@ -72,6 +73,7 @@ jobs:
           test -x "$prefix/bin/s-gw"
           test -x "$package_root/dist/native/darwin-arm64/s-gw-core"
           test -x "$package_root/dist/native/darwin-arm64/s-gw-keychain-helper"
+          test -x "$package_root/dist/native/darwin-arm64/s-gw-keychain-inspector"
           test -x "$package_root/dist/s-gw.app/Contents/MacOS/s-gw"
           test -x "$package_root/dist/s-gw Menu Bar.app/Contents/MacOS/s-gw-menu-bar-helper"
           test ! -e "$package_root/dist/native/s-gw-core"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ Notable changes to s-gw are documented here. The project follows [Semantic Versi
 
 ## Unreleased
 
+## 0.1.11 - 2026-07-13
+
+### Added
+
+- `s-gw unlock keychain repair` verifies and repairs the master unlock item and every Keychain-backed credential without exposing their values.
+
+### Fixed
+
+- macOS Keychain access now validates the helper's exact trusted-application identity before reading or deleting an item, so an unknown helper fails with a repair error instead of opening a login-password dialog.
+- Existing items are transactionally rebound to the persistent helper through a verified temporary Keychain backup, with automatic recovery after an interrupted repair.
+- The macOS installer preserves the pre-upgrade helper before npm replaces its package path, allowing old ACLs to be migrated after an upgrade.
+- Upgrades pin the preserved helper back at the npm compatibility path used by already-running MCP servers, preventing stale agent sessions from launching a newly built helper identity.
+
 ## 0.1.10 - 2026-07-13
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,7 +143,7 @@ dependencies = [
 
 [[package]]
 name = "sgw-core"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "base64",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/sgw-core"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.10"
+version = "0.1.11"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/sgateway/s-gw"

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ s-gw status
 
 To build from source, use a stable Rust toolchain. Building the native macOS surfaces also requires a Swift toolchain.
 
-Preview desktop builds are available from [GitHub Releases](https://github.com/sgateway/s-gw/releases). The current macOS and Windows downloads are unsigned preview artifacts. The npm package is the recommended installation path. It includes the native app, menu helper, Keychain helper, and Rust core for Apple Silicon Macs; Linux and Windows use the TypeScript execution path when a matching native core is not packaged. Intel Macs must build the native Keychain and desktop surfaces from source for now; the npm package and DMG reject their arm64-only helpers with a clear compatibility error.
+Preview desktop builds are available from [GitHub Releases](https://github.com/sgateway/s-gw/releases). The current macOS and Windows downloads are unsigned preview artifacts. The npm package is the recommended installation path. It includes the native app, menu helper, Keychain helper, metadata-only Keychain inspector, and Rust core for Apple Silicon Macs; Linux and Windows use the TypeScript execution path when a matching native core is not packaged. Intel Macs must build the native Keychain and desktop surfaces from source for now; the npm package and DMG reject their arm64-only helpers with a clear compatibility error.
 
 ```bash
 git clone https://github.com/sgateway/s-gw.git

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -421,8 +421,9 @@ npm pack
 For macOS production packages, also verify:
 
 - native helper exists at `dist/native/darwin-arm64/s-gw-keychain-helper`;
+- metadata-only Keychain inspector exists at `dist/native/darwin-arm64/s-gw-keychain-inspector`;
 - Rust core exists at `dist/native/darwin-arm64/s-gw-core`;
-- all four native executables report `arm64` through `lipo -verify_arch`;
+- all five native executables report `arm64` through `lipo -verify_arch`;
 - native macOS app exists at `dist/s-gw.app`;
 - `s-gw unlock status` reports `provider: "native-helper"`;
 - real Keychain + MCP e2e passes with no `SGW_MASTER_PASSPHRASE`;
@@ -451,6 +452,7 @@ The public npm package contains:
 - compiled TypeScript under `dist`;
 - compiled Rust execution core at `dist/native/darwin-arm64/s-gw-core`;
 - native macOS Keychain helper at `dist/native/darwin-arm64/s-gw-keychain-helper`;
+- metadata-only macOS Keychain inspector at `dist/native/darwin-arm64/s-gw-keychain-inspector`;
 - native macOS management app at `dist/s-gw.app`;
 - native macOS menu-bar helper app at `dist/s-gw Menu Bar.app`;
 - local console HTML/CSS/JS assets under `docs/ui`;

--- a/docs/keychain.md
+++ b/docs/keychain.md
@@ -24,7 +24,17 @@ The raw credential is written through the bundled helper on stdin. The encrypted
 
 Use `--service SERVICE` or `SGW_SECRET_KEYCHAIN_SERVICE` when you want a separate credential-store namespace for testing, work, or isolated profiles.
 
-On macOS, setup copies the first working Keychain helper to `~/.s-gw/native/darwin-arm64/s-gw-keychain-helper` with owner-only permissions. s-gw keeps using that exact helper across npm and desktop upgrades because Keychain authorization is tied to the helper's code identity. The updater preserves the existing helper before replacing a package, and later releases do not overwrite it silently.
+On macOS, setup copies the first working Keychain helper to `~/.s-gw/native/darwin-arm64/s-gw-keychain-helper` with owner-only permissions. A Keychain ACL records the creating helper's path and code-signing requirement; macOS grants access only when the executing helper satisfies that requirement. The updater preserves the existing helper before replacing a package, and later releases do not overwrite it silently.
+
+After an upgrade, s-gw checks each item's trusted-application metadata before any credential read. An item tied to an older package path is copied through a verified temporary Keychain backup and recreated for the persistent helper. The original is not deleted until the recovery copy has been verified. Run the same repair explicitly at any time:
+
+```bash
+s-gw unlock keychain repair
+```
+
+The command reports counts and per-handle errors, but never prints credential values. If no trusted legacy helper can be verified, s-gw stops before invoking a helper and leaves the item unchanged.
+
+Already-running MCP servers may keep an older s-gw module in memory across an application upgrade. Setup and the updater therefore pin the preserved helper at both the persistent path and the package compatibility path used by those sessions. New agent sessions use the persistent path directly.
 
 Automatic capture paths, including guard mode and the local console API, prefer the OS credential store on macOS and Windows. Set `SGW_SECRET_BACKEND=local` only for compatibility testing or environments without the native helper.
 
@@ -36,7 +46,7 @@ Automatic capture paths, including guard mode and the local console API, prefer 
 4. During approved execution, s-gw reads the credential from the local store and injects it into the local child process.
 5. Command output is sanitized back to handles before it is returned.
 
-Routine status, dashboard, and menu refreshes inspect only Keychain metadata. They do not read the unlock passphrase or credential values and should not open a macOS password prompt. A prompt during an approved execution means macOS does not recognize the helper that originally created the item; choosing `Always Allow` authorizes that helper for the item, while current s-gw installations avoid future identity changes by retaining the persistent helper above.
+Routine status, dashboard, and menu refreshes inspect only Keychain metadata. They do not read the unlock passphrase or credential values and should not open a macOS password prompt. If an unexpected s-gw Keychain password dialog appears, cancel it and run `s-gw unlock keychain repair`; current releases fail closed before starting an unverified helper.
 
 ## 1Password Migration Later
 

--- a/native/installers/macos/Install s-gw.command
+++ b/native/installers/macos/Install s-gw.command
@@ -46,6 +46,54 @@ if [[ -n "$old_sgw" ]]; then
   fi
 fi
 
+node_arch=$(node -p 'process.arch')
+keychain_target="darwin-$node_arch"
+sgw_home=${SGW_HOME:-"$HOME/.s-gw"}
+persistent_helper="$sgw_home/native/$keychain_target/s-gw-keychain-helper"
+
+archive_keychain_helper() {
+  local candidate=$1
+  [[ -f "$candidate" && -x "$candidate" && ! -L "$candidate" ]] || return 0
+
+  local helper_hash
+  helper_hash=$(/usr/bin/shasum -a 256 "$candidate" | /usr/bin/awk '{print $1}') || fail "An existing Keychain helper could not be fingerprinted."
+  print -r -- "$helper_hash" | /usr/bin/grep -Eq '^[0-9a-f]{64}$' || fail "An existing Keychain helper returned an invalid fingerprint."
+
+  local archive_dir="$sgw_home/native/legacy/$helper_hash"
+  local archive_path="$archive_dir/s-gw-keychain-helper"
+  [[ ! -L "$archive_path" ]] || fail "A preserved Keychain helper has an unsafe path."
+  if [[ -f "$archive_path" ]]; then
+    local archived_hash
+    archived_hash=$(/usr/bin/shasum -a 256 "$archive_path" | /usr/bin/awk '{print $1}') || fail "A preserved Keychain helper could not be verified."
+    [[ "$archived_hash" == "$helper_hash" ]] || fail "A preserved Keychain helper failed verification."
+    /bin/chmod 700 "$archive_dir" "$archive_path" || fail "A preserved Keychain helper could not be secured."
+    return 0
+  fi
+
+  /bin/mkdir -p "$archive_dir" || fail "The Keychain helper archive could not be created."
+  /bin/chmod 700 "$sgw_home/native/legacy" "$archive_dir" || fail "The Keychain helper archive could not be secured."
+  local archive_staging="$archive_path.preserve-$$"
+  /bin/cp "$candidate" "$archive_staging" || fail "An existing Keychain helper could not be archived."
+  /bin/chmod 700 "$archive_staging" || fail "An archived Keychain helper could not be secured."
+  /bin/mv -f "$archive_staging" "$archive_path" || fail "An archived Keychain helper could not be activated."
+}
+
+for package_root in "$npm_root/@s-gw/s-gw" "$npm_root/s-gw"; do
+  for candidate in \
+    "$package_root/dist/native/$keychain_target/s-gw-keychain-helper" \
+    "$package_root/dist/native/s-gw-keychain-helper" \
+    "$package_root/dist/native/sgw-keychain-helper"; do
+    [[ -f "$candidate" && -x "$candidate" && ! -L "$candidate" ]] || continue
+    archive_keychain_helper "$candidate"
+    if [[ ! -f "$persistent_helper" ]]; then
+      /bin/mkdir -p "${persistent_helper:h}" || fail "The existing Keychain helper directory could not be created."
+      /bin/chmod 700 "${persistent_helper:h}" || fail "The existing Keychain helper directory could not be secured."
+      /bin/cp "$candidate" "$persistent_helper" || fail "The existing Keychain helper could not be preserved before upgrade."
+      /bin/chmod 700 "$persistent_helper" || fail "The preserved Keychain helper could not be secured."
+    fi
+  done
+done
+
 legacy_root="$npm_root/s-gw"
 legacy_version=""
 rollback_dir=""
@@ -97,6 +145,16 @@ if ! npm install --global --prefix "$npm_prefix" --ignore-scripts -- "$package_p
     fail "The new package and automatic rollback both failed. Your ~/.s-gw data was preserved. Restore with: npm uninstall --global --prefix '$npm_prefix' @s-gw/s-gw && npm install --global --prefix '$npm_prefix' '$rollback_path'"
   fi
   fail "npm could not install the package. Check your npm global-directory permissions. Your ~/.s-gw data was preserved."
+fi
+
+installed_helper="$npm_root/@s-gw/s-gw/dist/native/$keychain_target/s-gw-keychain-helper"
+if [[ -f "$persistent_helper" ]]; then
+  archive_keychain_helper "$installed_helper"
+  /bin/mkdir -p "${installed_helper:h}" || fail "The installed Keychain helper directory could not be created."
+  helper_staging="$installed_helper.pin-$$"
+  /bin/cp "$persistent_helper" "$helper_staging" || fail "The stable Keychain helper could not be restored after upgrade."
+  /bin/chmod 755 "$helper_staging" || fail "The restored Keychain helper could not be made executable."
+  /bin/mv -f "$helper_staging" "$installed_helper" || fail "The stable Keychain helper could not be activated after upgrade."
 fi
 
 [[ -z "$rollback_dir" ]] || rm -rf "$rollback_dir"

--- a/native/macos-app/Sources/SgwMac/Services/UpdateChecker.swift
+++ b/native/macos-app/Sources/SgwMac/Services/UpdateChecker.swift
@@ -64,7 +64,7 @@ actor UpdateChecker: UpdateChecking {
     private let cli = CLIRunner()
 
     static var currentVersion: String {
-        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.1.10"
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.1.11"
     }
 
     static func isNewer(_ candidate: String, than current: String) -> Bool {

--- a/native/macos-keychain/SgwKeychainInspector.swift
+++ b/native/macos-keychain/SgwKeychainInspector.swift
@@ -1,0 +1,130 @@
+import Foundation
+import Security
+
+// Security.framework exports the same requirement validator used by `security dump-keychain`.
+@_silgen_name("SecTrustedApplicationValidateWithPath")
+func validateTrustedApplication(
+  _ application: SecTrustedApplication,
+  _ path: UnsafePointer<CChar>?
+) -> OSStatus
+
+let usage = """
+Usage:
+  sgw-keychain-inspector trusted-helper --service SERVICE --account ACCOUNT --candidate PATH [...]
+"""
+
+enum InspectorExit {
+  static let usage: Int32 = 64
+  static let notFound: Int32 = 44
+  static let failed: Int32 = 70
+}
+
+func fail(_ message: String, code: Int32 = InspectorExit.failed) -> Never {
+  FileHandle.standardError.write(Data((message + "\n").utf8))
+  exit(code)
+}
+
+func option(_ name: String) -> String? {
+  let args = CommandLine.arguments
+  for index in args.indices where args[index] == name {
+    guard index + 1 < args.count else { return nil }
+    return args[index + 1]
+  }
+  return nil
+}
+
+func options(_ name: String) -> [String] {
+  var values: [String] = []
+  let args = CommandLine.arguments
+  for index in args.indices where args[index] == name && index + 1 < args.count {
+    values.append(args[index + 1])
+  }
+  return values
+}
+
+func requireOption(_ name: String) -> String {
+  guard let value = option(name), !value.isEmpty else {
+    fail(usage, code: InspectorExit.usage)
+  }
+  return value
+}
+
+func check(_ status: OSStatus) {
+  guard status != errSecSuccess else { return }
+  if status == errSecItemNotFound {
+    exit(InspectorExit.notFound)
+  }
+
+  let message = SecCopyErrorMessageString(status, nil) as String? ?? "Keychain inspection failed"
+  fail("\(message) (\(status))")
+}
+
+func copyTrustedApplications(item: SecKeychainItem) -> [SecTrustedApplication] {
+  var access: SecAccess?
+  check(SecKeychainItemCopyAccess(item, &access))
+  guard let access else { return [] }
+
+  guard let aclList = SecAccessCopyMatchingACLList(access, kSecACLAuthorizationDecrypt) as? [SecACL]
+  else { return [] }
+
+  var result: [SecTrustedApplication] = []
+  for acl in aclList {
+    var applicationList: CFArray?
+    var description: CFString?
+    var prompt = SecKeychainPromptSelector()
+    check(SecACLCopyContents(acl, &applicationList, &description, &prompt))
+
+    guard let applications = applicationList as? [SecTrustedApplication] else { continue }
+    result.append(contentsOf: applications)
+  }
+  return result
+}
+
+func trustedHelper(service: String, account: String, candidates: [String]) {
+  var query: [String: Any] = [
+    kSecClass as String: kSecClassGenericPassword,
+    kSecAttrService as String: service,
+    kSecAttrAccount as String: account,
+    kSecReturnRef as String: true,
+    kSecMatchLimit as String: kSecMatchLimitOne
+  ]
+  query[kSecUseAuthenticationUI as String] = kSecUseAuthenticationUIFail
+
+  var item: CFTypeRef?
+  check(SecItemCopyMatching(query as CFDictionary, &item))
+  guard let keychainItem = item as! SecKeychainItem? else {
+    fail("Keychain item reference was unavailable")
+  }
+
+  let trustedApplications = copyTrustedApplications(item: keychainItem)
+  var matches: [String] = []
+  for candidate in candidates {
+    let trusted = candidate.withCString { path in
+      trustedApplications.contains { application in
+        validateTrustedApplication(application, path) == errSecSuccess
+      }
+    }
+    if trusted {
+      matches.append(candidate)
+    }
+  }
+
+  let encoded = try! JSONSerialization.data(withJSONObject: ["trustedHelpers": matches])
+  FileHandle.standardOutput.write(encoded)
+  FileHandle.standardOutput.write(Data("\n".utf8))
+}
+
+guard CommandLine.arguments.count >= 2 else {
+  fail(usage, code: InspectorExit.usage)
+}
+
+let command = CommandLine.arguments[1]
+let service = requireOption("--service")
+let account = requireOption("--account")
+
+switch command {
+case "trusted-helper":
+  trustedHelper(service: service, account: account, candidates: options("--candidate"))
+default:
+  fail(usage, code: InspectorExit.usage)
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@s-gw/s-gw",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@s-gw/s-gw",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "license": "Apache-2.0",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-gw/s-gw",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "mcpName": "io.github.sgateway/s-gw",
   "description": "Local credential control for AI coding agents.",
   "type": "module",

--- a/scripts/build-native-keychain.mjs
+++ b/scripts/build-native-keychain.mjs
@@ -5,8 +5,10 @@ import { fileURLToPath } from "node:url";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const source = resolve(root, "native/macos-keychain/SgwKeychain.swift");
+const inspectorSource = resolve(root, "native/macos-keychain/SgwKeychainInspector.swift");
 const target = `${process.platform}-${process.arch}`;
 const output = resolve(root, "dist/native", target, "s-gw-keychain-helper");
+const inspectorOutput = resolve(root, "dist/native", target, "s-gw-keychain-inspector");
 const legacyOutputs = [
   resolve(root, "dist/native/s-gw-keychain-helper"),
   resolve(root, "dist/native/sgw-keychain-helper")
@@ -17,8 +19,8 @@ if (process.platform !== "darwin") {
   process.exit(0);
 }
 
-if (!existsSync(source)) {
-  console.error(`Missing native Keychain helper source: ${source}`);
+if (!existsSync(source) || !existsSync(inspectorSource)) {
+  console.error(`Missing native Keychain source: ${!existsSync(source) ? source : inspectorSource}`);
   process.exit(1);
 }
 
@@ -50,3 +52,16 @@ if (result.status !== 0) {
 
 chmodSync(output, 0o755);
 console.log(`Built native macOS Keychain helper: ${output}`);
+
+const inspectorResult = spawnSync("swiftc", [inspectorSource, "-O", "-o", inspectorOutput], {
+  encoding: "utf8",
+  stdio: ["ignore", "pipe", "pipe"]
+});
+
+if (inspectorResult.status !== 0) {
+  console.error(inspectorResult.stderr || inspectorResult.stdout);
+  process.exit(inspectorResult.status || 1);
+}
+
+chmodSync(inspectorOutput, 0o755);
+console.log(`Built native macOS Keychain inspector: ${inspectorOutput}`);

--- a/scripts/validate-npm-package.mjs
+++ b/scripts/validate-npm-package.mjs
@@ -28,6 +28,7 @@ const files = new Map(packed.files.map((entry) => [entry.path, entry]));
 const requiredExecutables = [
   `dist/native/${target}/s-gw-core`,
   `dist/native/${target}/s-gw-keychain-helper`,
+  `dist/native/${target}/s-gw-keychain-inspector`,
   "dist/s-gw.app/Contents/MacOS/s-gw",
   "dist/s-gw Menu Bar.app/Contents/MacOS/s-gw-menu-bar-helper"
 ];
@@ -64,7 +65,7 @@ for (const filePath of forbidden) {
 
 const targetExecutables = [...files.keys()].filter((filePath) => (
   /^dist\/native\/[^/]+\/s-gw-core(?:\.exe)?$/.test(filePath)
-  || /^dist\/native\/[^/]+\/(?:s-gw-keychain-helper|sgw-keychain-helper)$/.test(filePath)
+  || /^dist\/native\/[^/]+\/(?:s-gw-keychain-helper|sgw-keychain-helper|s-gw-keychain-inspector)$/.test(filePath)
 ));
 for (const filePath of targetExecutables) {
   if (!filePath.startsWith(`dist/native/${target}/`)) {

--- a/server.json
+++ b/server.json
@@ -15,13 +15,13 @@
     "url": "https://github.com/sgateway/s-gw",
     "source": "github"
   },
-  "version": "0.1.10",
+  "version": "0.1.11",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@s-gw/s-gw",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "runtimeHint": "npx",
       "runtimeArguments": [
         {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -45,6 +45,8 @@ import { SecretStore } from "./store.js";
 import {
   deleteKeychainPassphrase,
   installPersistentKeychainHelper,
+  pinPackagedKeychainHelper,
+  repairKeychainPassphraseAccess,
   setKeychainPassphrase,
   unlockStatus
 } from "./unlock.js";
@@ -237,6 +239,22 @@ async function main(): Promise<void> {
     printJson({
       deleted: deleteKeychainPassphrase(),
       keychain: unlockStatus().keychain
+    });
+    return;
+  }
+
+  if (first === "unlock" && second === "keychain" && third === "repair") {
+    const keychainHelper = process.platform === "darwin" ? installPersistentKeychainHelper() : undefined;
+    const keychainCompatibility = process.platform === "darwin" ? pinPackagedKeychainHelper() : undefined;
+    const master = repairKeychainPassphraseAccess();
+    await store.init();
+    const secrets = await store.repairKeychainAccess();
+    printJson({
+      ok: secrets.failed.length === 0,
+      keychainHelper,
+      keychainCompatibility,
+      master,
+      secrets
     });
     return;
   }
@@ -958,7 +976,11 @@ async function handleSetupCommand(
 ): Promise<void> {
   const port = numericFlag(flags, "port", 8718);
   const keychainHelper = process.platform === "darwin" ? installPersistentKeychainHelper() : undefined;
+  const keychainCompatibility = process.platform === "darwin" ? pinPackagedKeychainHelper() : undefined;
   const beforeUnlock = unlockStatus();
+  const masterKeychainRepair = process.platform === "darwin" && beforeUnlock.keychain.configured
+    ? repairKeychainPassphraseAccess()
+    : undefined;
   let unlockAction = beforeUnlock.activeSource === "none" ? "not-configured" : `existing-${beforeUnlock.activeSource}`;
 
   if (beforeUnlock.activeSource === "none") {
@@ -974,6 +996,9 @@ async function handleSetupCommand(
   }
 
   await store.init();
+  const secretKeychainRepair = process.platform === "darwin"
+    ? await store.repairKeychainAccess()
+    : undefined;
   const consoleUrl = `http://127.0.0.1:${port}/`;
   let service = launchAgentStatus("console");
   let menuBar = launchAgentStatus("menubar");
@@ -1001,7 +1026,7 @@ async function handleSetupCommand(
     : { skipped: false, results: installAgentIntegrations() };
 
   printJson({
-    ok: true,
+    ok: !secretKeychainRepair || secretKeychainRepair.failed.length === 0,
     unlock: unlockAction,
     storePath: store.storePath,
     consoleUrl,
@@ -1010,6 +1035,11 @@ async function handleSetupCommand(
     menuBar,
     windowsHelper,
     keychainHelper,
+    keychainCompatibility,
+    keychainRepair: {
+      master: masterKeychainRepair,
+      secrets: secretKeychainRepair
+    },
     appInstall,
     agents,
     nextSteps: [
@@ -1881,6 +1911,7 @@ Commands:
   s-gw unlock status
   s-gw unlock keychain set --value-stdin
   s-gw unlock keychain delete
+  s-gw unlock keychain repair
   s-gw secret add --name NAME --type api-token --value-stdin --inject-env ENV --allow-command CMD
   s-gw secret add-keychain --name NAME --type api-token --value-stdin --inject-env ENV --allow-command CMD [--service SERVICE]
   s-gw secret add-1password --name NAME --type api-token --ref op://vault/item/field --inject-env ENV --allow-command CMD [--verify]

--- a/src/command-suggest.ts
+++ b/src/command-suggest.ts
@@ -38,6 +38,7 @@ export const KNOWN_COMMANDS = [
   "unlock status",
   "unlock keychain set",
   "unlock keychain delete",
+  "unlock keychain repair",
   "secret add",
   "secret add-1password",
   "secret list",

--- a/src/package-update.ts
+++ b/src/package-update.ts
@@ -7,6 +7,8 @@ import path from "node:path";
 import { getSgwHome } from "./paths.js";
 import {
   installPersistentKeychainHelper,
+  pinPackagedKeychainHelper,
+  type PackagedKeychainHelperPin,
   type PersistentKeychainHelperInstall
 } from "./unlock.js";
 
@@ -94,6 +96,7 @@ export interface PackageUpdateResult {
   installed: GlobalSgwInstall;
   dataHomePreserved: boolean;
   keychainHelper?: PersistentKeychainHelperInstall;
+  keychainCompatibility?: PackagedKeychainHelperPin;
   nextCommands: string[];
 }
 
@@ -227,6 +230,7 @@ export async function installPackageUpdate(options: PackageInstallOptions = {}):
   let stopAttempted = false;
   let restartAttempted = false;
   let keychainHelper: PersistentKeychainHelperInstall | undefined;
+  let keychainCompatibility: PackagedKeychainHelperPin | undefined;
 
   try {
     if (options.stopServices) {
@@ -294,6 +298,14 @@ export async function installPackageUpdate(options: PackageInstallOptions = {}):
       );
     }
 
+    if (process.platform === "darwin" && keychainHelper && finalInstall.scoped) {
+      keychainCompatibility = pinPackagedKeychainHelper(
+        finalInstall.scoped.packageRoot,
+        keychainHelper.helperPath,
+        plan.dataHome
+      );
+    }
+
     await discardRollback(rollback);
     rollback = null;
     removedLegacy = false;
@@ -318,6 +330,7 @@ export async function installPackageUpdate(options: PackageInstallOptions = {}):
       installed: finalInstall,
       dataHomePreserved,
       keychainHelper,
+      keychainCompatibility,
       nextCommands: plan.nextCommands
     };
   } catch (error) {

--- a/src/store.ts
+++ b/src/store.ts
@@ -12,6 +12,7 @@ import {
   defaultSecretKeychainService,
   deleteMacKeychainItem,
   getMacKeychainItem,
+  repairMacKeychainItemAccess,
   setMacKeychainItem,
   type MacKeychainItemRef
 } from "./unlock.js";
@@ -149,6 +150,16 @@ export interface StoreBackupSummary {
   path: string;
   bytes: number;
   modifiedAt: string;
+}
+
+export interface KeychainAccessRepairSummary {
+  checked: number;
+  alreadyBound: number;
+  migrated: number;
+  recovered: number;
+  missing: number;
+  unsupported: number;
+  failed: Array<{ handle: string; name: string; error: string }>;
 }
 
 export class SecretStore {
@@ -399,6 +410,41 @@ export class SecretStore {
     }
 
     return decryptSecret(record.encrypted);
+  }
+
+  async repairKeychainAccess(): Promise<KeychainAccessRepairSummary> {
+    const store = await this.read();
+    const result: KeychainAccessRepairSummary = {
+      checked: 0,
+      alreadyBound: 0,
+      migrated: 0,
+      recovered: 0,
+      missing: 0,
+      unsupported: 0,
+      failed: []
+    };
+
+    for (const record of store.secrets) {
+      if (record.backend !== "keychain") continue;
+      result.checked += 1;
+
+      try {
+        const repair = repairMacKeychainItemAccess(keychainRefFromRecord(record));
+        if (repair.state === "already-bound") result.alreadyBound += 1;
+        else if (repair.state === "migrated") result.migrated += 1;
+        else if (repair.state === "recovered") result.recovered += 1;
+        else if (repair.state === "missing") result.missing += 1;
+        else result.unsupported += 1;
+      } catch (error) {
+        result.failed.push({
+          handle: record.handle,
+          name: record.name,
+          error: error instanceof Error ? error.message : String(error)
+        });
+      }
+    }
+
+    return result;
   }
 
   private async storeOnePasswordCache(handle: string, value: string, request?: RequestRecord): Promise<void> {

--- a/src/unlock.ts
+++ b/src/unlock.ts
@@ -1,4 +1,5 @@
 import { execFileSync, spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import {
   accessSync,
   chmodSync,
@@ -6,7 +7,11 @@ import {
   copyFileSync,
   existsSync,
   linkSync,
+  lstatSync,
   mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
   rmSync,
   statSync
 } from "node:fs";
@@ -18,7 +23,11 @@ import { getSgwHome } from "./paths.js";
 const defaultService = "com.s-gw.sgw.master-passphrase";
 const defaultSecretService = "com.s-gw.sgw.secret";
 const nativeHelperName = "s-gw-keychain-helper";
+const nativeInspectorName = "s-gw-keychain-inspector";
+const keychainRepairService = "com.s-gw.sgw.keychain-repair";
 const windowsCredentialHelperName = "s-gw-credential.ps1";
+const keychainRepairTimeoutMs = 10_000;
+const staleKeychainRepairMs = 30_000;
 
 export interface KeychainInfo {
   supported: boolean;
@@ -51,6 +60,23 @@ export interface PersistentKeychainHelperInstall {
 export interface PersistentKeychainHelperOptions {
   sourcePath?: string;
   sgwHome?: string;
+}
+
+export interface PackagedKeychainHelperPin {
+  sourcePath: string;
+  packagePath: string;
+  changed: boolean;
+}
+
+export interface PreservedKeychainHelperIdentity {
+  sourcePath: string;
+  helperPath: string;
+  changed: boolean;
+}
+
+export interface MacKeychainAccessRepair {
+  state: "already-bound" | "migrated" | "recovered" | "missing" | "unsupported";
+  helperPath?: string;
 }
 
 export function requireUnlockPassphrase(): string {
@@ -98,6 +124,10 @@ export function setKeychainPassphrase(passphrase: string): void {
 
   ensureLocalCredentialStore();
   preparePersistentMacHelper();
+  if (managedMacKeychainAccessEnabled()) {
+    setManagedMacKeychainItem(masterPassphraseRef(), passphrase);
+    return;
+  }
   runKeychainSet(keychainInfo(), passphrase);
 }
 
@@ -105,6 +135,9 @@ export function deleteKeychainPassphrase(): boolean {
   ensureLocalCredentialStore();
   preparePersistentMacHelper();
   try {
+    if (managedMacKeychainAccessEnabled()) {
+      return deleteManagedMacKeychainItem(masterPassphraseRef());
+    }
     runKeychainDelete(keychainInfo());
     return true;
   } catch {
@@ -144,6 +177,10 @@ export function setMacKeychainItem(ref: MacKeychainItemRef, value: string): void
   }
 
   preparePersistentMacHelper();
+  if (managedMacKeychainAccessEnabled()) {
+    setManagedMacKeychainItem(ref, value);
+    return;
+  }
   const info = keychainInfoForItem(ref);
   ensureNativeCredentialStore(info);
   runKeychainSet(info, value, ref.label || "s-gw local secret");
@@ -151,6 +188,9 @@ export function setMacKeychainItem(ref: MacKeychainItemRef, value: string): void
 
 export function getMacKeychainItem(ref: MacKeychainItemRef): string {
   preparePersistentMacHelper();
+  if (managedMacKeychainAccessEnabled()) {
+    return readManagedMacKeychainItem(ref).value;
+  }
   const info = keychainInfoForItem(ref);
   ensureNativeCredentialStore(info);
   return runKeychainGet(info).replace(/\r?\n$/, "");
@@ -159,6 +199,9 @@ export function getMacKeychainItem(ref: MacKeychainItemRef): string {
 export function deleteMacKeychainItem(ref: MacKeychainItemRef): boolean {
   try {
     preparePersistentMacHelper();
+    if (managedMacKeychainAccessEnabled()) {
+      return deleteManagedMacKeychainItem(ref);
+    }
     const info = keychainInfoForItem(ref);
     ensureNativeCredentialStore(info);
     runKeychainDelete(info);
@@ -168,14 +211,39 @@ export function deleteMacKeychainItem(ref: MacKeychainItemRef): boolean {
   }
 }
 
+export function repairKeychainPassphraseAccess(): MacKeychainAccessRepair {
+  if (!managedMacKeychainAccessEnabled()) {
+    return { state: "unsupported" };
+  }
+  preparePersistentMacHelper();
+  return repairManagedMacKeychainItem(masterPassphraseRef());
+}
+
+export function repairMacKeychainItemAccess(ref: MacKeychainItemRef): MacKeychainAccessRepair {
+  if (!managedMacKeychainAccessEnabled()) {
+    return { state: "unsupported" };
+  }
+  preparePersistentMacHelper();
+  return repairManagedMacKeychainItem(ref);
+}
+
 function readKeychainPassphrase(): string | undefined {
   if (!supportsLocalCredentialStore() || process.env.SGW_DISABLE_KEYCHAIN === "1") {
     return undefined;
   }
 
   preparePersistentMacHelper();
-  const info = keychainInfo();
+  if (managedMacKeychainAccessEnabled()) {
+    const ref = masterPassphraseRef();
+    const itemExists = keychainItemExists(keychainInfoForItem(ref));
+    if (!itemExists && !keychainItemExists(keychainInfoForItem(keychainRepairBackupRef(ref)))) {
+      return undefined;
+    }
+    return readManagedMacKeychainItem(ref).value;
+  }
+
   try {
+    const info = keychainInfo();
     const output = runKeychainGet(info);
 
     return output.replace(/\r?\n$/, "");
@@ -260,19 +328,34 @@ function findNativeHelper(): string | undefined {
 }
 
 function findPackagedNativeHelper(): string | undefined {
-  if (process.platform !== "darwin") {
-    return undefined;
-  }
+  return packagedNativeHelperCandidates().find((candidate) => existsSync(candidate));
+}
+
+function packagedNativeHelperCandidates(): string[] {
+  if (process.platform !== "darwin") return [];
 
   const here = path.dirname(fileURLToPath(import.meta.url));
   const nativeTarget = `${process.platform}-${process.arch}`;
-  const candidates = [
+  return uniquePaths([
     path.resolve(here, "native", nativeTarget, nativeHelperName),
     path.resolve(process.cwd(), "dist", "native", nativeTarget, nativeHelperName),
     path.resolve(here, "native", nativeHelperName),
     path.resolve(process.cwd(), "dist", "native", nativeHelperName)
-  ];
+  ]);
+}
 
+function findPackagedKeychainInspector(): string | undefined {
+  if (process.platform !== "darwin") return undefined;
+
+  const fromEnv = process.env.SGW_KEYCHAIN_INSPECTOR;
+  if (fromEnv) return existsSync(fromEnv) ? path.resolve(fromEnv) : undefined;
+
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const nativeTarget = `${process.platform}-${process.arch}`;
+  const candidates = [
+    path.resolve(here, "native", nativeTarget, nativeInspectorName),
+    path.resolve(process.cwd(), "dist", "native", nativeTarget, nativeInspectorName)
+  ];
   return candidates.find((candidate) => existsSync(candidate));
 }
 
@@ -299,6 +382,9 @@ export function installPersistentKeychainHelper(
   const helperPath = persistentKeychainHelperPath(options.sgwHome);
   if (existsSync(helperPath)) {
     assertUsableHelper(helperPath);
+    if (helperHash(sourcePath) !== helperHash(helperPath)) {
+      preserveLegacyKeychainHelper(sourcePath, options.sgwHome);
+    }
     chmodSync(helperPath, 0o700);
     return { helperPath, sourcePath, changed: false };
   }
@@ -324,6 +410,90 @@ export function installPersistentKeychainHelper(
   return { helperPath, sourcePath, changed: true };
 }
 
+export function pinPackagedKeychainHelper(
+  packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), ".."),
+  sourcePath = persistentKeychainHelperPath(),
+  sgwHome = getSgwHome()
+): PackagedKeychainHelperPin | undefined {
+  if (process.platform !== "darwin") return undefined;
+
+  assertUsableHelper(sourcePath);
+  const nativeTarget = `${process.platform}-${process.arch}`;
+  const packagePath = path.join(path.resolve(packageRoot), "dist", "native", nativeTarget, nativeHelperName);
+  const sourceHash = helperHash(sourcePath);
+
+  if (existsSync(packagePath)) {
+    const info = lstatSync(packagePath);
+    if (!info.isFile() || info.isSymbolicLink()) {
+      throw new Error(`Refusing to replace an unsafe packaged Keychain helper: ${packagePath}`);
+    }
+    if (helperHash(packagePath) === sourceHash) {
+      return { sourcePath, packagePath, changed: false };
+    }
+    preserveLegacyKeychainHelper(packagePath, sgwHome);
+  }
+
+  mkdirSync(path.dirname(packagePath), { recursive: true });
+  const staging = `${packagePath}.pin-${process.pid}-${Date.now()}`;
+  try {
+    copyFileSync(sourcePath, staging);
+    chmodSync(staging, 0o755);
+    renameSync(staging, packagePath);
+  } finally {
+    rmSync(staging, { force: true });
+  }
+
+  assertUsableHelper(packagePath);
+  if (helperHash(packagePath) !== sourceHash) {
+    throw new Error(`Packaged Keychain helper verification failed: ${packagePath}`);
+  }
+  return { sourcePath, packagePath, changed: true };
+}
+
+export function preserveLegacyKeychainHelper(
+  sourcePath: string,
+  sgwHome = getSgwHome()
+): PreservedKeychainHelperIdentity {
+  const resolvedSource = path.resolve(sourcePath);
+  assertUsableHelper(resolvedSource);
+  const hash = helperHash(resolvedSource);
+  const legacyRoot = path.join(path.resolve(sgwHome), "native", "legacy");
+  const helperPath = path.join(legacyRoot, hash, nativeHelperName);
+
+  if (existsSync(helperPath)) {
+    assertUsableHelper(helperPath);
+    if (helperHash(helperPath) !== hash) {
+      throw new Error(`Preserved Keychain helper verification failed: ${helperPath}`);
+    }
+    chmodSync(helperPath, 0o700);
+    return { sourcePath: resolvedSource, helperPath, changed: false };
+  }
+
+  mkdirSync(path.dirname(helperPath), { recursive: true, mode: 0o700 });
+  chmodSync(legacyRoot, 0o700);
+  chmodSync(path.dirname(helperPath), 0o700);
+  const staging = `${helperPath}.preserve-${process.pid}-${Date.now()}`;
+  try {
+    copyFileSync(resolvedSource, staging);
+    chmodSync(staging, 0o700);
+    linkSync(staging, helperPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+  } finally {
+    rmSync(staging, { force: true });
+  }
+
+  assertUsableHelper(helperPath);
+  if (helperHash(helperPath) !== hash) {
+    throw new Error(`Preserved Keychain helper verification failed: ${helperPath}`);
+  }
+  return { sourcePath: resolvedSource, helperPath, changed: true };
+}
+
+function helperHash(filePath: string): string {
+  return createHash("sha256").update(readFileSync(filePath)).digest("hex");
+}
+
 function preparePersistentMacHelper(): void {
   if (process.platform !== "darwin" || process.env.SGW_KEYCHAIN_HELPER) {
     return;
@@ -339,6 +509,390 @@ function assertUsableHelper(helperPath: string): void {
     throw new Error(`Keychain helper is not a usable file: ${helperPath}`);
   }
   accessSync(helperPath, constants.X_OK);
+}
+
+interface ManagedMacKeychainRead {
+  value: string;
+  repair: MacKeychainAccessRepair;
+}
+
+interface TrustedHelperResolution {
+  helpers: string[];
+  cleanup: () => void;
+}
+
+let keychainAclDumpCache: string | undefined;
+const keychainRepairWait = new Int32Array(new SharedArrayBuffer(4));
+
+function managedMacKeychainAccessEnabled(): boolean {
+  return process.platform === "darwin" && !process.env.SGW_KEYCHAIN_HELPER;
+}
+
+function masterPassphraseRef(): MacKeychainItemRef {
+  const info = keychainInfo();
+  return {
+    service: info.service,
+    account: info.account,
+    label: "s-gw local unlock passphrase"
+  };
+}
+
+function repairManagedMacKeychainItem(ref: MacKeychainItemRef): MacKeychainAccessRepair {
+  return withKeychainRepairLock(() => {
+    const info = keychainInfoForItem(ref);
+    if (!keychainItemExists(info)) {
+      const recovered = recoverInterruptedKeychainRepair(ref);
+      return recovered?.repair || { state: "missing" };
+    }
+    return readManagedMacKeychainItemLocked(ref).repair;
+  });
+}
+
+function readManagedMacKeychainItem(ref: MacKeychainItemRef): ManagedMacKeychainRead {
+  return withKeychainRepairLock(() => readManagedMacKeychainItemLocked(ref));
+}
+
+function readManagedMacKeychainItemLocked(ref: MacKeychainItemRef): ManagedMacKeychainRead {
+  const persistent = persistentKeychainHelperPath();
+  assertUsableHelper(persistent);
+  const info = keychainInfoForItem(ref);
+
+  if (!keychainItemExists(info)) {
+    const recovered = recoverInterruptedKeychainRepair(ref);
+    if (recovered) return recovered;
+    throw new Error(`Keychain item was not found for account ${ref.account}.`);
+  }
+
+  const resolution = resolveTrustedHelper(ref, persistent);
+  try {
+    if (resolution.helpers.includes(persistent)) {
+      removeRepairBackup(ref, persistent);
+      return {
+        value: runNativeHelper(persistent, keychainGetArgs(ref)).replace(/\r?\n$/, ""),
+        repair: { state: "already-bound", helperPath: persistent }
+      };
+    }
+
+    const source = resolution.helpers[0];
+    if (!source) throw untrustedKeychainItemError(ref);
+
+    const value = runNativeHelper(source, keychainGetArgs(ref)).replace(/\r?\n$/, "");
+    const backup = keychainRepairBackupRef(ref);
+    const backupInfo = keychainInfoForItem(backup);
+    if (keychainItemExists(backupInfo)) {
+      const backupResolution = resolveTrustedHelper(backup, persistent);
+      try {
+        if (!backupResolution.helpers.includes(persistent)) throw untrustedKeychainItemError(backup);
+      } finally {
+        backupResolution.cleanup();
+      }
+    }
+    runKeychainSet({ ...backupInfo, provider: "native-helper", helperPath: persistent }, value, backup.label);
+    verifyKeychainValue(backup, persistent, value);
+
+    runNativeHelper(source, keychainDeleteArgs(ref));
+    try {
+      runKeychainSet({ ...info, provider: "native-helper", helperPath: persistent }, value, ref.label);
+      verifyKeychainValue(ref, persistent, value);
+    } catch (migrationError) {
+      try {
+        runKeychainSet({ ...info, provider: "native-helper", helperPath: source }, value, ref.label);
+        verifyKeychainValue(ref, source, value);
+        runKeychainDelete({ ...backupInfo, provider: "native-helper", helperPath: persistent });
+      } catch {
+        throw new Error(
+          `Keychain access repair failed for ${ref.account}; a verified recovery copy remains in macOS Keychain. ` +
+          "Run `s-gw unlock keychain repair` before using this handle again."
+        );
+      }
+      throw migrationError;
+    }
+
+    runKeychainDelete({ ...backupInfo, provider: "native-helper", helperPath: persistent });
+    return {
+      value,
+      repair: { state: "migrated", helperPath: persistent }
+    };
+  } finally {
+    resolution.cleanup();
+  }
+}
+
+function setManagedMacKeychainItem(ref: MacKeychainItemRef, value: string): void {
+  withKeychainRepairLock(() => {
+    const persistent = persistentKeychainHelperPath();
+    assertUsableHelper(persistent);
+    const info = keychainInfoForItem(ref);
+
+    if (keychainItemExists(info)) {
+      readManagedMacKeychainItemLocked(ref);
+    } else {
+      recoverInterruptedKeychainRepair(ref);
+    }
+
+    runKeychainSet({ ...info, provider: "native-helper", helperPath: persistent }, value, ref.label);
+    verifyKeychainValue(ref, persistent, value);
+  });
+}
+
+function deleteManagedMacKeychainItem(ref: MacKeychainItemRef): boolean {
+  return withKeychainRepairLock(() => {
+    const persistent = persistentKeychainHelperPath();
+    assertUsableHelper(persistent);
+    const info = keychainInfoForItem(ref);
+    let deleted = false;
+
+    if (keychainItemExists(info)) {
+      const resolution = resolveTrustedHelper(ref, persistent);
+      try {
+        const helper = resolution.helpers[0];
+        if (!helper) throw untrustedKeychainItemError(ref);
+        runNativeHelper(helper, keychainDeleteArgs(ref));
+        deleted = true;
+      } finally {
+        resolution.cleanup();
+      }
+    }
+
+    const backup = keychainRepairBackupRef(ref);
+    const backupInfo = keychainInfoForItem(backup);
+    if (keychainItemExists(backupInfo)) {
+      const resolution = resolveTrustedHelper(backup, persistent);
+      try {
+        if (!resolution.helpers.includes(persistent)) throw untrustedKeychainItemError(backup);
+        runKeychainDelete({ ...backupInfo, provider: "native-helper", helperPath: persistent });
+      } finally {
+        resolution.cleanup();
+      }
+    }
+
+    return deleted;
+  });
+}
+
+function recoverInterruptedKeychainRepair(ref: MacKeychainItemRef): ManagedMacKeychainRead | undefined {
+  const persistent = persistentKeychainHelperPath();
+  const backup = keychainRepairBackupRef(ref);
+  const backupInfo = keychainInfoForItem(backup);
+  if (!keychainItemExists(backupInfo)) return undefined;
+
+  const resolution = resolveTrustedHelper(backup, persistent);
+  try {
+    if (!resolution.helpers.includes(persistent)) throw untrustedKeychainItemError(backup);
+    const value = runNativeHelper(persistent, keychainGetArgs(backup)).replace(/\r?\n$/, "");
+    const info = keychainInfoForItem(ref);
+    runKeychainSet({ ...info, provider: "native-helper", helperPath: persistent }, value, ref.label);
+    verifyKeychainValue(ref, persistent, value);
+    runKeychainDelete({ ...backupInfo, provider: "native-helper", helperPath: persistent });
+    return {
+      value,
+      repair: { state: "recovered", helperPath: persistent }
+    };
+  } finally {
+    resolution.cleanup();
+  }
+}
+
+function removeRepairBackup(ref: MacKeychainItemRef, persistent: string): void {
+  const backup = keychainRepairBackupRef(ref);
+  const info = keychainInfoForItem(backup);
+  if (!keychainItemExists(info)) return;
+
+  const resolution = resolveTrustedHelper(backup, persistent);
+  try {
+    if (!resolution.helpers.includes(persistent)) throw untrustedKeychainItemError(backup);
+    runKeychainDelete({ ...info, provider: "native-helper", helperPath: persistent });
+  } finally {
+    resolution.cleanup();
+  }
+}
+
+function verifyKeychainValue(ref: MacKeychainItemRef, helperPath: string, expected: string): void {
+  const actual = runNativeHelper(helperPath, keychainGetArgs(ref)).replace(/\r?\n$/, "");
+  if (actual !== expected) {
+    throw new Error(`Keychain verification failed for account ${ref.account}.`);
+  }
+}
+
+function resolveTrustedHelper(ref: MacKeychainItemRef, persistent: string): TrustedHelperResolution {
+  const known = safeHelperCandidates([
+    persistent,
+    ...packagedNativeHelperCandidates(),
+    ...preservedLegacyHelperCandidates(),
+    ...(process.env.SGW_KEYCHAIN_LEGACY_HELPERS || "").split(path.delimiter)
+  ]);
+  const firstMatch = inspectTrustedHelpers(ref, known);
+  if (firstMatch.length > 0) {
+    return { helpers: preferPersistent(firstMatch, persistent), cleanup: () => undefined };
+  }
+
+  const candidates = safeHelperCandidates([...known, ...trustedApplicationPaths(ref)]);
+  const matches = inspectTrustedHelpers(ref, candidates);
+  return {
+    helpers: preferPersistent(matches, persistent),
+    cleanup: () => undefined
+  };
+}
+
+function preservedLegacyHelperCandidates(): string[] {
+  const legacyRoot = path.join(path.resolve(getSgwHome()), "native", "legacy");
+  try {
+    return readdirSync(legacyRoot, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory() && /^[a-f0-9]{64}$/.test(entry.name))
+      .map((entry) => path.join(legacyRoot, entry.name, nativeHelperName));
+  } catch {
+    return [];
+  }
+}
+
+function inspectTrustedHelpers(ref: MacKeychainItemRef, candidates: string[]): string[] {
+  if (candidates.length === 0) return [];
+  const inspector = findPackagedKeychainInspector();
+  if (!inspector) {
+    throw new Error("The macOS Keychain inspector is missing. Reinstall s-gw before accessing credentials.");
+  }
+
+  const args = ["trusted-helper", "--service", ref.service, "--account", ref.account];
+  for (const candidate of candidates) args.push("--candidate", candidate);
+  const result = spawnSync(inspector, args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"]
+  });
+  if (result.status === 44) return [];
+  if (result.status !== 0) {
+    throw new Error(result.stderr.trim() || `Keychain inspector failed with status ${result.status}`);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(result.stdout);
+  } catch {
+    throw new Error("Keychain inspector returned invalid JSON.");
+  }
+  const values = (parsed as { trustedHelpers?: unknown }).trustedHelpers;
+  if (!Array.isArray(values)) throw new Error("Keychain inspector returned an invalid helper list.");
+  const allowed = new Set(candidates);
+  return values.filter((value): value is string => typeof value === "string" && allowed.has(value));
+}
+
+function trustedApplicationPaths(ref: MacKeychainItemRef): string[] {
+  if (keychainAclDumpCache === undefined) {
+    const result = spawnSync(keychainStatusCliPath(), ["dump-keychain", "-a"], {
+      encoding: "utf8",
+      maxBuffer: 32 * 1024 * 1024,
+      stdio: ["ignore", "pipe", "pipe"]
+    });
+    if (result.status !== 0) {
+      throw new Error(result.stderr.trim() || `Keychain ACL inspection failed with status ${result.status}`);
+    }
+    keychainAclDumpCache = `${result.stdout}\n${result.stderr}`;
+  }
+  return parseKeychainTrustedApplicationPaths(keychainAclDumpCache, ref.service, ref.account);
+}
+
+export function parseKeychainTrustedApplicationPaths(
+  dump: string,
+  service: string,
+  account: string
+): string[] {
+  const blocks = dump.split(/(?=keychain: )/g);
+  for (const block of blocks) {
+    const foundService = block.match(/"svce"<blob>="([^"]*)"/)?.[1];
+    const foundAccount = block.match(/"acct"<blob>="([^"]*)"/)?.[1];
+    if (foundService !== service || foundAccount !== account) continue;
+
+    const paths: string[] = [];
+    const matcher = /^\s+\d+:\s+(\/.*?)\s+\((?:OK|status\s+-?\d+)\)\s*$/gm;
+    for (const match of block.matchAll(matcher)) paths.push(match[1]);
+    return uniquePaths(paths);
+  }
+  return [];
+}
+
+function safeHelperCandidates(candidates: string[]): string[] {
+  return uniquePaths(candidates.filter(Boolean).map((candidate) => path.resolve(candidate))).filter((candidate) => {
+    if (!existsSync(candidate)) return false;
+    if (![nativeHelperName, "sgw-keychain-helper"].includes(path.basename(candidate))) return false;
+    try {
+      const info = lstatSync(candidate);
+      const uid = typeof process.getuid === "function" ? process.getuid() : info.uid;
+      if (!info.isFile() || info.isSymbolicLink()) return false;
+      if (info.uid !== 0 && info.uid !== uid) return false;
+      if ((info.mode & 0o022) !== 0) return false;
+      accessSync(candidate, constants.X_OK);
+      return true;
+    } catch {
+      return false;
+    }
+  });
+}
+
+function preferPersistent(matches: string[], persistent: string): string[] {
+  return matches.includes(persistent)
+    ? [persistent, ...matches.filter((candidate) => candidate !== persistent)]
+    : matches;
+}
+
+function keychainRepairBackupRef(ref: MacKeychainItemRef): MacKeychainItemRef {
+  const account = createHash("sha256").update(ref.service).update("\0").update(ref.account).digest("hex");
+  return {
+    service: keychainRepairService,
+    account,
+    label: "s-gw Keychain repair backup"
+  };
+}
+
+function keychainGetArgs(ref: MacKeychainItemRef): string[] {
+  return ["get", "--service", ref.service, "--account", ref.account];
+}
+
+function keychainDeleteArgs(ref: MacKeychainItemRef): string[] {
+  return ["delete", "--service", ref.service, "--account", ref.account];
+}
+
+function untrustedKeychainItemError(ref: MacKeychainItemRef): Error {
+  return new Error(
+    `No trusted s-gw helper is available for Keychain account ${ref.account}. ` +
+    "s-gw stopped before requesting your login password. Run `s-gw unlock keychain repair`."
+  );
+}
+
+function withKeychainRepairLock<T>(body: () => T): T {
+  const lockPath = path.join(path.resolve(getSgwHome()), ".keychain-repair.lock");
+  mkdirSync(path.dirname(lockPath), { recursive: true, mode: 0o700 });
+  const started = Date.now();
+
+  while (true) {
+    try {
+      mkdirSync(lockPath, { mode: 0o700 });
+      break;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+      try {
+        if (Date.now() - statSync(lockPath).mtimeMs > staleKeychainRepairMs) {
+          rmSync(lockPath, { recursive: true, force: true });
+          continue;
+        }
+      } catch (statError) {
+        if ((statError as NodeJS.ErrnoException).code === "ENOENT") continue;
+        throw statError;
+      }
+      if (Date.now() - started > keychainRepairTimeoutMs) {
+        throw new Error(`Timed out waiting for Keychain repair lock at ${lockPath}.`);
+      }
+      Atomics.wait(keychainRepairWait, 0, 0, 25);
+    }
+  }
+
+  try {
+    return body();
+  } finally {
+    rmSync(lockPath, { recursive: true, force: true });
+  }
+}
+
+function uniquePaths(values: string[]): string[] {
+  return [...new Set(values.filter(Boolean).map((value) => path.resolve(value)))];
 }
 
 function findWindowsCredentialHelper(): string | undefined {

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const CURRENT_VERSION = "0.1.10";
+export const CURRENT_VERSION = "0.1.11";

--- a/tests/installers.test.ts
+++ b/tests/installers.test.ts
@@ -7,9 +7,10 @@ const root = process.cwd();
 
 describe("platform installers", () => {
   it("builds versioned Mac and Windows artifacts from the package tarball", async () => {
-    const [pkgRaw, builder] = await Promise.all([
+    const [pkgRaw, builder, inspectorSource] = await Promise.all([
       readFile(path.join(root, "package.json"), "utf8"),
-      readFile(path.join(root, "scripts/build-installers.mjs"), "utf8")
+      readFile(path.join(root, "scripts/build-installers.mjs"), "utf8"),
+      readFile(path.join(root, "native/macos-keychain/SgwKeychainInspector.swift"), "utf8")
     ]);
     const pkg = JSON.parse(pkgRaw);
 
@@ -35,6 +36,8 @@ describe("platform installers", () => {
     expect(builder).toContain("s-gw-${version}-windows.zip");
     expect(builder).toContain('const packageFile = `s-gw-${version}.tgz`');
     expect(builder).toContain("SHA256SUMS.txt");
+    expect(inspectorSource).toContain("validateTrustedApplication");
+    expect(inspectorSource).not.toContain("kSecReturnData");
     const validator = await readFile(path.join(root, "scripts/validate-release-assets.mjs"), "utf8");
     expect(validator).toContain("validateReleaseDirectory");
   });
@@ -62,6 +65,7 @@ describe("platform installers", () => {
     expect(files).not.toContain("dist/native/s-gw-core.exe");
     if (process.platform === "darwin") {
       expect(files).toContain(`dist/native/${target}/s-gw-keychain-helper`);
+      expect(files).toContain(`dist/native/${target}/s-gw-keychain-inspector`);
       expect(files).toContain("dist/s-gw.app/Contents/MacOS/s-gw");
       expect(files).toContain("dist/s-gw Menu Bar.app/Contents/MacOS/s-gw-menu-bar-helper");
     }
@@ -83,6 +87,13 @@ describe("platform installers", () => {
 
     expect(mac).toContain('"$sgw_bin" setup --port 8718');
     expect(mac).toContain('PATH="$npm_prefix/bin:$PATH" "$sgw_bin" setup');
+    expect(mac).toContain('persistent_helper="$sgw_home/native/$keychain_target/s-gw-keychain-helper"');
+    expect(mac).toContain('The existing Keychain helper could not be preserved before upgrade.');
+    expect(mac).toContain('archive_keychain_helper "$candidate"');
+    expect(mac).toContain('archive_keychain_helper "$installed_helper"');
+    expect(mac).toContain('/usr/bin/shasum -a 256');
+    expect(mac).toContain('installed_helper="$npm_root/@s-gw/s-gw/dist/native/$keychain_target/s-gw-keychain-helper"');
+    expect(mac).toContain('The stable Keychain helper could not be activated after upgrade.');
     expect(windows).toContain('$setupArgs = @("setup", "--port", [string]$Port)');
     expect(combined).toContain("npm");
     expect(combined).not.toContain("SGW_MASTER_PASSPHRASE");

--- a/tests/installers.test.ts
+++ b/tests/installers.test.ts
@@ -38,6 +38,8 @@ describe("platform installers", () => {
     expect(builder).toContain("SHA256SUMS.txt");
     expect(inspectorSource).toContain("validateTrustedApplication");
     expect(inspectorSource).not.toContain("kSecReturnData");
+    const publishWorkflow = await readFile(path.join(root, ".github/workflows/publish.yml"), "utf8");
+    expect(publishWorkflow).toContain("dist/native/darwin-arm64/s-gw-keychain-inspector");
     const validator = await readFile(path.join(root, "scripts/validate-release-assets.mjs"), "utf8");
     expect(validator).toContain("validateReleaseDirectory");
   });

--- a/tests/package-update.test.ts
+++ b/tests/package-update.test.ts
@@ -98,7 +98,15 @@ describe("scoped package migration", () => {
     const tarballs = path.join(tmp, "tarballs");
     await mkdir(tarballs, { recursive: true });
     const oldTarball = await packageFixture(tmp, tarballs, "old-scoped", "@s-gw/s-gw", "0.1.8");
-    const nextTarball = await packageFixture(tmp, tarballs, "next-scoped", "@s-gw/s-gw", CURRENT_VERSION);
+    const nextHelperIdentity = "new helper identity\n";
+    const nextTarball = await packageFixture(
+      tmp,
+      tarballs,
+      "next-scoped",
+      "@s-gw/s-gw",
+      CURRENT_VERSION,
+      nextHelperIdentity
+    );
     await npm(["install", "--global", "--prefix", npmPrefix, "--ignore-scripts", "--", oldTarball]);
 
     const before = await inspectGlobalSgwInstall({ npmPrefix });
@@ -113,7 +121,7 @@ describe("scoped package migration", () => {
     await writeFile(oldHelper, "trusted helper identity\n");
     await chmod(oldHelper, 0o755);
 
-    await installPackageUpdate({
+    const result = await installPackageUpdate({
       target: nextTarball,
       npmPrefix,
       sgwHome,
@@ -129,6 +137,25 @@ describe("scoped package migration", () => {
     );
     expect(await readFile(persistent, "utf8")).toBe("trusted helper identity\n");
     expect((await stat(persistent)).mode & 0o777).toBe(0o700);
+    const installedHelper = path.join(
+      result.installed.scoped?.packageRoot || "",
+      "dist",
+      "native",
+      `${process.platform}-${process.arch}`,
+      "s-gw-keychain-helper"
+    );
+    expect(result.keychainCompatibility?.packagePath).toBe(installedHelper);
+    expect(await readFile(installedHelper, "utf8")).toBe("trusted helper identity\n");
+    const nextHash = createHash("sha256").update(nextHelperIdentity).digest("hex");
+    const archivedHelper = path.join(
+      sgwHome,
+      "native",
+      "legacy",
+      nextHash,
+      "s-gw-keychain-helper"
+    );
+    expect(await readFile(archivedHelper, "utf8")).toBe(nextHelperIdentity);
+    expect((await stat(archivedHelper)).mode & 0o777).toBe(0o700);
   }, 30_000);
 
   it("exposes the migration plan and top-level install result through the CLI", async () => {
@@ -683,7 +710,8 @@ async function packageFixture(
   outputDir: string,
   folder: string,
   name: string,
-  version: string
+  version: string,
+  nativeHelper?: string
 ): Promise<string> {
   const packageDir = path.join(root, folder);
   await mkdir(packageDir, { recursive: true });
@@ -694,6 +722,18 @@ async function packageFixture(
   }, null, 2)}\n`);
   await writeFile(path.join(packageDir, "cli.js"), `#!/usr/bin/env node\nconsole.log(${JSON.stringify(`${name} ${version}`)});\n`);
   await chmod(path.join(packageDir, "cli.js"), 0o755);
+  if (nativeHelper !== undefined) {
+    const helperPath = path.join(
+      packageDir,
+      "dist",
+      "native",
+      `${process.platform}-${process.arch}`,
+      "s-gw-keychain-helper"
+    );
+    await mkdir(path.dirname(helperPath), { recursive: true });
+    await writeFile(helperPath, nativeHelper);
+    await chmod(helperPath, 0o755);
+  }
   const packed = await npm(["pack", "--ignore-scripts", "--json", "--pack-destination", outputDir], packageDir);
   const manifest = JSON.parse(packed.stdout) as Array<{ filename: string }>;
   return path.join(outputDir, manifest[0].filename);

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -275,6 +275,12 @@ describe("SecretStore", () => {
     expect(handles[0].backend).toBe("keychain");
     expect(handles[0].provider).toBe("macos-keychain");
 
+    expect(await store.repairKeychainAccess()).toMatchObject({
+      checked: 1,
+      unsupported: 1,
+      failed: []
+    });
+
     const request = await store.createRequest(
       record.handle,
       buildEnvCommandAction({

--- a/tests/unlock.test.ts
+++ b/tests/unlock.test.ts
@@ -1,12 +1,17 @@
-import { chmod, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { chmod, mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { requirePassphrase } from "../src/crypto.js";
 import {
+  getMacKeychainItem,
   installPersistentKeychainHelper,
   keychainInfo,
+  parseKeychainTrustedApplicationPaths,
   persistentKeychainHelperPath,
+  pinPackagedKeychainHelper,
+  repairMacKeychainItemAccess,
   setKeychainPassphrase,
   unlockStatus
 } from "../src/unlock.js";
@@ -27,11 +32,14 @@ afterEach(async () => {
   delete process.env.SGW_KEYCHAIN_SERVICE;
   delete process.env.SGW_KEYCHAIN_ACCOUNT;
   delete process.env.SGW_KEYCHAIN_HELPER;
+  delete process.env.SGW_KEYCHAIN_INSPECTOR;
+  delete process.env.SGW_KEYCHAIN_LEGACY_HELPERS;
   delete process.env.SGW_KEYCHAIN_STATUS_CLI;
   delete process.env.SGW_FAKE_KEYCHAIN_VALUE;
   delete process.env.SGW_FAKE_KEYCHAIN_CAPTURE;
   delete process.env.SGW_FAKE_KEYCHAIN_GET_DENIED;
   delete process.env.SGW_FAKE_SECURITY_CAPTURE;
+  delete process.env.SGW_FAKE_KEYCHAIN_DB;
   delete process.env.SGW_HOME;
   if (tmpDir) {
     await rm(tmpDir, { recursive: true, force: true });
@@ -123,9 +131,157 @@ describe("unlock passphrase provider", () => {
     expect(second).toMatchObject({ helperPath, changed: false });
     expect(await readFile(helperPath, "utf8")).toBe("trusted helper\n");
     expect((await stat(helperPath)).mode & 0o777).toBe(0o700);
+    const replacementHash = createHash("sha256").update("new helper\n").digest("hex");
+    const archivedReplacement = path.join(
+      sgwHome,
+      "native",
+      "legacy",
+      replacementHash,
+      "s-gw-keychain-helper"
+    );
+    expect(await readFile(archivedReplacement, "utf8")).toBe("new helper\n");
+    expect((await stat(archivedReplacement)).mode & 0o777).toBe(0o700);
 
     process.env.SGW_HOME = sgwHome;
     expect(keychainInfo().helperPath).toBe(helperPath);
+  });
+
+  it("pins the persistent identity at the package path used by stale agent sessions", async () => {
+    if (process.platform !== "darwin") return;
+
+    const sgwHome = path.join(tmpDir, "home");
+    const packageRoot = path.join(tmpDir, "package");
+    const original = path.join(tmpDir, "original-helper");
+    const packageHelper = path.join(
+      packageRoot,
+      "dist",
+      "native",
+      `${process.platform}-${process.arch}`,
+      "s-gw-keychain-helper"
+    );
+    await writeFile(original, "stable helper identity\n");
+    await chmod(original, 0o755);
+    await mkdir(path.dirname(packageHelper), { recursive: true });
+    await writeFile(packageHelper, "replacement helper identity\n");
+    await chmod(packageHelper, 0o755);
+    process.env.SGW_HOME = sgwHome;
+    installPersistentKeychainHelper({ sourcePath: original, sgwHome });
+
+    expect(pinPackagedKeychainHelper(packageRoot)).toMatchObject({
+      sourcePath: persistentKeychainHelperPath(sgwHome),
+      packagePath: packageHelper,
+      changed: true
+    });
+    expect(await readFile(packageHelper, "utf8")).toBe("stable helper identity\n");
+    expect((await stat(packageHelper)).mode & 0o777).toBe(0o755);
+    const packageHash = createHash("sha256").update("replacement helper identity\n").digest("hex");
+    const archivedPackageHelper = path.join(
+      sgwHome,
+      "native",
+      "legacy",
+      packageHash,
+      "s-gw-keychain-helper"
+    );
+    expect(await readFile(archivedPackageHelper, "utf8")).toBe("replacement helper identity\n");
+    expect((await stat(archivedPackageHelper)).mode & 0o777).toBe(0o700);
+  });
+
+  it("rebinds a legacy Keychain item to the persistent helper without prompting", async () => {
+    if (process.platform !== "darwin") return;
+
+    const service = "com.s-gw.test.secret";
+    const account = "s-gw:test:legacy";
+    const value = "disposable-keychain-value";
+    const harness = await installRepairHarness({ service, account, value });
+
+    const result = repairMacKeychainItemAccess({ service, account, label: "test secret" });
+    expect(result).toEqual({ state: "migrated", helperPath: harness.persistent });
+    expect(getMacKeychainItem({ service, account })).toBe(value);
+
+    const db = JSON.parse(await readText(harness.dbPath));
+    expect(db.items[`${service}\u0000${account}`].trustedIdentity).toBe(await helperIdentity(harness.persistent));
+    expect(Object.keys(db.items).some((key) => key.startsWith("com.s-gw.sgw.keychain-repair\u0000"))).toBe(false);
+  });
+
+  it("recovers an original item from a verified repair backup", async () => {
+    if (process.platform !== "darwin") return;
+
+    const service = "com.s-gw.test.secret";
+    const account = "s-gw:test:interrupted";
+    const value = "recoverable-keychain-value";
+    const harness = await installRepairHarness({ service, account, value });
+    const db = JSON.parse(await readText(harness.dbPath));
+    delete db.items[`${service}\u0000${account}`];
+    const backupAccount = createHash("sha256").update(service).update("\0").update(account).digest("hex");
+    db.items[`com.s-gw.sgw.keychain-repair\u0000${backupAccount}`] = {
+      value,
+      trustedIdentity: await helperIdentity(harness.persistent)
+    };
+    await writeFile(harness.dbPath, JSON.stringify(db));
+
+    expect(repairMacKeychainItemAccess({ service, account, label: "recovered secret" })).toEqual({
+      state: "recovered",
+      helperPath: harness.persistent
+    });
+    expect(getMacKeychainItem({ service, account })).toBe(value);
+
+    const repaired = JSON.parse(await readText(harness.dbPath));
+    expect(repaired.items[`${service}\u0000${account}`].trustedIdentity).toBe(await helperIdentity(harness.persistent));
+    expect(repaired.items[`com.s-gw.sgw.keychain-repair\u0000${backupAccount}`]).toBeUndefined();
+  });
+
+  it("stops before running a helper when no trusted application can be verified", async () => {
+    if (process.platform !== "darwin") return;
+
+    const service = "com.s-gw.test.secret";
+    const account = "s-gw:test:untrusted";
+    const harness = await installRepairHarness({ service, account, value: "do-not-read" });
+    const db = JSON.parse(await readText(harness.dbPath));
+    db.items[`${service}\u0000${account}`].trustedIdentity = "unavailable-helper-identity";
+    await writeFile(harness.dbPath, JSON.stringify(db));
+
+    expect(() => getMacKeychainItem({ service, account })).toThrow(/stopped before requesting your login password/i);
+  });
+
+  it("reports a blocked master-passphrase ACL instead of hiding it as missing", async () => {
+    if (process.platform !== "darwin") return;
+
+    const harness = await installRepairHarness({
+      service: "com.s-gw.test",
+      account: "unit-test",
+      value: "valid master passphrase"
+    });
+    const db = JSON.parse(await readText(harness.dbPath));
+    db.items["com.s-gw.test\u0000unit-test"].trustedIdentity = "unavailable-helper-identity";
+    await writeFile(harness.dbPath, JSON.stringify(db));
+
+    expect(() => requirePassphrase()).toThrow(/stopped before requesting your login password/i);
+  });
+
+  it("parses only the requested Keychain item's trusted application paths", () => {
+    const dump = `keychain: "/Users/test/login.keychain-db"
+attributes:
+    "acct"<blob>="s-gw:first"
+    "svce"<blob>="com.s-gw.secret"
+access: 1 entries
+    entry 0:
+        applications (1):
+            0: /tmp/first/s-gw-keychain-helper (OK)
+keychain: "/Users/test/login.keychain-db"
+attributes:
+    "acct"<blob>="s-gw:second"
+    "svce"<blob>="com.s-gw.secret"
+access: 1 entries
+    entry 0:
+        applications (2):
+            0: /tmp/second/s-gw-keychain-helper (status -67068)
+            1: /tmp/second copy/s-gw-keychain-helper (OK)
+`;
+
+    expect(parseKeychainTrustedApplicationPaths(dump, "com.s-gw.secret", "s-gw:second")).toEqual([
+      "/tmp/second/s-gw-keychain-helper",
+      "/tmp/second copy/s-gw-keychain-helper"
+    ]);
   });
 
   it("reports a clear unlock error when no provider is configured", async () => {
@@ -190,6 +346,132 @@ process.exit(process.env.SGW_FAKE_KEYCHAIN_VALUE ? 0 : 44);
   );
   await chmod(fakeSecurity, 0o700);
   process.env.SGW_KEYCHAIN_STATUS_CLI = fakeSecurity;
+}
+
+async function installRepairHarness(input: { service: string; account: string; value: string }): Promise<{
+  dbPath: string;
+  legacy: string;
+  persistent: string;
+}> {
+  const sgwHome = path.join(tmpDir, "repair-home");
+  const dbPath = path.join(tmpDir, "repair-keychain.json");
+  const legacy = path.join(tmpDir, "legacy", "s-gw-keychain-helper");
+  const current = path.join(tmpDir, "current", "s-gw-keychain-helper");
+  const inspector = path.join(tmpDir, "s-gw-keychain-inspector");
+  const security = path.join(tmpDir, "security");
+  const itemKey = `${input.service}\u0000${input.account}`;
+  const legacySource = fakeRepairHelperSource();
+  await writeFile(dbPath, JSON.stringify({
+    items: {
+      [itemKey]: {
+        value: input.value,
+        trustedIdentity: createHash("sha256").update(legacySource).digest("hex")
+      }
+    }
+  }));
+  await mkdir(path.dirname(legacy), { recursive: true });
+  await mkdir(path.dirname(current), { recursive: true });
+  await writeFile(legacy, legacySource);
+  await writeFile(current, `${legacySource}\n// current helper identity\n`);
+  await chmod(legacy, 0o700);
+  await chmod(current, 0o700);
+
+  await writeFile(inspector, `#!/usr/bin/env node
+const crypto = require("crypto");
+const fs = require("fs");
+const args = process.argv.slice(2);
+const value = name => args[args.indexOf(name) + 1];
+const candidates = [];
+for (let i = 0; i < args.length; i++) if (args[i] === "--candidate") candidates.push(args[i + 1]);
+const db = JSON.parse(fs.readFileSync(process.env.SGW_FAKE_KEYCHAIN_DB, "utf8"));
+const item = db.items[value("--service") + "\\0" + value("--account")];
+if (!item) process.exit(44);
+const identity = path => {
+  try { return crypto.createHash("sha256").update(fs.readFileSync(path)).digest("hex"); }
+  catch { return ""; }
+};
+process.stdout.write(JSON.stringify({ trustedHelpers: candidates.filter(path => identity(path) === item.trustedIdentity) }) + "\\n");
+`);
+  await chmod(inspector, 0o700);
+
+  await writeFile(security, `#!/usr/bin/env node
+const fs = require("fs");
+const args = process.argv.slice(2);
+const db = JSON.parse(fs.readFileSync(process.env.SGW_FAKE_KEYCHAIN_DB, "utf8"));
+if (args[0] === "find-generic-password") {
+  const account = args[args.indexOf("-a") + 1];
+  const service = args[args.indexOf("-s") + 1];
+  process.exit(db.items[service + "\\0" + account] ? 0 : 44);
+}
+if (args[0] === "dump-keychain") {
+  for (const [key, item] of Object.entries(db.items)) {
+    const split = key.indexOf("\\0");
+    const service = key.slice(0, split);
+    const account = key.slice(split + 1);
+    process.stdout.write('keychain: "test"\\nattributes:\\n');
+    process.stdout.write('    "acct"<blob>="' + account + '"\\n');
+    process.stdout.write('    "svce"<blob>="' + service + '"\\n');
+    process.stdout.write('access: 1 entries\\n    entry 0:\\n        applications (1):\\n');
+    process.stdout.write('            0: /unavailable/s-gw-keychain-helper (status -67068)\\n');
+  }
+  process.exit(0);
+}
+process.exit(2);
+`);
+  await chmod(security, 0o700);
+
+  process.env.SGW_HOME = sgwHome;
+  process.env.SGW_FAKE_KEYCHAIN_DB = dbPath;
+  process.env.SGW_KEYCHAIN_INSPECTOR = inspector;
+  process.env.SGW_KEYCHAIN_LEGACY_HELPERS = legacy;
+  process.env.SGW_KEYCHAIN_STATUS_CLI = security;
+  const persistent = installPersistentKeychainHelper({ sourcePath: current, sgwHome }).helperPath;
+  return { dbPath, legacy, persistent };
+}
+
+function fakeRepairHelperSource(): string {
+  return `#!/usr/bin/env node
+const crypto = require("crypto");
+const fs = require("fs");
+const args = process.argv.slice(2);
+const command = args[0];
+const value = name => args[args.indexOf(name) + 1];
+const key = value("--service") + "\\0" + value("--account");
+const dbPath = process.env.SGW_FAKE_KEYCHAIN_DB;
+const db = JSON.parse(fs.readFileSync(dbPath, "utf8"));
+const item = db.items[key];
+const ownIdentity = crypto.createHash("sha256").update(fs.readFileSync(process.argv[1])).digest("hex");
+if (command === "get") {
+  if (!item) process.exit(44);
+  if (item.trustedIdentity !== ownIdentity) process.exit(70);
+  process.stdout.write(item.value + "\\n");
+  process.exit(0);
+}
+if (command === "delete") {
+  if (!item) process.exit(44);
+  if (item.trustedIdentity !== ownIdentity) process.exit(70);
+  delete db.items[key];
+  fs.writeFileSync(dbPath, JSON.stringify(db));
+  process.exit(0);
+}
+if (command === "set") {
+  let input = "";
+  process.stdin.setEncoding("utf8");
+  process.stdin.on("data", chunk => input += chunk);
+  process.stdin.on("end", () => {
+    if (item && item.trustedIdentity !== ownIdentity) process.exit(70);
+    db.items[key] = { value: input, trustedIdentity: ownIdentity };
+    fs.writeFileSync(dbPath, JSON.stringify(db));
+    process.exit(0);
+  });
+} else {
+  process.exit(2);
+}
+`;
+}
+
+async function helperIdentity(filePath: string): Promise<string> {
+  return createHash("sha256").update(await readFile(filePath)).digest("hex");
 }
 
 async function readText(filePath: string): Promise<string> {


### PR DESCRIPTION
## Summary
- validate each macOS Keychain ACL before invoking a credential helper
- transactionally rebind legacy items to the persistent helper with verified recovery
- preserve superseded helper identities and pin the stable helper for stale MCP sessions
- add `s-gw unlock keychain repair` and ship the metadata-only native inspector

## Verification
- `npm run verify` (32 files, 273 tests)
- `npm run validate:npm-package`
- `npm run build:installers`
- live repair: 54/54 Keychain items already bound, no failures
- live approved GitHub SSH-key execution completed with no SecurityAgent process