### PR TITLE
Prepare 0.1.15 release

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "s-gw",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "Local s-gw plugin that lets coding agents use typed secret handles without receiving raw credentials.",
   "author": {
     "name": "Barry Yuan"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Notable changes to s-gw are documented here. The project follows [Semantic Versioning](https://semver.org/) once public releases begin.
 
+## 0.1.15 - 2026-07-16
+
+### Fixed
+
+- High-contention approval-request tests now use a scoped timeout that matches their durable locking work, keeping release verification stable without weakening the global test timeout.
+
 ## 0.1.14 - 2026-07-16
 
 ### Fixed

--- a/native/macos-app/Sources/SgwMac/Services/UpdateChecker.swift
+++ b/native/macos-app/Sources/SgwMac/Services/UpdateChecker.swift
@@ -64,7 +64,7 @@ actor UpdateChecker: UpdateChecking {
     private let cli = CLIRunner()
 
     static var currentVersion: String {
-        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.1.14"
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.1.15"
     }
 
     static func isNewer(_ candidate: String, than current: String) -> Bool {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@s-gw/s-gw",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@s-gw/s-gw",
-      "version": "0.1.14",
+      "version": "0.1.15",
       "license": "Apache-2.0",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-gw/s-gw",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "mcpName": "io.github.sgateway/s-gw",
   "description": "Local credential control for AI coding agents.",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -15,13 +15,13 @@
     "url": "https://github.com/sgateway/s-gw",
     "source": "github"
   },
-  "version": "0.1.14",
+  "version": "0.1.15",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@s-gw/s-gw",
-      "version": "0.1.14",
+      "version": "0.1.15",
       "runtimeHint": "npx",
       "runtimeArguments": [
         {

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const CURRENT_VERSION = "0.1.14";
+export const CURRENT_VERSION = "0.1.15";

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -1840,7 +1840,7 @@ describe("SecretStore", () => {
 
     expect(ids.size).toBe(1);
     expect((await store.listRequests("denied")).filter((request) => request.handle === record.handle)).toHaveLength(1);
-  });
+  }, 15_000);
 
   it("requires one matching allow policy for every injected secret", async () => {
     const store = new SecretStore();


### PR DESCRIPTION
## Summary

- Complete the release recovery without mutating the published 0.1.14 tag.
- Give both 16-writer durable-store regression tests the same scoped 15-second timeout.
- Align all public package surfaces with 0.1.15.

## Why this patch

The 0.1.14 npm package published successfully, but its release-assets job found that the adjacent policy-denial concurrency test can also exceed the global five-second timeout under a full macOS release build. A new patch release preserves tag immutability and produces reproducible assets.

## Validation

- focused two-test regression, including 8 concurrent isolated runners
- `npm run verify` with isolated `SGW_HOME`, `SGW_RECOVERY_HOME`, `CARGO_TARGET_DIR`, and required private core — 33 files / 324 tests passed
- `npm run build:installers` with the same isolated configuration
- private core format, clippy, tests, release build, and version smoke test