### PR TITLE
Prepare 0.1.13 release

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "s-gw",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Local s-gw plugin that lets coding agents use typed secret handles without receiving raw credentials.",
   "author": {
     "name": "Barry Yuan"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,13 +26,17 @@ jobs:
       SGW_RUST_CORE_DIR: ${{ github.workspace }}/.private/sgw-core
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Check out private Rust core
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           repository: barryqy/s-gw-rust-core
           token: ${{ secrets.SGW_CORE_REPO_TOKEN }}
+          ref: ${{ github.event.release.tag_name }}
           path: .private/sgw-core
+          persist-credentials: false
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
@@ -106,6 +110,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
@@ -145,10 +151,22 @@ jobs:
       contents: write
     env:
       RELEASE_TAG: ${{ github.event_name == 'release' && github.ref_name || inputs.release_tag }}
+      SGW_REQUIRE_RUST_CORE: "1"
+      SGW_RUST_CORE_DIR: ${{ github.workspace }}/.private/sgw-core
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
+          persist-credentials: false
           ref: ${{ env.RELEASE_TAG }}
+
+      - name: Check out private Rust core
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          repository: barryqy/s-gw-rust-core
+          token: ${{ secrets.SGW_CORE_REPO_TOKEN }}
+          ref: ${{ env.RELEASE_TAG }}
+          path: .private/sgw-core
+          persist-credentials: false
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
@@ -164,6 +182,7 @@ jobs:
           test "v${package_version}" = "${RELEASE_TAG}"
 
       - run: npm run verify
+      - run: npm run validate:npm-package
       - run: npm run build:installers
 
       - name: Upload verified release assets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,18 @@ Notable changes to s-gw are documented here. The project follows [Semantic Versi
 
 ## Unreleased
 
+## 0.1.13 - 2026-07-15
+
 ### Changed
 
 - Moved the proprietary Rust execution core to a separate private repository. The public repository now contains the broker integration and TypeScript compatibility path, while maintainer release builds package the compiled core from a private checkout.
+
+### Fixed
+
+- High-frequency authorized environment commands now keep their reusable decision in memory, so routine AWS, MCP, and environment-command calls do not churn the ledger or rolling backups.
+- Credential, approval-policy, grant, and settings recovery checkpoints are append-only. s-gw seals a candidate checkpoint before it changes the primary ledger and fails closed if the recovery anchor is missing, malformed, or from another ledger.
+- Automatically approved durable requests now revalidate the original policy or grant before execution, so disabling or revoking that authority takes effect before the command starts.
+- Test runs require disposable, explicitly configured s-gw and recovery homes, preventing test processes from using a real local ledger.
 
 ## 0.1.12 - 2026-07-15
 

--- a/native/macos-app/Sources/SgwMac/Services/UpdateChecker.swift
+++ b/native/macos-app/Sources/SgwMac/Services/UpdateChecker.swift
@@ -64,7 +64,7 @@ actor UpdateChecker: UpdateChecking {
     private let cli = CLIRunner()
 
     static var currentVersion: String {
-        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.1.12"
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.1.13"
     }
 
     static func isNewer(_ candidate: String, than current: String) -> Bool {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@s-gw/s-gw",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@s-gw/s-gw",
-      "version": "0.1.12",
+      "version": "0.1.13",
       "license": "Apache-2.0",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-gw/s-gw",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "mcpName": "io.github.sgateway/s-gw",
   "description": "Local credential control for AI coding agents.",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -15,13 +15,13 @@
     "url": "https://github.com/sgateway/s-gw",
     "source": "github"
   },
-  "version": "0.1.12",
+  "version": "0.1.13",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@s-gw/s-gw",
-      "version": "0.1.12",
+      "version": "0.1.13",
       "runtimeHint": "npx",
       "runtimeArguments": [
         {

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const CURRENT_VERSION = "0.1.12";
+export const CURRENT_VERSION = "0.1.13";

--- a/tests/installers.test.ts
+++ b/tests/installers.test.ts
@@ -167,7 +167,12 @@ describe("platform installers", () => {
     expect(workflow).toContain("release_tag:");
     expect(assetJob).toContain("inputs.release_tag != ''");
     expect(assetJob).toContain("ref: ${{ env.RELEASE_TAG }}");
+    expect(assetJob).toContain('SGW_REQUIRE_RUST_CORE: "1"');
+    expect(assetJob).toContain("SGW_RUST_CORE_DIR: ${{ github.workspace }}/.private/sgw-core");
+    expect(assetJob).toContain("repository: barryqy/s-gw-rust-core");
+    expect(assetJob).toContain("path: .private/sgw-core");
     expect(assetJob).toContain("npm run verify");
+    expect(assetJob).toContain("npm run validate:npm-package");
     expect(assetJob).toContain("npm run build:installers");
     expect(assetJob).toContain("first_tgz");
     expect(assetJob).not.toContain("needs: publish");
@@ -188,6 +193,9 @@ describe("platform installers", () => {
     );
 
     expect(npmJob).toContain("runs-on: macos-15");
+    expect(npmJob).toContain('SGW_REQUIRE_RUST_CORE: "1"');
+    expect(npmJob).toContain("repository: barryqy/s-gw-rust-core");
+    expect(npmJob).toContain("ref: ${{ github.event.release.tag_name }}");
     expect(npmJob).toContain("npm run validate:npm-package");
     expect(npmJob).toContain("npm publish --access public --ignore-scripts");
     expect(npmJob).toContain("-verify_arch arm64");

--- a/tests/rust-core.test.ts
+++ b/tests/rust-core.test.ts
@@ -12,7 +12,7 @@ let tmpHome = "";
 const oldEngine = process.env.SGW_EXECUTION_ENGINE;
 const oldAwsSecret = process.env.AWS_SECRET_ACCESS_KEY;
 const coreName = process.platform === "win32" ? "s-gw-core.exe" : "s-gw-core";
-const packagedCore = path.resolve("dist", "native", coreName);
+const packagedCore = path.resolve("dist", "native", `${process.platform}-${process.arch}`, coreName);
 const coreIt = existsSync(packagedCore) ? it : it.skip;
 
 beforeEach(async () => {


### PR DESCRIPTION
## Release

- Bump all public release surfaces to 0.1.13.
- Pin npm and installer publication to the matching private `v0.1.13` Rust core.
- Require and validate the native core before release assets are built.

## Validation

- `npm run verify` with disposable s-gw and recovery homes
- Private Rust core fmt, clippy, and tests
- Installer and npm-package validation