### PR TITLE
Keep menu helper running

### DIFF
--- a/src/install.ts
+++ b/src/install.ts
@@ -845,7 +845,7 @@ export function buildMenuBarLaunchAgentPlist(options: MenuBarOptions, logsDir: s
     programArguments: args,
     environment: menuBarEnvironment(options.consoleUrl || consoleUrl(options.port || 8718), options.countMode),
     runAtLoad: true,
-    keepAlive: false,
+    keepAlive: true,
     stdoutPath: path.join(logsDir, "menubar.log"),
     stderrPath: path.join(logsDir, "menubar.err.log"),
     limitToAqua: true

--- a/tests/install.test.ts
+++ b/tests/install.test.ts
@@ -177,6 +177,7 @@ describe("launch-agent packaging", () => {
     expect(plist).toContain("<string>--notify-on-launch</string>");
     expect(plist).toContain("http://127.0.0.1:9900/");
     expect(plist).toContain("<string>Aqua</string>");
+    expect(plist).toContain("<key>KeepAlive</key>\n  <true/>");
     expect(plist).not.toContain("SGW_MASTER_PASSPHRASE");
   });
 


### PR DESCRIPTION
## What changed
- keep the macOS menu helper LaunchAgent alive after a clean singleton handoff exit
- lock the KeepAlive setting with an install-plist regression test

## Root cause
The helper could exit cleanly while an older process still owned the singleton lock. Because the LaunchAgent used KeepAlive=false, launchd never retried after the older process disappeared.

## Verification
- npm run verify
- live launchd termination/respawn test with exactly one helper process