### PR TITLE
Stabilize release asset verification

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -181,7 +181,14 @@ jobs:
           package_version="$(node -p "require('./package.json').version")"
           test "v${package_version}" = "${RELEASE_TAG}"
 
-      - run: npm run verify
+      - name: Verify release build
+        run: |
+          npm run build
+          npm run check:rust
+          npm run build:rust-core
+          npx vitest run --testTimeout 15000
+          npm audit --audit-level=high
+          npm run package:dry-run
       - run: npm run validate:npm-package
       - run: npm run build:installers
 

--- a/tests/installers.test.ts
+++ b/tests/installers.test.ts
@@ -171,7 +171,11 @@ describe("platform installers", () => {
     expect(assetJob).toContain("SGW_RUST_CORE_DIR: ${{ github.workspace }}/.private/sgw-core");
     expect(assetJob).toContain("repository: barryqy/s-gw-rust-core");
     expect(assetJob).toContain("path: .private/sgw-core");
-    expect(assetJob).toContain("npm run verify");
+    expect(assetJob).toContain("npm run build");
+    expect(assetJob).toContain("npm run check:rust");
+    expect(assetJob).toContain("npx vitest run --testTimeout 15000");
+    expect(assetJob).toContain("npm audit --audit-level=high");
+    expect(assetJob).toContain("npm run package:dry-run");
     expect(assetJob).toContain("npm run validate:npm-package");
     expect(assetJob).toContain("npm run build:installers");
     expect(assetJob).toContain("first_tgz");


### PR DESCRIPTION
## Summary

- Run release-asset tests with a 15-second cap suited to the macOS release runner.
- Keep the complete build, Rust checks, tests, audit, package validation, and installer validation sequence.
- Enables a workflow-dispatch rebuild of the existing immutable `v0.1.13` tag without republishing npm or Registry artifacts.

## Validation

- `tests/installers.test.ts` with the updated workflow contract
- Local release-asset verification sequence with isolated s-gw homes