### PR TITLE
Prevent silent credential ledger resets

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,6 +27,8 @@ The TypeScript CLI owns setup, handle enrollment, request creation, approval orc
 
 The ledger stores handle metadata, encrypted local values or credential-store pointers, request manifests, reusable grants, policy rules, and audit events. Its unlock material comes from the operating system credential store during normal desktop use. `SGW_MASTER_PASSPHRASE` exists for tests and controlled automation.
 
+Control-plane changes use a pending transaction marker and fingerprinted manifest. Compact encrypted checkpoints are retained both inside the s-gw home and in a sibling recovery home, so loss of the ledger or the entire primary home does not silently become a new empty installation. Request-only writes use the rolling backup ring but do not consume control-plane checkpoint retention. A mismatched, corrupt, or missing ledger is quarantined when available and recovered from a verified checkpoint; s-gw refuses an empty reset when recovery evidence exists but cannot be validated.
+
 ### Credential Backends
 
 - **macOS Keychain:** the preferred backend on macOS.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -262,6 +262,16 @@ Default local ledger:
 ~/.s-gw/store.json
 ```
 
+Independent encrypted recovery checkpoints:
+
+```text
+~/.s-gw-recovery/control-plane/
+```
+
+The recovery checkpoints contain credential records, approval settings, grants, and policy rules. They omit request history, audit history, and cached values, which keeps them small and prevents high-volume request traffic from rotating away the last usable control-plane state. s-gw also keeps ordinary rolling backups under `~/.s-gw/backups/`.
+
+Every committed control-plane change updates an integrity manifest through a pending transaction record. If the primary ledger is missing, corrupt, or replaced with a different valid ledger, s-gw restores a verified checkpoint and records `store.recovered`. If recovery evidence exists but no valid copy remains, s-gw fails closed instead of initializing an empty ledger.
+
 Default Keychain item:
 
 ```text
@@ -273,6 +283,7 @@ Environment overrides:
 
 ```bash
 export SGW_HOME="$HOME/.s-gw"
+export SGW_RECOVERY_HOME="$HOME/.s-gw-recovery"
 export SGW_KEYCHAIN_SERVICE="com.s-gw.sgw.master-passphrase"
 export SGW_KEYCHAIN_ACCOUNT="$USER"
 ```

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -15,7 +15,26 @@ export function expandHome(inputPath: string): string {
 }
 
 export function getSgwHome(): string {
-  return path.resolve(expandHome(process.env.SGW_HOME || "~/.s-gw"));
+  const home = path.resolve(expandHome(process.env.SGW_HOME || "~/.s-gw"));
+  if (process.env.SGW_TEST_MODE === "1") {
+    const liveHome = path.resolve(process.env.SGW_TEST_LIVE_HOME || path.join(os.homedir(), ".s-gw"));
+    if (home === liveHome) {
+      throw new Error(`Refusing to use the live s-gw home while tests are running: ${home}`);
+    }
+  }
+  return home;
+}
+
+export function getSgwRecoveryHome(home = getSgwHome()): string {
+  const recoveryHome = path.resolve(expandHome(process.env.SGW_RECOVERY_HOME || `${home}-recovery`));
+  if (process.env.SGW_TEST_MODE === "1") {
+    const liveHome = path.resolve(process.env.SGW_TEST_LIVE_HOME || path.join(os.homedir(), ".s-gw"));
+    const liveRecoveryHome = path.resolve(process.env.SGW_TEST_LIVE_RECOVERY_HOME || `${liveHome}-recovery`);
+    if (recoveryHome === liveRecoveryHome) {
+      throw new Error(`Refusing to use the live s-gw recovery home while tests are running: ${recoveryHome}`);
+    }
+  }
+  return recoveryHome;
 }
 
 export function getStorePath(home = getSgwHome()): string {

--- a/src/store.ts
+++ b/src/store.ts
@@ -7,7 +7,7 @@ import { decryptSecret, encryptSecret, fingerprintSecret, shortId } from "./cryp
 import { requestAgentIdentity, requestAgentName, type AgentIdentityContext } from "./agent-context.js";
 import { normalizeOnePasswordReference, readOnePasswordReference } from "./onepassword.js";
 import { SGW_SSH_SESSION_COMMAND, normalizeSshPort, normalizeSshTarget, sshSessionIdentity } from "./ssh.js";
-import { ensureSgwHome, getSgwHome, getStorePath } from "./paths.js";
+import { ensureSgwHome, getSgwHome, getSgwRecoveryHome, getStorePath } from "./paths.js";
 import {
   defaultSecretKeychainService,
   deleteMacKeychainItem,
@@ -55,6 +55,10 @@ const staleLockMs = 30_000;
 // so we reap it back to a terminal failed state instead of bricking it forever.
 const staleExecutionMs = 10 * 60 * 1000;
 const maxStoreBackups = 20;
+const maxControlPlaneBackups = 50;
+const storeMarkerName = ".store-initialized";
+const controlStateName = ".store-control.json";
+const pendingControlStateName = ".store-control.pending.json";
 
 const emptyStore = (): StoreFile => ({
   version: 1,
@@ -162,6 +166,26 @@ export interface KeychainAccessRepairSummary {
   failed: Array<{ handle: string; name: string; error: string }>;
 }
 
+interface StoreControlState {
+  version: 1;
+  fingerprint: string;
+  updatedAt: string;
+  secrets: number;
+  approvalPolicyRules: number;
+}
+
+interface PendingStoreControlState {
+  version: 1;
+  previousFingerprint?: string;
+  nextFingerprint: string;
+  createdAt: string;
+}
+
+interface RecoveryCandidate {
+  path: string;
+  modifiedAtMs: number;
+}
+
 export class SecretStore {
   readonly home: string;
   readonly storePath: string;
@@ -174,13 +198,7 @@ export class SecretStore {
   async init(): Promise<void> {
     await ensureSgwHome(this.home);
     await this.withStoreLock(async () => {
-      const exists = await this.exists();
-      if (exists) {
-        return;
-      }
-
-      await this.writeUnlocked(emptyStore());
-      await chmod(this.storePath, 0o600);
+      await this.loadOrRecoverUnlocked();
     });
   }
 
@@ -926,45 +944,149 @@ export class SecretStore {
   }
 
   private async read(): Promise<StoreFile> {
-    const exists = await this.exists();
-    if (!exists) {
-      await this.init();
+    if (await this.exists()) {
+      try {
+        const store = await this.readUnlocked();
+        if (await controlStateMatches(this.home, store)) {
+          return store;
+        }
+      } catch {
+        // Recovery runs under the store lock below.
+      }
     }
 
-    return this.readUnlocked();
+    await ensureSgwHome(this.home);
+    return this.withStoreLock(() => this.loadOrRecoverUnlocked());
   }
 
   private async readUnlocked(): Promise<StoreFile> {
     const raw = await readFile(this.storePath, "utf8");
-    const parsed = JSON.parse(raw) as Partial<StoreFile>;
-    if (parsed.version !== 1 || !Array.isArray(parsed.secrets) || !Array.isArray(parsed.requests)) {
-      throw new Error(`Invalid s-gw store at ${this.storePath}`);
-    }
-
-    return normalizeStoreFile(parsed);
+    return parseStoreFile(raw, this.storePath);
   }
 
   private async writeUnlocked(store: StoreFile): Promise<void> {
     await ensureSgwHome(this.home);
+    const previous = await readStoreFileIfValid(this.storePath);
+    const previousFingerprint = previous ? controlPlaneFingerprint(previous) : undefined;
+    const nextFingerprint = controlPlaneFingerprint(store);
+    const controlChanged = previousFingerprint !== nextFingerprint;
+
+    if (controlChanged) {
+      await writePendingControlState(this.home, {
+        version: 1,
+        previousFingerprint,
+        nextFingerprint,
+        createdAt: new Date().toISOString()
+      });
+    }
+
     await backupCurrentStore(this.home, this.storePath);
-    const tmpPath = path.join(this.home, `.store.${process.pid}.${Date.now()}.tmp`);
-    await writeFile(tmpPath, `${JSON.stringify(store, null, 2)}\n`, { mode: 0o600 });
-    await rename(tmpPath, this.storePath);
-    await chmod(this.storePath, 0o600);
+    const serialized = serializeStore(store);
+    await writeAtomicFile(this.storePath, serialized);
+
+    const controlState = await readControlState(this.home);
+    if (controlChanged || !controlState) {
+      await writeControlPlaneCheckpoint(this.home, store, nextFingerprint);
+      await writeControlState(this.home, controlStateFor(store, nextFingerprint));
+      await unlink(pendingControlStatePath(this.home)).catch(() => undefined);
+    }
+    await ensureStoreMarker(this.home);
   }
 
   private async mutate<T>(updater: (store: StoreFile) => T | Promise<T>): Promise<T> {
     await ensureSgwHome(this.home);
     return this.withStoreLock(async () => {
-      if (!(await this.exists())) {
-        await this.writeUnlocked(emptyStore());
-      }
-
-      const store = await this.readUnlocked();
+      const store = await this.loadOrRecoverUnlocked();
       const result = await updater(store);
       await this.writeUnlocked(store);
       return result;
     });
+  }
+
+  private async loadOrRecoverUnlocked(): Promise<StoreFile> {
+    const manifest = await readControlState(this.home);
+    if (!(await this.exists())) {
+      const recovered = await recoverStoreFromBackups(this.home, this.storePath, manifest?.fingerprint);
+      if (recovered) {
+        return recovered;
+      }
+
+      if (manifest || await hasStoreMarker(this.home) || await hasRecoveryEvidence(this.home)) {
+        throw new Error(
+          `s-gw store is missing at ${this.storePath}; refusing to create an empty ledger because recovery evidence exists.`
+        );
+      }
+
+      const fresh = emptyStore();
+      await this.writeUnlocked(fresh);
+      return fresh;
+    }
+
+    let store: StoreFile;
+    try {
+      store = await this.readUnlocked();
+    } catch (error) {
+      await preserveUnavailableStore(this.home, this.storePath, "invalid");
+      const recovered = await recoverStoreFromBackups(this.home, this.storePath, manifest?.fingerprint);
+      if (recovered) {
+        return recovered;
+      }
+      throw new Error(`s-gw store is invalid and no verified recovery copy is available: ${errorMessage(error)}`);
+    }
+
+    const fingerprint = controlPlaneFingerprint(store);
+    const pending = await readPendingControlState(this.home);
+    if (!manifest) {
+      if (pending?.nextFingerprint === fingerprint) {
+        await initializeControlState(this.home, store);
+        return store;
+      }
+
+      const priorControlState = await fileExists(controlStatePath(this.home)) || await hasStoreMarker(this.home);
+      if (priorControlState) {
+        if (await hasRecoveryCandidateFingerprint(this.home, fingerprint)) {
+          await writeControlState(this.home, controlStateFor(store, fingerprint));
+          await unlink(pendingControlStatePath(this.home)).catch(() => undefined);
+          await ensureStoreMarker(this.home);
+          return store;
+        }
+
+        await preserveUnavailableStore(this.home, this.storePath, "missing-control-state");
+        const recovered = await recoverStoreFromBackups(this.home, this.storePath);
+        if (recovered) {
+          return recovered;
+        }
+        throw new Error("s-gw store control manifest is unavailable and no verified recovery copy exists.");
+      }
+
+      await initializeControlState(this.home, store);
+      return store;
+    }
+
+    if (fingerprint === manifest.fingerprint) {
+      await unlink(pendingControlStatePath(this.home)).catch(() => undefined);
+      await ensureStoreMarker(this.home);
+      return store;
+    }
+
+    if (pending?.nextFingerprint === fingerprint) {
+      const serialized = serializeStore(store);
+      await writeControlPlaneCheckpoint(this.home, store, fingerprint);
+      await writeControlState(this.home, controlStateFor(store, fingerprint));
+      await unlink(pendingControlStatePath(this.home)).catch(() => undefined);
+      await ensureStoreMarker(this.home);
+      return store;
+    }
+
+    await preserveUnavailableStore(this.home, this.storePath, "control-mismatch");
+    const recovered = await recoverStoreFromBackups(this.home, this.storePath, manifest.fingerprint);
+    if (recovered) {
+      return recovered;
+    }
+
+    throw new Error(
+      `s-gw store control state changed outside a committed transaction; refusing to use or replace the ledger.`
+    );
   }
 
   private async withStoreLock<T>(body: () => Promise<T>): Promise<T> {
@@ -995,6 +1117,343 @@ export class SecretStore {
       await unlink(lockPath).catch(() => undefined);
     }
   }
+}
+
+function storeMarkerPath(home: string): string {
+  return path.join(home, storeMarkerName);
+}
+
+function controlStatePath(home: string): string {
+  return path.join(home, controlStateName);
+}
+
+function pendingControlStatePath(home: string): string {
+  return path.join(home, pendingControlStateName);
+}
+
+function controlPlaneBackupDir(home: string): string {
+  return path.join(home, "backups", "control-plane");
+}
+
+function externalControlPlaneBackupDir(home: string): string {
+  return path.join(getSgwRecoveryHome(home), "control-plane");
+}
+
+function serializeStore(store: StoreFile): string {
+  return `${JSON.stringify(store, null, 2)}\n`;
+}
+
+function parseStoreFile(raw: string, source: string): StoreFile {
+  let parsed: Partial<StoreFile>;
+  try {
+    parsed = JSON.parse(raw) as Partial<StoreFile>;
+  } catch {
+    throw new Error(`Invalid JSON in s-gw store at ${source}`);
+  }
+  if (parsed.version !== 1 || !Array.isArray(parsed.secrets) || !Array.isArray(parsed.requests)) {
+    throw new Error(`Invalid s-gw store at ${source}`);
+  }
+  return normalizeStoreFile(parsed);
+}
+
+async function readStoreFileIfValid(storePath: string): Promise<StoreFile | undefined> {
+  try {
+    return parseStoreFile(await readFile(storePath, "utf8"), storePath);
+  } catch {
+    return undefined;
+  }
+}
+
+function controlPlaneFingerprint(store: StoreFile): string {
+  const secrets = store.secrets.map((secret) => {
+    const copy = { ...secret };
+    delete copy.cache;
+    return copy;
+  }).sort((a, b) => a.handle.localeCompare(b.handle));
+  const grants = [...store.approvalGrants].sort((a, b) => a.id.localeCompare(b.id));
+  const rules = [...store.approvalPolicyRules].sort((a, b) => a.id.localeCompare(b.id));
+  const control = {
+    version: store.version,
+    secrets,
+    approvalSettings: store.approvalSettings,
+    approvalGrants: grants,
+    approvalPolicyRules: rules
+  };
+  return createHash("sha256").update(JSON.stringify(canonicalValue(control))).digest("hex");
+}
+
+function controlPlaneSnapshot(store: StoreFile): StoreFile {
+  const secrets = store.secrets.map((secret) => {
+    const copy = { ...secret };
+    delete copy.cache;
+    return copy;
+  });
+  return {
+    version: store.version,
+    secrets,
+    requests: [],
+    audit: [],
+    approvalSettings: store.approvalSettings,
+    approvalGrants: store.approvalGrants,
+    approvalPolicyRules: store.approvalPolicyRules
+  };
+}
+
+function canonicalValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(canonicalValue);
+  }
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+  const input = value as Record<string, unknown>;
+  const output: Record<string, unknown> = {};
+  for (const key of Object.keys(input).sort()) {
+    if (input[key] !== undefined) {
+      output[key] = canonicalValue(input[key]);
+    }
+  }
+  return output;
+}
+
+function controlStateFor(store: StoreFile, fingerprint = controlPlaneFingerprint(store)): StoreControlState {
+  return {
+    version: 1,
+    fingerprint,
+    updatedAt: new Date().toISOString(),
+    secrets: store.secrets.length,
+    approvalPolicyRules: store.approvalPolicyRules.length
+  };
+}
+
+async function controlStateMatches(home: string, store: StoreFile): Promise<boolean> {
+  const manifest = await readControlState(home);
+  if (!manifest || await fileExists(pendingControlStatePath(home))) {
+    return false;
+  }
+  return manifest.fingerprint === controlPlaneFingerprint(store);
+}
+
+async function readControlState(home: string): Promise<StoreControlState | undefined> {
+  try {
+    const value = JSON.parse(await readFile(controlStatePath(home), "utf8")) as Partial<StoreControlState>;
+    if (
+      value.version !== 1 ||
+      typeof value.fingerprint !== "string" || !/^[a-f0-9]{64}$/.test(value.fingerprint) ||
+      typeof value.updatedAt !== "string" ||
+      typeof value.secrets !== "number" ||
+      typeof value.approvalPolicyRules !== "number"
+    ) {
+      return undefined;
+    }
+    return value as StoreControlState;
+  } catch {
+    return undefined;
+  }
+}
+
+async function readPendingControlState(home: string): Promise<PendingStoreControlState | undefined> {
+  try {
+    const value = JSON.parse(await readFile(pendingControlStatePath(home), "utf8")) as Partial<PendingStoreControlState>;
+    if (
+      value.version !== 1 ||
+      typeof value.nextFingerprint !== "string" || !/^[a-f0-9]{64}$/.test(value.nextFingerprint) ||
+      typeof value.createdAt !== "string" ||
+      (value.previousFingerprint !== undefined && !/^[a-f0-9]{64}$/.test(value.previousFingerprint))
+    ) {
+      return undefined;
+    }
+    return value as PendingStoreControlState;
+  } catch {
+    return undefined;
+  }
+}
+
+async function writeControlState(home: string, state: StoreControlState): Promise<void> {
+  await writeAtomicFile(controlStatePath(home), `${JSON.stringify(state, null, 2)}\n`);
+}
+
+async function writePendingControlState(home: string, state: PendingStoreControlState): Promise<void> {
+  await writeAtomicFile(pendingControlStatePath(home), `${JSON.stringify(state, null, 2)}\n`);
+}
+
+async function initializeControlState(home: string, store: StoreFile): Promise<void> {
+  const fingerprint = controlPlaneFingerprint(store);
+  await writeControlPlaneCheckpoint(home, store, fingerprint);
+  await writeControlState(home, controlStateFor(store, fingerprint));
+  await unlink(pendingControlStatePath(home)).catch(() => undefined);
+  await ensureStoreMarker(home);
+}
+
+async function writeControlPlaneCheckpoint(home: string, store: StoreFile, fingerprint: string): Promise<void> {
+  const serialized = serializeStore(controlPlaneSnapshot(store));
+  const backupDirs = new Set([
+    controlPlaneBackupDir(home),
+    externalControlPlaneBackupDir(home)
+  ]);
+  for (const backupDir of backupDirs) {
+    await mkdir(backupDir, { recursive: true, mode: 0o700 });
+    const stamp = new Date().toISOString().replace(/[-:.]/g, "").slice(0, 15);
+    const checkpointPath = path.join(
+      backupDir,
+      `store-${stamp}-${fingerprint.slice(0, 12)}-${process.pid}-${Date.now()}.json`
+    );
+    await writeFile(checkpointPath, serialized, { mode: 0o600 });
+    const entries = await listJsonFiles(backupDir);
+    for (const entry of entries.slice(maxControlPlaneBackups)) {
+      await rm(entry.path, { force: true }).catch(() => undefined);
+    }
+  }
+}
+
+async function writeAtomicFile(targetPath: string, content: string): Promise<void> {
+  const tmpPath = path.join(
+    path.dirname(targetPath),
+    `.${path.basename(targetPath)}.${process.pid}.${Date.now()}.tmp`
+  );
+  await writeFile(tmpPath, content, { mode: 0o600 });
+  try {
+    await rename(tmpPath, targetPath);
+    await chmod(targetPath, 0o600);
+  } catch (error) {
+    await rm(tmpPath, { force: true }).catch(() => undefined);
+    throw error;
+  }
+}
+
+async function ensureStoreMarker(home: string): Promise<void> {
+  let handle: Awaited<ReturnType<typeof open>> | undefined;
+  try {
+    handle = await open(storeMarkerPath(home), "wx", 0o600);
+    await handle.writeFile("s-gw store initialized\n");
+  } catch (error) {
+    if (!isNodeError(error) || error.code !== "EEXIST") {
+      throw error;
+    }
+  } finally {
+    await handle?.close().catch(() => undefined);
+  }
+}
+
+async function hasStoreMarker(home: string): Promise<boolean> {
+  return fileExists(storeMarkerPath(home));
+}
+
+async function hasRecoveryEvidence(home: string): Promise<boolean> {
+  return (await listRecoveryCandidates(home)).length > 0;
+}
+
+async function hasRecoveryCandidateFingerprint(home: string, requiredFingerprint: string): Promise<boolean> {
+  const candidates = await listRecoveryCandidates(home);
+  for (const candidate of candidates) {
+    try {
+      const store = parseStoreFile(await readFile(candidate.path, "utf8"), candidate.path);
+      if (controlPlaneFingerprint(store) === requiredFingerprint) {
+        return true;
+      }
+    } catch {
+      continue;
+    }
+  }
+  return false;
+}
+
+async function recoverStoreFromBackups(
+  home: string,
+  storePath: string,
+  requiredFingerprint?: string
+): Promise<StoreFile | undefined> {
+  const candidates = await listRecoveryCandidates(home);
+  for (const candidate of candidates) {
+    let store: StoreFile;
+    try {
+      store = parseStoreFile(await readFile(candidate.path, "utf8"), candidate.path);
+    } catch {
+      continue;
+    }
+    const fingerprint = controlPlaneFingerprint(store);
+    if (requiredFingerprint && fingerprint !== requiredFingerprint) {
+      continue;
+    }
+
+    store.audit.push(audit(
+      "store.recovered",
+      `Recovered the s-gw ledger from ${path.basename(candidate.path)} after the primary store became unavailable.`
+    ));
+    const serialized = serializeStore(store);
+    await writeAtomicFile(storePath, serialized);
+    await writeControlPlaneCheckpoint(home, store, fingerprint);
+    await writeControlState(home, controlStateFor(store, fingerprint));
+    await unlink(pendingControlStatePath(home)).catch(() => undefined);
+    await ensureStoreMarker(home);
+    return store;
+  }
+  return undefined;
+}
+
+async function preserveUnavailableStore(home: string, storePath: string, reason: string): Promise<void> {
+  if (!(await fileExists(storePath))) {
+    return;
+  }
+  const recoveryDir = path.join(home, "recovery", "automatic");
+  await mkdir(recoveryDir, { recursive: true, mode: 0o700 });
+  const stamp = new Date().toISOString().replace(/[-:.]/g, "");
+  const recoveryPath = path.join(recoveryDir, `store-${reason}-${stamp}-${process.pid}.json`);
+  await rename(storePath, recoveryPath);
+  await chmod(recoveryPath, 0o600);
+}
+
+async function listRecoveryCandidates(home: string): Promise<RecoveryCandidate[]> {
+  const dirs = new Set([
+    controlPlaneBackupDir(home),
+    externalControlPlaneBackupDir(home),
+    path.join(home, "backups", "manual"),
+    path.join(home, "backups")
+  ]);
+  const candidates: RecoveryCandidate[] = [];
+  for (const dir of dirs) {
+    const entries = await readdir(dir).catch(() => []);
+    for (const entry of entries) {
+      if (!entry.endsWith(".json")) {
+        continue;
+      }
+      const candidatePath = path.join(dir, entry);
+      const info = await stat(candidatePath).catch(() => undefined);
+      if (info?.isFile()) {
+        candidates.push({ path: candidatePath, modifiedAtMs: info.mtimeMs });
+      }
+    }
+  }
+  return candidates.sort((a, b) => b.modifiedAtMs - a.modifiedAtMs);
+}
+
+async function listJsonFiles(dir: string): Promise<RecoveryCandidate[]> {
+  const entries = await readdir(dir).catch(() => []);
+  const files: RecoveryCandidate[] = [];
+  for (const entry of entries) {
+    if (!entry.endsWith(".json")) {
+      continue;
+    }
+    const entryPath = path.join(dir, entry);
+    const info = await stat(entryPath).catch(() => undefined);
+    if (info?.isFile()) {
+      files.push({ path: entryPath, modifiedAtMs: info.mtimeMs });
+    }
+  }
+  return files.sort((a, b) => b.modifiedAtMs - a.modifiedAtMs);
+}
+
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await access(filePath, constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 async function backupCurrentStore(home: string, storePath: string): Promise<void> {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -64,28 +64,34 @@ describe("command suggestions", () => {
 });
 
 describe("CLI unknown-command behavior (end to end)", () => {
-  it("reports update status without requiring local store setup", () => {
-    const result = JSON.parse(execFileSync(tsxBin, ["src/cli.ts", "update", "check"], {
-      cwd: repoRoot,
-      env: { ...process.env, SGW_DISABLE_UPDATE_CHECK: "1" },
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "pipe"]
-    }));
+  it("reports update status without requiring local store setup", async () => {
+    const home = await mkdtemp(path.join(os.tmpdir(), "sgw-cli-update-"));
+    try {
+      const result = JSON.parse(execFileSync(tsxBin, ["src/cli.ts", "update", "check"], {
+        cwd: repoRoot,
+        env: { ...process.env, SGW_HOME: home, SGW_DISABLE_UPDATE_CHECK: "1" },
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"]
+      }));
 
-    expect(result).toMatchObject({
-      checked: false,
-      currentVersion: CURRENT_VERSION,
-      available: false
-    });
+      expect(result).toMatchObject({
+        checked: false,
+        currentVersion: CURRENT_VERSION,
+        available: false
+      });
+    } finally {
+      await rm(home, { recursive: true, force: true });
+    }
   });
 
-  it("exits non-zero and prints a suggestion to stderr for a typo", () => {
+  it("exits non-zero and prints a suggestion to stderr for a typo", async () => {
+    const home = await mkdtemp(path.join(os.tmpdir(), "sgw-cli-typo-"));
     let stderr = "";
     let code = 0;
     try {
       execFileSync(tsxBin, ["src/cli.ts", "statu"], {
         cwd: repoRoot,
-        env: { ...process.env, SGW_DISABLE_KEYCHAIN: "1" },
+        env: { ...process.env, SGW_HOME: home, SGW_DISABLE_KEYCHAIN: "1" },
         encoding: "utf8",
         stdio: ["ignore", "pipe", "pipe"]
       });
@@ -93,6 +99,8 @@ describe("CLI unknown-command behavior (end to end)", () => {
       const err = error as { status?: number; stderr?: string };
       code = err.status ?? 0;
       stderr = err.stderr ?? "";
+    } finally {
+      await rm(home, { recursive: true, force: true });
     }
 
     expect(code).toBe(1);
@@ -108,13 +116,19 @@ describe("CLI unknown-command behavior (end to end)", () => {
     const port = await new Promise<number>((resolve) => {
       occupier.listen(0, "127.0.0.1", () => resolve((occupier.address() as AddressInfo).port));
     });
+    const home = await mkdtemp(path.join(os.tmpdir(), "sgw-cli-port-"));
 
     let stderr = "";
     let code = 0;
     try {
       execFileSync(tsxBin, ["src/cli.ts", "console", "--port", String(port), "--no-open"], {
         cwd: repoRoot,
-        env: { ...process.env, SGW_DISABLE_KEYCHAIN: "1", SGW_MASTER_PASSPHRASE: "throwaway-eaddr-test" },
+        env: {
+          ...process.env,
+          SGW_HOME: home,
+          SGW_DISABLE_KEYCHAIN: "1",
+          SGW_MASTER_PASSPHRASE: "throwaway-eaddr-test"
+        },
         encoding: "utf8",
         stdio: ["ignore", "pipe", "pipe"]
       });
@@ -124,6 +138,7 @@ describe("CLI unknown-command behavior (end to end)", () => {
       stderr = err.stderr ?? "";
     } finally {
       await new Promise<void>((resolve) => occupier.close(() => resolve()));
+      await rm(home, { recursive: true, force: true });
     }
 
     expect(code).toBe(1);

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,18 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeEach } from "vitest";
+
+const suiteHome = mkdtempSync(path.join(os.tmpdir(), "sgw-vitest-"));
+function useDisposableHomes(): void {
+  process.env.SGW_HOME = suiteHome;
+  delete process.env.SGW_RECOVERY_HOME;
+}
+
+useDisposableHomes();
+beforeEach(useDisposableHomes);
+
+afterAll(() => {
+  rmSync(suiteHome, { recursive: true, force: true });
+  rmSync(`${suiteHome}-recovery`, { recursive: true, force: true });
+});

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -1,4 +1,4 @@
-import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { createHash } from "node:crypto";
 import os from "node:os";
 import path from "node:path";
@@ -26,19 +26,25 @@ beforeEach(async () => {
   tmpHome = await mkdtemp(path.join(os.tmpdir(), "sgw-test-"));
   process.env.SGW_HOME = tmpHome;
   process.env.SGW_MASTER_PASSPHRASE = "local test passphrase";
+  process.env.SGW_DISABLE_KEYCHAIN = "1";
+  process.env.SGW_DISABLE_ONEPASSWORD_BACKUP = "1";
 });
 
 afterEach(async () => {
   delete process.env.SGW_HOME;
   delete process.env.SGW_MASTER_PASSPHRASE;
+  delete process.env.SGW_DISABLE_KEYCHAIN;
+  delete process.env.SGW_DISABLE_ONEPASSWORD_BACKUP;
   delete process.env.SGW_OP_CLI;
   delete process.env.SGW_ONEPASSWORD_TIMEOUT_MS;
   delete process.env.SGW_KEYCHAIN_HELPER;
   delete process.env.SGW_SECRET_KEYCHAIN_SERVICE;
   delete process.env.SGW_LOGIN_SESSION_ID;
+  delete process.env.SGW_RECOVERY_HOME;
   delete process.env.AWS_SECRET_ACCESS_KEY;
   if (tmpHome) {
     await rm(tmpHome, { recursive: true, force: true });
+    await rm(`${tmpHome}-recovery`, { recursive: true, force: true });
   }
 });
 
@@ -118,6 +124,196 @@ describe("SecretStore", () => {
     expect(backupText).not.toContain(firstSecret);
     expect(backupText).not.toContain(secondSecret);
     expect(backupText).not.toContain("op://");
+  });
+
+  it("recovers a missing ledger without losing credentials or approval policies", async () => {
+    const store = new SecretStore();
+    const secret = await store.addSecret({
+      name: "recovery token",
+      type: "api-token",
+      value: fakeOpenAiToken("missing_store_recovery"),
+      policy: { injectEnv: "RECOVERY_TOKEN", allowedCommands: [process.execPath] }
+    });
+    const rule = await store.addApprovalPolicyRule({
+      name: "Allow Codex recovery test",
+      decision: "allow",
+      conditions: { agents: ["codex"] }
+    });
+
+    await rm(store.storePath);
+
+    const recovered = new SecretStore();
+    expect((await recovered.listHandles()).map((item) => item.handle)).toContain(secret.handle);
+    expect((await recovered.listApprovalPolicyRules()).map((item) => item.id)).toContain(rule.id);
+    expect((await recovered.auditLog()).some((event) => event.type === "store.recovered")).toBe(true);
+  });
+
+  it("recovers credentials and policies after the entire primary home is removed", async () => {
+    const store = new SecretStore();
+    const secret = await store.addSecret({
+      name: "external recovery token",
+      type: "api-token",
+      value: fakeOpenAiToken("external_recovery"),
+      policy: { injectEnv: "EXTERNAL_RECOVERY_TOKEN", allowedCommands: [process.execPath] }
+    });
+    const rule = await store.addApprovalPolicyRule({
+      name: "External recovery policy",
+      decision: "allow",
+      conditions: { agents: ["codex"] }
+    });
+
+    await rm(tmpHome, { recursive: true, force: true });
+
+    const recovered = new SecretStore();
+    expect((await recovered.listHandles()).map((item) => item.handle)).toContain(secret.handle);
+    expect((await recovered.listApprovalPolicyRules()).map((item) => item.id)).toContain(rule.id);
+  });
+
+  it("rejects an externally replaced ledger and restores the verified control state", async () => {
+    const store = new SecretStore();
+    const secret = await store.addSecret({
+      name: "replacement guard token",
+      type: "api-token",
+      value: fakeOpenAiToken("replacement_guard"),
+      policy: { injectEnv: "REPLACEMENT_GUARD_TOKEN", allowedCommands: [process.execPath] }
+    });
+    const rule = await store.addApprovalPolicyRule({
+      name: "Replacement guard policy",
+      decision: "allow",
+      conditions: { agents: ["codex"] }
+    });
+    await writeFile(store.storePath, `${JSON.stringify({
+      version: 1,
+      secrets: [],
+      requests: [],
+      audit: [],
+      approvalSettings: { mode: "per-transaction", durationMs: 15 * 60 * 1000 },
+      approvalGrants: [],
+      approvalPolicyRules: []
+    }, null, 2)}\n`);
+
+    const recovered = new SecretStore();
+    expect((await recovered.listHandles()).map((item) => item.handle)).toContain(secret.handle);
+    expect((await recovered.listApprovalPolicyRules()).map((item) => item.id)).toContain(rule.id);
+
+    const preserved = await readdir(path.join(tmpHome, "recovery", "automatic"));
+    expect(preserved.some((name) => name.includes("control-mismatch"))).toBe(true);
+  });
+
+  it("recovers a corrupt ledger and preserves it for investigation", async () => {
+    const store = new SecretStore();
+    const secret = await store.addSecret({
+      name: "corrupt recovery token",
+      type: "api-token",
+      value: fakeOpenAiToken("corrupt_recovery"),
+      policy: { injectEnv: "CORRUPT_RECOVERY_TOKEN" }
+    });
+    await writeFile(store.storePath, "{not valid json\n");
+
+    const recovered = new SecretStore();
+    expect((await recovered.listHandles()).map((item) => item.handle)).toContain(secret.handle);
+    const preserved = await readdir(path.join(tmpHome, "recovery", "automatic"));
+    expect(preserved.some((name) => name.includes("store-invalid"))).toBe(true);
+  });
+
+  it("rebuilds a missing control manifest only from a matching checkpoint", async () => {
+    const store = new SecretStore();
+    const secret = await store.addSecret({
+      name: "manifest recovery token",
+      type: "api-token",
+      value: fakeOpenAiToken("manifest_recovery"),
+      policy: { injectEnv: "MANIFEST_RECOVERY_TOKEN" }
+    });
+    await rm(path.join(tmpHome, ".store-control.json"));
+
+    const recovered = new SecretStore();
+    expect((await recovered.listHandles()).map((item) => item.handle)).toContain(secret.handle);
+    expect(JSON.parse(await readFile(path.join(tmpHome, ".store-control.json"), "utf8"))).toMatchObject({
+      version: 1,
+      secrets: 1
+    });
+  });
+
+  it("does not rotate control-plane checkpoints for request-only traffic", async () => {
+    const store = new SecretStore();
+    const secret = await store.addSecret({
+      name: "request traffic token",
+      type: "api-token",
+      value: fakeOpenAiToken("request_traffic"),
+      policy: { injectEnv: "REQUEST_TRAFFIC_TOKEN", allowedCommands: [process.execPath] }
+    });
+    const checkpointDir = path.join(tmpHome, "backups", "control-plane");
+    const before = (await readdir(checkpointDir)).length;
+    const action = buildEnvCommandAction({
+      command: process.execPath,
+      args: ["-e", "0"],
+      injectEnv: "REQUEST_TRAFFIC_TOKEN"
+    });
+
+    for (let index = 0; index < 8; index += 1) {
+      await store.createRequest(secret.handle, action, `request traffic ${index}`);
+    }
+
+    expect((await readdir(checkpointDir)).length).toBe(before);
+    await store.addApprovalPolicyRule({
+      name: "New durable policy",
+      decision: "allow",
+      conditions: { agents: ["codex"] }
+    });
+    expect((await readdir(checkpointDir)).length).toBeGreaterThan(before);
+  });
+
+  it("fails closed when recovery evidence exists but no valid ledger remains", async () => {
+    const store = new SecretStore();
+    await store.addSecret({
+      name: "fail closed token",
+      type: "api-token",
+      value: fakeOpenAiToken("fail_closed"),
+      policy: { injectEnv: "FAIL_CLOSED_TOKEN" }
+    });
+    await rm(store.storePath);
+    await rm(path.join(tmpHome, "backups"), { recursive: true, force: true });
+    await rm(`${tmpHome}-recovery`, { recursive: true, force: true });
+
+    await expect(new SecretStore().listHandles()).rejects.toThrow(/refusing to create an empty ledger/i);
+    await expect(readFile(store.storePath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("serializes concurrent recovery so every reader gets the same ledger", async () => {
+    const store = new SecretStore();
+    const secret = await store.addSecret({
+      name: "concurrent recovery token",
+      type: "api-token",
+      value: fakeOpenAiToken("concurrent_recovery"),
+      policy: { injectEnv: "CONCURRENT_RECOVERY_TOKEN" }
+    });
+    await rm(store.storePath);
+
+    const results = await Promise.all(
+      Array.from({ length: 20 }, () => new SecretStore().listHandles())
+    );
+    for (const handles of results) {
+      expect(handles.map((item) => item.handle)).toContain(secret.handle);
+    }
+  });
+
+  it("refuses to use the live s-gw home while running tests", () => {
+    const oldHome = process.env.SGW_HOME;
+    const oldLiveHome = process.env.SGW_TEST_LIVE_HOME;
+    const guardedHome = path.join(tmpHome, "pretend-live-home");
+    process.env.SGW_HOME = guardedHome;
+    process.env.SGW_TEST_LIVE_HOME = guardedHome;
+
+    try {
+      expect(() => new SecretStore()).toThrow(/refusing to use the live s-gw home/i);
+    } finally {
+      process.env.SGW_HOME = oldHome;
+      if (oldLiveHome === undefined) {
+        delete process.env.SGW_TEST_LIVE_HOME;
+      } else {
+        process.env.SGW_TEST_LIVE_HOME = oldLiveHome;
+      }
+    }
   });
 
   it("tokenizes local text with a unique handle representation", async () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,12 +1,19 @@
+import os from "node:os";
+import path from "node:path";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
     environment: "node",
     include: ["tests/**/*.test.ts"],
+    setupFiles: ["tests/setup.ts"],
     restoreMocks: true,
     env: {
-      SGW_DISABLE_UPDATE_CHECK: "1"
+      SGW_DISABLE_UPDATE_CHECK: "1",
+      SGW_DISABLE_KEYCHAIN: "1",
+      SGW_DISABLE_ONEPASSWORD_BACKUP: "1",
+      SGW_TEST_MODE: "1",
+      SGW_TEST_LIVE_HOME: path.join(os.homedir(), ".s-gw")
     }
   }
 });


### PR DESCRIPTION
## Summary
- fail closed when an initialized ledger disappears instead of creating an empty store
- protect credentials, approval settings, grants, and policy rules with transaction fingerprints and compact checkpoints
- keep a second encrypted checkpoint outside the primary s-gw home so whole-home deletion can recover
- quarantine corrupt or externally replaced stores and restore a verified control state
- force every Vitest process and child CLI into a disposable home

## Incident
The replacement ledger began with no prior audit history, proving the old store was absent when s-gw silently initialized an empty one. A later high-volume Lens EKS retry loop rotated the 20-file backup ring, so the original deleting process can no longer be attributed from retained evidence.

## Verification
- `npm run verify`
- 32 Vitest files / 282 tests
- installed-package whole-home deletion and recovery drill
- live macOS app verified at 82 credentials and one enabled policy before and after refresh
- zero npm audit vulnerabilities