### PR TITLE
Prepare 0.1.14 release

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "s-gw",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "Local s-gw plugin that lets coding agents use typed secret handles without receiving raw credentials.",
   "author": {
     "name": "Barry Yuan"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Notable changes to s-gw are documented here. The project follows [Semantic Versioning](https://semver.org/) once public releases begin.
 
-## Unreleased
+## 0.1.14 - 2026-07-16
 
 ### Fixed
 

--- a/native/macos-app/Sources/SgwMac/Services/UpdateChecker.swift
+++ b/native/macos-app/Sources/SgwMac/Services/UpdateChecker.swift
@@ -64,7 +64,7 @@ actor UpdateChecker: UpdateChecking {
     private let cli = CLIRunner()
 
     static var currentVersion: String {
-        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.1.13"
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.1.14"
     }
 
     static func isNewer(_ candidate: String, than current: String) -> Bool {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@s-gw/s-gw",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@s-gw/s-gw",
-      "version": "0.1.13",
+      "version": "0.1.14",
       "license": "Apache-2.0",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-gw/s-gw",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "mcpName": "io.github.sgateway/s-gw",
   "description": "Local credential control for AI coding agents.",
   "type": "module",

--- a/scripts/build-rust-core.mjs
+++ b/scripts/build-rust-core.mjs
@@ -10,7 +10,10 @@ const coreRoot = resolve(
 const manifest = resolve(coreRoot, "Cargo.toml");
 const extension = process.platform === "win32" ? ".exe" : "";
 const target = `${process.platform}-${process.arch}`;
-const built = resolve(coreRoot, "target", "release", `sgw-core${extension}`);
+const cargoTargetDir = process.env.CARGO_TARGET_DIR
+  ? resolve(coreRoot, process.env.CARGO_TARGET_DIR)
+  : resolve(coreRoot, "target");
+const built = resolve(cargoTargetDir, "release", `sgw-core${extension}`);
 const output = resolve(root, "dist", "native", target, `s-gw-core${extension}`);
 const legacyOutputs = [
   resolve(root, "dist", "native", "s-gw-core"),

--- a/server.json
+++ b/server.json
@@ -15,13 +15,13 @@
     "url": "https://github.com/sgateway/s-gw",
     "source": "github"
   },
-  "version": "0.1.13",
+  "version": "0.1.14",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@s-gw/s-gw",
-      "version": "0.1.13",
+      "version": "0.1.14",
       "runtimeHint": "npx",
       "runtimeArguments": [
         {

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const CURRENT_VERSION = "0.1.13";
+export const CURRENT_VERSION = "0.1.14";

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -1803,7 +1803,7 @@ describe("SecretStore", () => {
 
     expect(ids.size).toBe(1);
     expect((await store.listRequests("pending")).filter((request) => request.handle === record.handle)).toHaveLength(1);
-  });
+  }, 15_000);
 
   it("coalesces repeated policy denials into one durable record", async () => {
     const store = new SecretStore();


### PR DESCRIPTION
## Summary

- Align every shipped public surface with 0.1.14 and publish the update-notice reliability fix.
- Respect `CARGO_TARGET_DIR` when staging the private core, so isolated maintainer builds are valid.
- Give the existing 16-writer durable-store regression its already-needed scoped timeout, avoiding a CI-only 5-second flake.

## Validation

- `npm run check`
- focused store regression, including 8 concurrent isolated runners
- `npm run verify` with isolated `SGW_HOME`, `SGW_RECOVERY_HOME`, `CARGO_TARGET_DIR`, and the private core required — 33 files / 324 tests passed
- `npm run build:installers` with the same isolated configuration
- private core format, clippy, tests, release build, and version smoke test