### PR TITLE
Improve approval policy management

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -56,6 +56,7 @@ import type {
   ApprovalMode,
   ApprovalPolicyDecision,
   ApprovalPolicyActionKind,
+  ApprovalPolicyConditions,
   CommandEnvBinding,
   HandleSummary,
   RequestRecord,
@@ -837,6 +838,14 @@ function secretType(input: string): SecretType {
   ];
 
   return allowed.includes(input as SecretType) ? (input as SecretType) : "unknown";
+}
+
+function approvalPolicySecretType(input: string): SecretType {
+  const type = secretType(input);
+  if (type === "unknown" && input.trim().toLowerCase() !== "unknown") {
+    throw new Error(`--type is not a supported credential type: ${input}`);
+  }
+  return type;
 }
 
 function approvalMode(input: string): ApprovalMode {
@@ -1774,21 +1783,35 @@ async function handleApprovalPolicyCommand(
         decision: approvalPolicyDecision(getFlag(flags, "decision") || "ask"),
         durationMs: duration ? parseDurationMs(duration) : undefined,
         expiresAt: getFlag(flags, "expires-at"),
-        conditions: {
-          handles: getFlagList(flags, "handle"),
-          secretTypes: getFlagList(flags, "type").map(secretType),
-          providers: getFlagList(flags, "provider"),
-          minSeverity: optionalSecretSeverity(getFlag(flags, "min-severity")),
-          agents: getFlagList(flags, "agent"),
-          actionKinds: getFlagList(flags, "action-kind").map(approvalPolicyActionKind),
-          commands: getFlagList(flags, "command"),
-          injectEnvs: getFlagList(flags, "inject-env"),
-          workingDirs: getFlagList(flags, "working-dir").concat(getFlagList(flags, "cwd")),
-          sshTargets: getFlagList(flags, "ssh-target").concat(getFlagList(flags, "target")),
-          sshPorts: getFlagList(flags, "ssh-port").concat(getFlagList(flags, "port")).map((item) => Number(item))
-        }
+        conditions: approvalPolicyConditionsFromFlags(flags)
       })
     );
+    return;
+  }
+
+  if (action === "update" || action === "edit") {
+    if (!approvalPolicyUpdateFlags.some((flag) => hasFlag(flags, flag))) {
+      throw new Error("approval policy update needs at least one change.");
+    }
+
+    const duration = getFlag(flags, "duration") || getFlag(flags, "duration-ms");
+    const conditions = approvalPolicyConditionPatchFromFlags(flags);
+    printJson(
+      await store.updateApprovalPolicyRule(requireFlag(flags, "id"), {
+        name: hasFlag(flags, "name") ? getFlag(flags, "name") : undefined,
+        enabled: hasFlag(flags, "enabled") ? true : hasFlag(flags, "disabled") ? false : undefined,
+        priority: hasFlag(flags, "priority") ? optionalNumericFlag(flags, "priority") : undefined,
+        decision: hasFlag(flags, "decision") ? approvalPolicyDecision(getFlag(flags, "decision") || "ask") : undefined,
+        durationMs: duration ? parseDurationMs(duration) : undefined,
+        expiresAt: hasFlag(flags, "clear-expiry") ? null : hasFlag(flags, "expires-at") ? getFlag(flags, "expires-at") : undefined,
+        conditions
+      })
+    );
+    return;
+  }
+
+  if (action === "arrange" || action === "organize") {
+    printJson(await store.arrangeApprovalPolicyRules());
     return;
   }
 
@@ -1803,7 +1826,117 @@ async function handleApprovalPolicyCommand(
     return;
   }
 
-  throw new Error("approval policy requires list, add, delete, enable, or disable.");
+  throw new Error("approval policy requires list, add, update, arrange, delete, enable, or disable.");
+}
+
+const approvalPolicyUpdateFlags = [
+  "name",
+  "enabled",
+  "disabled",
+  "priority",
+  "decision",
+  "duration",
+  "duration-ms",
+  "expires-at",
+  "clear-expiry",
+  "handle",
+  "binding",
+  "type",
+  "provider",
+  "min-severity",
+  "agent",
+  "action-kind",
+  "command",
+  "inject-env",
+  "working-dir",
+  "cwd",
+  "ssh-target",
+  "target",
+  "ssh-port",
+  "port"
+];
+
+function approvalPolicyConditionsFromFlags(
+  flags: Record<string, string | boolean | string[]>
+): ApprovalPolicyConditions {
+  return {
+    handles: getFlagList(flags, "handle"),
+    envBindings: approvalPolicyEnvBindingsFromFlags(flags),
+    secretTypes: getFlagList(flags, "type").map(approvalPolicySecretType),
+    providers: getFlagList(flags, "provider"),
+    minSeverity: optionalSecretSeverity(getFlag(flags, "min-severity")),
+    agents: getFlagList(flags, "agent"),
+    actionKinds: getFlagList(flags, "action-kind").map(approvalPolicyActionKind),
+    commands: getFlagList(flags, "command"),
+    injectEnvs: getFlagList(flags, "inject-env"),
+    workingDirs: getFlagList(flags, "working-dir").concat(getFlagList(flags, "cwd")),
+    sshTargets: getFlagList(flags, "ssh-target").concat(getFlagList(flags, "target")),
+    sshPorts: getFlagList(flags, "ssh-port").concat(getFlagList(flags, "port")).map((item) => Number(item))
+  };
+}
+
+function approvalPolicyConditionPatchFromFlags(
+  flags: Record<string, string | boolean | string[]>
+): Partial<ApprovalPolicyConditions> | undefined {
+  const fields = [
+    "handle",
+    "binding",
+    "type",
+    "provider",
+    "min-severity",
+    "agent",
+    "action-kind",
+    "command",
+    "inject-env",
+    "working-dir",
+    "cwd",
+    "ssh-target",
+    "target",
+    "ssh-port",
+    "port"
+  ];
+  if (!fields.some((field) => hasFlag(flags, field))) {
+    return undefined;
+  }
+
+  const patch: Partial<ApprovalPolicyConditions> = {};
+  if (hasFlag(flags, "handle")) patch.handles = getFlagList(flags, "handle");
+  if (hasFlag(flags, "binding")) patch.envBindings = approvalPolicyEnvBindingsFromFlags(flags);
+  if (hasFlag(flags, "type")) patch.secretTypes = getFlagList(flags, "type").map(approvalPolicySecretType);
+  if (hasFlag(flags, "provider")) patch.providers = getFlagList(flags, "provider");
+  if (hasFlag(flags, "min-severity")) patch.minSeverity = optionalSecretSeverity(getFlag(flags, "min-severity"));
+  if (hasFlag(flags, "agent")) patch.agents = getFlagList(flags, "agent");
+  if (hasFlag(flags, "action-kind")) patch.actionKinds = getFlagList(flags, "action-kind").map(approvalPolicyActionKind);
+  if (hasFlag(flags, "command")) patch.commands = getFlagList(flags, "command");
+  if (hasFlag(flags, "inject-env")) patch.injectEnvs = getFlagList(flags, "inject-env");
+  if (hasFlag(flags, "working-dir") || hasFlag(flags, "cwd")) {
+    patch.workingDirs = getFlagList(flags, "working-dir").concat(getFlagList(flags, "cwd"));
+  }
+  if (hasFlag(flags, "ssh-target") || hasFlag(flags, "target")) {
+    patch.sshTargets = getFlagList(flags, "ssh-target").concat(getFlagList(flags, "target"));
+  }
+  if (hasFlag(flags, "ssh-port") || hasFlag(flags, "port")) {
+    patch.sshPorts = getFlagList(flags, "ssh-port").concat(getFlagList(flags, "port")).map((item) => Number(item));
+  }
+  return patch;
+}
+
+function approvalPolicyEnvBindingsFromFlags(
+  flags: Record<string, string | boolean | string[]>
+): CommandEnvBinding[] {
+  const values = getFlagList(flags, "binding");
+  const out: CommandEnvBinding[] = [];
+  for (const value of values) {
+    const index = value.indexOf("=");
+    if (index <= 0 || index === value.length - 1) {
+      throw new Error("--binding must look like ENV=HANDLE.");
+    }
+    out.push({
+      injectEnv: value.slice(0, index),
+      handle: value.slice(index + 1)
+    });
+  }
+  return out;
 }
 
 function onePasswordHandleName(itemTitle: string, fieldLabel: string): string {
@@ -2006,7 +2139,9 @@ Commands:
   s-gw approval set --mode per-transaction|timed-session|login-session|always [--duration 15m]
   s-gw approval grants
   s-gw approval policy list
-  s-gw approval policy add --name NAME --decision allow|ask|deny [--handle HANDLE] [--agent Codex] [--command /path/to/tool] [--action-kind env_command|ssh_session] [--duration 8h]
+  s-gw approval policy add --name NAME --decision allow|ask|deny [--handle HANDLE] [--binding ENV=HANDLE] [--agent Codex] [--command /path/to/tool] [--action-kind env_command|ssh_session] [--duration 8h]
+  s-gw approval policy update --id POLICY_ID [--name NAME] [--decision allow|ask|deny] [--handle HANDLE] [--agent Codex] [--command /path/to/tool] [--clear-expiry]
+  s-gw approval policy arrange
   s-gw approval policy delete --id POLICY_ID
   s-gw approval policy enable|disable --id POLICY_ID
   s-gw approval revoke GRANT_ID

--- a/src/console-server.ts
+++ b/src/console-server.ts
@@ -22,7 +22,7 @@ import {
 } from "./gateway.js";
 import { getAgentCodeGuardPlan, listAgentProfiles, renderAgentMcpSnippet, resolveAgentProfile } from "./agents.js";
 import { readinessForUnlock } from "./install.js";
-import { SecretStore } from "./store.js";
+import { SecretStore, type AddApprovalPolicyRuleInput, type UpdateApprovalPolicyRuleInput } from "./store.js";
 import { unlockStatus } from "./unlock.js";
 import { ReleaseChecker, UPDATE_CHECK_INTERVAL_MS, type UpdateCheckResult } from "./update-check.js";
 import { CURRENT_VERSION } from "./version.js";
@@ -31,6 +31,7 @@ import type {
   ApprovalAgentScope,
   ApprovalMode,
   ApprovalPolicyActionKind,
+  ApprovalPolicyConditions,
   ApprovalPolicyDecision,
   CommandEnvBinding,
   HandleSummary,
@@ -273,31 +274,12 @@ async function handleApi(
 
   if (req.method === "POST" && url.pathname === "/api/approval/policies") {
     const body = await readJson(req);
-    sendJson(
-      res,
-      200,
-      await store.addApprovalPolicyRule({
-        name: optionalString(body.name),
-        enabled: body.enabled !== false,
-        priority: optionalNumberValue(body.priority),
-        decision: approvalPolicyDecision(body.decision),
-        expiresAt: optionalString(body.expiresAt),
-        durationMs: optionalNumberValue(body.durationMs),
-        conditions: {
-          handles: stringArray(body.handles),
-          secretTypes: stringArray(body.secretTypes).map(secretType),
-          providers: stringArray(body.providers),
-          minSeverity: optionalSecretSeverity(body.minSeverity),
-          agents: stringArray(body.agents),
-          actionKinds: stringArray(body.actionKinds).map(approvalPolicyActionKind),
-          commands: stringArray(body.commands),
-          injectEnvs: stringArray(body.injectEnvs),
-          workingDirs: stringArray(body.workingDirs),
-          sshTargets: stringArray(body.sshTargets),
-          sshPorts: stringArray(body.sshPorts).map((item) => Number(item))
-        }
-      })
-    );
+    sendJson(res, 200, await store.addApprovalPolicyRule(policyRuleInput(body)));
+    return;
+  }
+
+  if (req.method === "POST" && url.pathname === "/api/approval/policies/arrange") {
+    sendJson(res, 200, await store.arrangeApprovalPolicyRules());
     return;
   }
 
@@ -325,6 +307,11 @@ async function handleApi(
         throw new HttpError(400, "enabled must be a boolean.");
       }
       sendJson(res, 200, await store.setApprovalPolicyRuleEnabled(id, body.enabled));
+      return;
+    }
+    if (req.method === "PUT") {
+      const body = await readJson(req);
+      sendJson(res, 200, await store.updateApprovalPolicyRule(id, policyRuleUpdateInput(body)));
       return;
     }
   }
@@ -409,7 +396,7 @@ async function handleApi(
     return;
   }
 
-  const match = url.pathname.match(/^\/api\/requests\/([^/]+)\/(approve|deny|execute|recover)$/);
+  const match = url.pathname.match(/^\/api\/requests\/([^/]+)\/(approve|approve-policy|deny|execute|recover)$/);
   if (req.method === "POST" && match) {
     const id = decodeURIComponent(match[1]);
     const action = match[2];
@@ -424,6 +411,11 @@ async function handleApi(
           agentScope: optionalApprovalAgentScope(body.agentScope)
         })
       );
+      return;
+    }
+
+    if (action === "approve-policy") {
+      sendJson(res, 200, await store.approveRequestWithScopedPolicy(id));
       return;
     }
 
@@ -1151,15 +1143,37 @@ function optionalSecretSeverity(input: unknown): SecretSeverity | undefined {
   throw new HttpError(400, "minSeverity must be low, medium, high, or critical.");
 }
 
-function stringArray(input: unknown): string[] {
-  if (input === undefined || input === null || input === "") {
+function policyStringArray(body: Record<string, unknown>, field: string): string[] {
+  if (!hasBodyField(body, field)) {
     return [];
   }
-  if (Array.isArray(input) && input.every((item) => typeof item === "string")) {
-    return input;
+  const value = body[field];
+  if (Array.isArray(value) && value.every((item) => typeof item === "string" && item.trim())) {
+    return value;
   }
 
-  throw new HttpError(400, "Expected an array of strings.");
+  throw new HttpError(400, `${field} must be an array of non-empty strings.`);
+}
+
+function policyNumberArray(body: Record<string, unknown>, field: string): number[] {
+  if (!hasBodyField(body, field)) {
+    return [];
+  }
+  return numberArray(body[field], field);
+}
+
+function policyOptionalNumberValue(body: Record<string, unknown>, field: string): number | undefined {
+  if (!hasBodyField(body, field)) {
+    return undefined;
+  }
+  const value = body[field];
+  if (value === null || (typeof value === "string" && !value.trim())) {
+    throw new HttpError(400, `${field} must be a finite number.`);
+  }
+  if (typeof value !== "number" && typeof value !== "string") {
+    throw new HttpError(400, `${field} must be a finite number.`);
+  }
+  return optionalNumberValue(value);
 }
 
 function optionalNumberValue(value: unknown): number | undefined {
@@ -1173,6 +1187,192 @@ function optionalNumberValue(value: unknown): number | undefined {
   }
 
   return parsed;
+}
+
+function policyRuleInput(body: Record<string, unknown>): AddApprovalPolicyRuleInput {
+  assertKnownPolicyFields(body);
+  return {
+    name: hasBodyField(body, "name") ? policyNameValue(body.name) : undefined,
+    enabled: booleanValue(body.enabled, "enabled", true),
+    priority: policyOptionalNumberValue(body, "priority"),
+    decision: approvalPolicyDecision(body.decision),
+    expiresAt: policyExpiresAtValue(body, false) ?? undefined,
+    durationMs: policyOptionalNumberValue(body, "durationMs"),
+    conditions: policyConditionsFromBody(body)
+  };
+}
+
+function policyRuleUpdateInput(body: Record<string, unknown>): UpdateApprovalPolicyRuleInput {
+  assertKnownPolicyFields(body);
+  const input: UpdateApprovalPolicyRuleInput = {};
+  if (hasBodyField(body, "name")) input.name = policyNameValue(body.name);
+  if (hasBodyField(body, "enabled")) input.enabled = booleanValue(body.enabled, "enabled");
+  if (hasBodyField(body, "priority")) input.priority = policyOptionalNumberValue(body, "priority");
+  if (hasBodyField(body, "decision")) input.decision = approvalPolicyDecision(body.decision);
+  if (hasBodyField(body, "expiresAt")) input.expiresAt = policyExpiresAtValue(body, true);
+  if (hasBodyField(body, "durationMs")) input.durationMs = policyOptionalNumberValue(body, "durationMs");
+
+  const conditions = policyConditionPatchFromBody(body);
+  if (conditions) input.conditions = conditions;
+  if (Object.keys(input).length === 0) {
+    throw new HttpError(400, "Approval policy update must include at least one change.");
+  }
+  return input;
+}
+
+function policyConditionsFromBody(body: Record<string, unknown>): ApprovalPolicyConditions {
+  return {
+    handles: policyStringArray(body, "handles"),
+    envBindings: policyEnvBindings(body.envBindings),
+    secretTypes: policyStringArray(body, "secretTypes").map(policySecretType),
+    providers: policyStringArray(body, "providers"),
+    minSeverity: optionalSecretSeverity(body.minSeverity),
+    agents: policyStringArray(body, "agents"),
+    actionKinds: policyStringArray(body, "actionKinds").map(approvalPolicyActionKind),
+    commands: policyStringArray(body, "commands"),
+    injectEnvs: policyStringArray(body, "injectEnvs"),
+    workingDirs: policyStringArray(body, "workingDirs"),
+    sshTargets: policyStringArray(body, "sshTargets"),
+    sshPorts: policyNumberArray(body, "sshPorts")
+  };
+}
+
+function policyConditionPatchFromBody(body: Record<string, unknown>): Partial<ApprovalPolicyConditions> | undefined {
+  const fields = [
+    "handles",
+    "envBindings",
+    "secretTypes",
+    "providers",
+    "minSeverity",
+    "agents",
+    "actionKinds",
+    "commands",
+    "injectEnvs",
+    "workingDirs",
+    "sshTargets",
+    "sshPorts"
+  ];
+  if (!fields.some((field) => hasBodyField(body, field))) {
+    return undefined;
+  }
+
+  const patch: Partial<ApprovalPolicyConditions> = {};
+  if (hasBodyField(body, "handles")) patch.handles = policyStringArray(body, "handles");
+  if (hasBodyField(body, "envBindings")) patch.envBindings = policyEnvBindings(body.envBindings);
+  if (hasBodyField(body, "secretTypes")) patch.secretTypes = policyStringArray(body, "secretTypes").map(policySecretType);
+  if (hasBodyField(body, "providers")) patch.providers = policyStringArray(body, "providers");
+  if (hasBodyField(body, "minSeverity")) patch.minSeverity = body.minSeverity === null ? undefined : optionalSecretSeverity(body.minSeverity);
+  if (hasBodyField(body, "agents")) patch.agents = policyStringArray(body, "agents");
+  if (hasBodyField(body, "actionKinds")) patch.actionKinds = policyStringArray(body, "actionKinds").map(approvalPolicyActionKind);
+  if (hasBodyField(body, "commands")) patch.commands = policyStringArray(body, "commands");
+  if (hasBodyField(body, "injectEnvs")) patch.injectEnvs = policyStringArray(body, "injectEnvs");
+  if (hasBodyField(body, "workingDirs")) patch.workingDirs = policyStringArray(body, "workingDirs");
+  if (hasBodyField(body, "sshTargets")) patch.sshTargets = policyStringArray(body, "sshTargets");
+  if (hasBodyField(body, "sshPorts")) patch.sshPorts = policyNumberArray(body, "sshPorts");
+  return patch;
+}
+
+function policyExpiresAtValue(body: Record<string, unknown>, allowClear: boolean): string | null | undefined {
+  if (!hasBodyField(body, "expiresAt")) {
+    return undefined;
+  }
+  if (body.expiresAt === null && allowClear) {
+    return null;
+  }
+  if (typeof body.expiresAt !== "string") {
+    throw new HttpError(400, "expiresAt must be an ISO timestamp.");
+  }
+  return body.expiresAt;
+}
+
+function policyNameValue(value: unknown): string {
+  if (typeof value !== "string") {
+    throw new HttpError(400, "name must be a string.");
+  }
+  return value;
+}
+
+function assertKnownPolicyFields(body: Record<string, unknown>): void {
+  const known = new Set([
+    "name",
+    "enabled",
+    "priority",
+    "decision",
+    "expiresAt",
+    "durationMs",
+    "handles",
+    "envBindings",
+    "secretTypes",
+    "providers",
+    "minSeverity",
+    "agents",
+    "actionKinds",
+    "commands",
+    "injectEnvs",
+    "workingDirs",
+    "sshTargets",
+    "sshPorts"
+  ]);
+  const unknown = Object.keys(body).filter((field) => !known.has(field));
+  if (unknown.length) {
+    throw new HttpError(400, `Unsupported approval policy field: ${unknown.join(", ")}.`);
+  }
+}
+
+function booleanValue(value: unknown, field: string, fallback?: boolean): boolean {
+  if (value === undefined && fallback !== undefined) {
+    return fallback;
+  }
+  if (typeof value === "boolean") {
+    return value;
+  }
+  throw new HttpError(400, `${field} must be a boolean.`);
+}
+
+function policySecretType(value: string): SecretType {
+  const type = secretType(value);
+  if (type === "unknown" && value !== "unknown") {
+    throw new HttpError(400, `Unsupported secret type: ${value}.`);
+  }
+  return type;
+}
+
+function numberArray(value: unknown, field: string): number[] {
+  if (!Array.isArray(value)) {
+    throw new HttpError(400, `${field} must be an array of numbers.`);
+  }
+
+  return value.map((item) => {
+    const number = typeof item === "number" || typeof item === "string" ? Number(item) : Number.NaN;
+    if (!Number.isFinite(number)) {
+      throw new HttpError(400, `${field} must contain finite numbers.`);
+    }
+    return number;
+  });
+}
+
+function policyEnvBindings(value: unknown): CommandEnvBinding[] {
+  if (value === undefined) {
+    return [];
+  }
+  if (!Array.isArray(value)) {
+    throw new HttpError(400, "envBindings must be an array of {handle, injectEnv} objects.");
+  }
+
+  return value.map((item) => {
+    if (!item || typeof item !== "object" || Array.isArray(item)) {
+      throw new HttpError(400, "envBindings must be an array of {handle, injectEnv} objects.");
+    }
+    const binding = item as Record<string, unknown>;
+    return {
+      handle: stringValue(binding.handle, "envBindings.handle"),
+      injectEnv: stringValue(binding.injectEnv, "envBindings.injectEnv")
+    };
+  });
+}
+
+function hasBodyField(body: Record<string, unknown>, field: string): boolean {
+  return Object.prototype.hasOwnProperty.call(body, field);
 }
 
 function providerForType(type: SecretType): string {
@@ -1301,15 +1501,15 @@ function sendError(res: ServerResponse, error: unknown): void {
 }
 
 function statusForErrorMessage(message: string): number {
-  if (/unknown (secret handle|request)/i.test(message)) {
+  if (/unknown (secret handle|request|approval policy)/i.test(message)) {
     return 404;
   }
 
-  if (/approval|approved|pending|denied|executed|failed/i.test(message)) {
+  if (/approval|approved|pending|denied|executed|failed|takes precedence/i.test(message)) {
     return 409;
   }
 
-  if (/not allowed|invalid|required|missing|empty/i.test(message)) {
+  if (/not allowed|invalid|required|missing|empty|must be|must contain|must include|unsupported|expected/i.test(message)) {
     return 400;
   }
 

--- a/src/console-ui/src/App.tsx
+++ b/src/console-ui/src/App.tsx
@@ -4,6 +4,7 @@ import {
   Activity,
   AlertTriangle,
   ArrowUpDown,
+  Ban,
   Bell,
   CheckCircle2,
   ChevronDown,
@@ -25,6 +26,7 @@ import {
   MoreVertical,
   Network,
   PanelRightOpen,
+  Pencil,
   Plus,
   RefreshCw,
   RotateCcw,
@@ -36,6 +38,7 @@ import {
   ScrollText,
   Trash2,
   UsersRound,
+  Wand2,
   X
 } from "lucide-react";
 import { Cell, Pie, PieChart } from "recharts";
@@ -46,6 +49,7 @@ import { AgentIcon } from "@/components/AgentIcon";
 import { ProviderIdentity } from "@/components/ProviderIdentity";
 import { EventFlowDiagram, describeEventFlow, isAgentActivityEvent } from "@/components/ActivityFlowRow";
 import { UsageFlowSankey } from "@/components/UsageFlowSankey";
+import { MultiSelectField, type MultiSelectOption } from "@/components/MultiSelectField";
 import { useElementSize } from "@/hooks/use-element-size";
 import { useReducedMotion } from "@/hooks/use-reduced-motion";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
@@ -131,6 +135,8 @@ import { Toaster } from "@/components/ui/sonner";
 import {
   addPolicy,
   approveRequest,
+  approveRequestWithScopedPolicy,
+  arrangePolicies,
   auditCsvUrl,
   clearGrants,
   createSecret,
@@ -141,8 +147,10 @@ import {
   installAgentIntegration,
   saveApprovalSettings,
   setPolicyEnabled,
+  updatePolicy,
   uninstallAgentIntegration
 } from "@/lib/api";
+import type { PolicyInput } from "@/lib/api";
 import {
   DASHBOARD_LAYOUT_KEY,
   defaultLayouts,
@@ -154,6 +162,7 @@ import {
   type PanelId
 } from "@/lib/layout";
 import { credentialBackendLabel, credentialProviderPresentation } from "@/lib/credential-presentation";
+import { findShadowingPolicyRule } from "../../policy-order";
 import {
   commandName,
   durationLabel,
@@ -1367,13 +1376,70 @@ function UsageFlowView({ state }: { state: ConsoleState }) {
 }
 
 function PoliciesView({ state, onDone, search }: { state: ConsoleState; onDone: () => void; search: string }) {
-  const [dialogOpen, setDialogOpen] = React.useState(false);
+  const [editing, setEditing] = React.useState<ApprovalPolicyRuleRecord | null>(null);
+  const [adding, setAdding] = React.useState(false);
+  const [deleting, setDeleting] = React.useState<ApprovalPolicyRuleRecord | null>(null);
+  const [arranging, setArranging] = React.useState(false);
   const rows = filterText(state.approvalPolicyRules, search, (rule) => `${rule.name} ${rule.decision} ${policyConditionSummary(rule.conditions)}`);
+  const shadowedBy = React.useMemo(() => {
+    const matches = new Map<string, ApprovalPolicyRuleRecord>();
+    for (const rule of state.approvalPolicyRules) {
+      if (!rule.enabled || (rule.expiresAt && rule.expiresAt <= new Date().toISOString())) continue;
+      const shadow = findShadowingPolicyRule(state.approvalPolicyRules, rule);
+      if (shadow) matches.set(rule.id, shadow);
+    }
+    return matches;
+  }, [state.approvalPolicyRules]);
+  const shadowedCount = shadowedBy.size;
+
+  async function arrange() {
+    if (arranging) return;
+    setArranging(true);
+    try {
+      const result = await arrangePolicies();
+      toast.success(result.reordered ? `Reordered ${result.reordered} rule${result.reordered === 1 ? "" : "s"}` : "Rules already use a safe order");
+      onDone();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Could not arrange policies");
+    } finally {
+      setArranging(false);
+    }
+  }
+
+  async function deleteRule() {
+    if (!deleting) return;
+    try {
+      await deletePolicy(deleting.id);
+      toast.success("Policy deleted");
+      setDeleting(null);
+      onDone();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Could not delete policy");
+    }
+  }
+
   return (
     <PageFrame title="Policies" description="Define when agents may use credentials without interrupting you, and when s-gw should always ask or deny.">
-      <div className="mb-4 flex justify-end">
-        <PolicyDialog open={dialogOpen} onOpenChange={setDialogOpen} onDone={onDone} />
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <p className="max-w-3xl text-sm text-muted-foreground">
+          Rules run in priority order. Auto-arrange moves narrower rules ahead of broader ask and allow rules; deny rules stay ahead as guardrails.
+        </p>
+        <div className="flex gap-2">
+          <Button variant="outline" disabled={arranging} onClick={() => void arrange()} data-policy-arrange>
+            {arranging ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Wand2 className="mr-2 h-4 w-4" />}
+            Auto-arrange
+          </Button>
+          <Button onClick={() => setAdding(true)} data-policy-add>
+            <Plus className="mr-2 h-4 w-4" />Add policy rule
+          </Button>
+        </div>
       </div>
+      {shadowedCount ? (
+        <div className="flex items-center gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-sm text-amber-700 dark:text-amber-300" data-policy-shadow-summary>
+          <AlertTriangle className="h-4 w-4" />
+          {shadowedCount} rule{shadowedCount === 1 ? " is" : "s are"} unreachable until the earlier rule is changed or auto-arranged.
+        </div>
+      ) : null}
       <DataCard>
         <Table>
           <TableHeader>
@@ -1386,23 +1452,45 @@ function PoliciesView({ state, onDone, search }: { state: ConsoleState; onDone: 
             </TableRow>
           </TableHeader>
           <TableBody>
+            {rows.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={5} className="py-8 text-center text-sm text-muted-foreground">
+                  No policy rules yet. Add a scoped rule or use Always allow from an approval.
+                </TableCell>
+              </TableRow>
+            ) : null}
             {rows.map((rule) => (
-              <TableRow key={rule.id}>
+              <TableRow key={rule.id} data-policy-row={rule.id} className={cn(shadowedBy.has(rule.id) && "bg-amber-500/5")}>
                 <TableCell>
                   <PolicyStatusControl rule={rule} onDone={onDone} />
                 </TableCell>
-                <TableCell className="font-medium">{rule.name}</TableCell>
+                <TableCell className="font-medium">
+                  <div className="flex min-w-0 items-center gap-2">
+                    <span className="truncate">{rule.name}</span>
+                    {shadowedBy.get(rule.id) ? (
+                      <Badge variant="secondary" className="shrink-0 text-amber-700 dark:text-amber-300" title={`Covered by ${shadowedBy.get(rule.id)?.name}`}>
+                        Shadowed
+                      </Badge>
+                    ) : null}
+                  </div>
+                </TableCell>
                 <TableCell><DecisionBadge decision={rule.decision} /></TableCell>
                 <TableCell className="max-w-[560px] truncate">{policyConditionSummary(rule.conditions)}</TableCell>
-                <TableCell className="text-right">
+                <TableCell className="text-right whitespace-nowrap">
                   <Button
                     variant="ghost"
                     size="icon-sm"
-                    onClick={async () => {
-                      await deletePolicy(rule.id);
-                      toast.success("Policy deleted");
-                      onDone();
-                    }}
+                    aria-label={`Edit ${rule.name}`}
+                    onClick={() => setEditing(rule)}
+                    data-policy-edit={rule.id}
+                  >
+                    <Pencil className="h-4 w-4" />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="icon-sm"
+                    aria-label={`Delete ${rule.name}`}
+                    onClick={() => setDeleting(rule)}
                   >
                     <Trash2 className="h-4 w-4" />
                   </Button>
@@ -1412,6 +1500,31 @@ function PoliciesView({ state, onDone, search }: { state: ConsoleState; onDone: 
           </TableBody>
         </Table>
       </DataCard>
+      <PolicyEditorDialog open={adding} state={state} onOpenChange={setAdding} onDone={onDone} />
+      <PolicyEditorDialog
+        open={Boolean(editing)}
+        rule={editing}
+        state={state}
+        onOpenChange={(open) => !open && setEditing(null)}
+        onDone={() => {
+          setEditing(null);
+          onDone();
+        }}
+      />
+      <AlertDialog open={Boolean(deleting)} onOpenChange={(open) => !open && setDeleting(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete policy rule?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {deleting ? `Delete “${deleting.name}”? Future matching requests will no longer use it.` : ""}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={() => void deleteRule()}>Delete rule</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </PageFrame>
   );
 }
@@ -2671,6 +2784,23 @@ function ApprovalSheet({
     }
   };
 
+  const alwaysAllow = async () => {
+    if (!request || busyRef.current) return;
+    busyRef.current = true;
+    setBusy(true);
+    try {
+      const result = await approveRequestWithScopedPolicy(request);
+      toast.success(result.created ? "Created a scoped allow rule and approved this request" : "Approved this request with an existing allow rule");
+      onOpenChange(false);
+      onDone();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Could not create a policy rule");
+    } finally {
+      busyRef.current = false;
+      setBusy(false);
+    }
+  };
+
   const deny = async () => {
     if (!request) return;
     if (busyRef.current) return;
@@ -2733,11 +2863,16 @@ function ApprovalSheet({
                 <ChevronDown className="ml-2 h-4 w-4" />
               </Button>
             </PopoverTrigger>
-            <PopoverContent className="grid w-56 gap-2">
+            <PopoverContent className="grid w-64 gap-2">
               <Button variant="ghost" onClick={() => approve({ mode: "timed-session", durationMs: 15 * 60 * 1000, agentScope: "same-agent" })}>15 minutes</Button>
               <Button variant="ghost" onClick={() => approve({ mode: "timed-session", durationMs: 60 * 60 * 1000, agentScope: "same-agent" })}>1 hour</Button>
               <Button variant="ghost" onClick={() => approve({ mode: "timed-session", durationMs: 24 * 60 * 60 * 1000, agentScope: "same-agent" })}>1 day</Button>
               <Button variant="ghost" onClick={() => approve({ mode: "login-session", agentScope: "same-agent" })}>Current login session</Button>
+              <Separator />
+              <Button variant="ghost" className="justify-start gap-2" disabled={busy} onClick={() => void alwaysAllow()} data-approve-policy={request?.id}>
+                <ShieldCheck className="h-4 w-4" />
+                Always allow this request scope
+              </Button>
             </PopoverContent>
           </Popover>
           <Button disabled={busy} variant="destructive" onClick={deny}>Deny</Button>
@@ -2900,68 +3035,383 @@ function AddCredentialDialog({
   );
 }
 
-function PolicyDialog({ open, onOpenChange, onDone }: { open: boolean; onOpenChange: (open: boolean) => void; onDone: () => void }) {
-  const [name, setName] = React.useState("Codex scoped access");
-  const [decision, setDecision] = React.useState<ApprovalPolicyDecision>("ask");
-  const [agent, setAgent] = React.useState("Codex");
-  const [provider, setProvider] = React.useState("");
-  const [command, setCommand] = React.useState("");
+const policySecretTypeOptions: MultiSelectOption[] = [
+  { value: "api-token", label: "API token" },
+  { value: "ssh-key", label: "SSH key" },
+  { value: "private-key", label: "Private key" },
+  { value: "password", label: "Password" },
+  { value: "credential", label: "Credential pair" },
+  { value: "access-key", label: "Access key" },
+  { value: "unknown", label: "Unknown" }
+];
+
+const policyActionKindOptions: MultiSelectOption[] = [
+  { value: "env_command", label: "Command" },
+  { value: "ssh_session", label: "SSH session" }
+];
+
+type PolicyOptionSources = {
+  agents: MultiSelectOption[];
+  handles: MultiSelectOption[];
+  providers: MultiSelectOption[];
+  commands: MultiSelectOption[];
+  injectEnvs: MultiSelectOption[];
+  workingDirs: MultiSelectOption[];
+  sshTargets: MultiSelectOption[];
+  sshPorts: MultiSelectOption[];
+};
+
+type PolicyFormState = {
+  name: string;
+  decision: ApprovalPolicyDecision;
+  priority: string;
+  agents: string[];
+  handles: string[];
+  providers: string[];
+  secretTypes: string[];
+  minSeverity: string;
+  actionKinds: string[];
+  commands: string[];
+  injectEnvs: string[];
+  workingDirs: string[];
+  sshTargets: string[];
+  sshPorts: string[];
+};
+
+function buildPolicyOptionSources(state: ConsoleState): PolicyOptionSources {
+  const agents = new Set<string>();
+  for (const agent of state.agents) agents.add(agent.name);
+  for (const request of state.requests) if (request.agentName) agents.add(request.agentName);
+
+  const providers = new Set<string>();
+  for (const handle of state.handles) if (handle.provider) providers.add(handle.provider);
+
+  const commands = new Set<string>();
+  for (const request of state.requests) commands.add(request.action.command);
+  for (const handle of state.handles) for (const command of handle.policy.allowedCommands) commands.add(command);
+
+  const injectEnvs = new Set<string>();
+  for (const handle of state.handles) if (handle.policy.injectEnv) injectEnvs.add(handle.policy.injectEnv);
+  for (const request of state.requests) if (request.action.injectEnv) injectEnvs.add(request.action.injectEnv);
+
+  const workingDirs = new Set<string>();
+  for (const request of state.requests) if (request.action.workingDir) workingDirs.add(request.action.workingDir);
+
+  const sshTargets = new Set<string>();
+  const sshPorts = new Set<string>();
+  for (const request of state.requests) {
+    if (request.action.ssh?.target) sshTargets.add(request.action.ssh.target);
+    if (request.action.ssh?.port) sshPorts.add(String(request.action.ssh.port));
+  }
+
+  return {
+    agents: sortedPolicyOptions(agents),
+    handles: state.handles
+      .map((handle) => ({ value: handle.handle, label: handle.name || shortHandle(handle.handle), hint: handle.provider || handle.type }))
+      .sort((left, right) => (left.label || left.value).localeCompare(right.label || right.value)),
+    providers: sortedPolicyOptions(providers),
+    commands: sortedPolicyOptions(commands),
+    injectEnvs: sortedPolicyOptions(injectEnvs),
+    workingDirs: sortedPolicyOptions(workingDirs),
+    sshTargets: sortedPolicyOptions(sshTargets),
+    sshPorts: sortedPolicyOptions(sshPorts)
+  };
+}
+
+function sortedPolicyOptions(values: Iterable<string>): MultiSelectOption[] {
+  return [...new Set([...values].filter(Boolean))]
+    .sort((left, right) => left.localeCompare(right))
+    .map((value) => ({ value }));
+}
+
+function emptyPolicyForm(): PolicyFormState {
+  return {
+    name: "",
+    decision: "ask",
+    priority: "",
+    agents: [],
+    handles: [],
+    providers: [],
+    secretTypes: [],
+    minSeverity: "",
+    actionKinds: [],
+    commands: [],
+    injectEnvs: [],
+    workingDirs: [],
+    sshTargets: [],
+    sshPorts: []
+  };
+}
+
+function policyFormFromRule(rule: ApprovalPolicyRuleRecord): PolicyFormState {
+  const conditions = rule.conditions;
+  return {
+    name: rule.name,
+    decision: rule.decision,
+    priority: String(rule.priority),
+    agents: conditions.agents || [],
+    handles: conditions.handles || [],
+    providers: conditions.providers || [],
+    secretTypes: conditions.secretTypes || [],
+    minSeverity: conditions.minSeverity || "",
+    actionKinds: conditions.actionKinds || [],
+    commands: conditions.commands || [],
+    injectEnvs: conditions.injectEnvs || [],
+    workingDirs: conditions.workingDirs || [],
+    sshTargets: conditions.sshTargets || [],
+    sshPorts: (conditions.sshPorts || []).map(String)
+  };
+}
+
+function policyFormToInput(form: PolicyFormState, enabled: boolean, bindingsLocked = false): PolicyInput {
+  const priority = form.priority.trim();
+  const input: PolicyInput = {
+    name: form.name.trim(),
+    enabled,
+    decision: form.decision,
+    priority: priority ? Number(priority) : undefined,
+    agents: form.agents,
+    providers: form.providers,
+    secretTypes: form.secretTypes,
+    minSeverity: form.minSeverity ? form.minSeverity as SecretSeverity : null,
+    actionKinds: form.actionKinds,
+    commands: form.commands,
+    workingDirs: form.workingDirs,
+    sshTargets: form.sshTargets,
+    sshPorts: form.sshPorts.map((port) => Number(port))
+  };
+  if (!bindingsLocked) {
+    input.handles = form.handles;
+    input.injectEnvs = form.injectEnvs;
+  }
+  return input;
+}
+
+function PolicyEditorDialog({
+  open,
+  onOpenChange,
+  onDone,
+  state,
+  rule
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onDone: () => void;
+  state: ConsoleState;
+  rule?: ApprovalPolicyRuleRecord | null;
+}) {
+  const [form, setForm] = React.useState<PolicyFormState>(emptyPolicyForm);
+  const [advanced, setAdvanced] = React.useState(false);
   const [busy, setBusy] = React.useState(false);
+  const sources = React.useMemo(() => buildPolicyOptionSources(state), [state]);
+  const editing = Boolean(rule);
+  const bindingsLocked = Boolean(rule?.conditions.envBindings?.length);
+
+  React.useEffect(() => {
+    if (!open) return;
+    setForm(rule ? policyFormFromRule(rule) : emptyPolicyForm());
+    setAdvanced(Boolean(rule));
+  }, [open, rule]);
+
+  const update = <K extends keyof PolicyFormState>(field: K, value: PolicyFormState[K]) => {
+    setForm((current) => ({ ...current, [field]: value }));
+  };
+
+  async function save() {
+    if (busy || !form.name.trim()) return;
+    setBusy(true);
+    try {
+      const body = policyFormToInput(form, rule?.enabled ?? true, bindingsLocked);
+      if (rule) {
+        await updatePolicy(rule.id, body);
+        toast.success("Policy rule updated");
+      } else {
+        await addPolicy(body);
+        toast.success("Policy rule added");
+      }
+      onOpenChange(false);
+      onDone();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Could not save policy");
+    } finally {
+      setBusy(false);
+    }
+  }
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogTrigger asChild>
-        <Button><Plus className="mr-2 h-4 w-4" />Add policy rule</Button>
-      </DialogTrigger>
-      <DialogContent>
+      <DialogContent className="max-h-[calc(100vh-48px)] w-[min(760px,calc(100vw-24px))] overflow-y-auto sm:max-w-none">
         <DialogHeader>
-          <DialogTitle>Add policy rule</DialogTitle>
-          <DialogDescription>Rules are evaluated before the approval queue, with deny taking priority.</DialogDescription>
+          <DialogTitle>{editing ? "Edit policy rule" : "Add policy rule"}</DialogTitle>
+          <DialogDescription>
+            Leave a condition empty to match anything. The preview shows the request shape this rule will affect.
+          </DialogDescription>
         </DialogHeader>
-        <div className="grid gap-3">
-          <Input value={name} onChange={(event) => setName(event.target.value)} placeholder="Rule name" />
-          <Select value={decision} onValueChange={(value) => setDecision(value as ApprovalPolicyDecision)}>
-            <SelectTrigger><SelectValue /></SelectTrigger>
-            <SelectContent>
-              <SelectItem value="ask">Ask</SelectItem>
-              <SelectItem value="allow">Allow</SelectItem>
-              <SelectItem value="deny">Deny</SelectItem>
-            </SelectContent>
-          </Select>
-          <Input value={agent} onChange={(event) => setAgent(event.target.value)} placeholder="Agent name" />
-          <Input value={provider} onChange={(event) => setProvider(event.target.value)} placeholder="Provider, e.g. ssh or aws" />
-          <Input value={command} onChange={(event) => setCommand(event.target.value)} placeholder="Command, e.g. ssh" />
+        <div className="space-y-5">
+          {rule?.conditions.envBindings?.length ? (
+            <Alert>
+              <AlertTitle>Exact credential bindings</AlertTitle>
+              <AlertDescription>
+                <span>This rule stays tied to the approved credential and environment-variable set.</span>
+                <span className="mt-2 flex flex-wrap gap-1.5">
+                  {rule.conditions.envBindings.map((binding) => (
+                    <code key={`${binding.injectEnv}:${binding.handle}`} className="rounded bg-muted px-1.5 py-0.5 text-xs">
+                      {binding.injectEnv} → {state.handles.find((handle) => handle.handle === binding.handle)?.name || shortHandle(binding.handle)}
+                    </code>
+                  ))}
+                </span>
+                <span className="mt-2 block">Create a new rule from an approval to change these bindings.</span>
+              </AlertDescription>
+            </Alert>
+          ) : null}
+          <PolicyFlowPreview form={form} state={state} />
+          <PolicyFormFields
+            form={form}
+            update={update}
+            sources={sources}
+            advanced={advanced}
+            bindingsLocked={bindingsLocked}
+            onShowAdvanced={() => setAdvanced(true)}
+          />
         </div>
         <DialogFooter>
-          <Button
-            disabled={busy || !name}
-            onClick={async () => {
-              setBusy(true);
-              try {
-                await addPolicy({
-                  name,
-                  enabled: true,
-                  priority: 100,
-                  decision,
-                  agents: agent ? [agent] : [],
-                  providers: provider ? [provider] : [],
-                  commands: command ? [command] : []
-                });
-                toast.success("Policy rule added");
-                onOpenChange(false);
-                onDone();
-              } catch (err) {
-                toast.error(err instanceof Error ? err.message : String(err));
-              } finally {
-                setBusy(false);
-              }
-            }}
-          >
-            Add rule
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={busy}>Cancel</Button>
+          <Button onClick={() => void save()} disabled={busy || !form.name.trim()}>
+            {busy ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+            {editing ? "Save changes" : "Add rule"}
           </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>
   );
+}
+
+function PolicyFormFields({
+  form,
+  update,
+  sources,
+  advanced,
+  bindingsLocked,
+  onShowAdvanced
+}: {
+  form: PolicyFormState;
+  update: <K extends keyof PolicyFormState>(field: K, value: PolicyFormState[K]) => void;
+  sources: PolicyOptionSources;
+  advanced: boolean;
+  bindingsLocked: boolean;
+  onShowAdvanced: () => void;
+}) {
+  return (
+    <div className="grid gap-x-6 gap-y-4 sm:grid-cols-2">
+      <PolicyField label="Name" className="sm:col-span-2">
+        <Input value={form.name} onChange={(event) => update("name", event.target.value)} placeholder="e.g. Allow Codex to run aws" />
+      </PolicyField>
+      <PolicyField label="Decision" hint="What s-gw does when this rule matches.">
+        <Select value={form.decision} onValueChange={(value) => update("decision", value as ApprovalPolicyDecision)}>
+          <SelectTrigger><SelectValue /></SelectTrigger>
+          <SelectContent>
+            <SelectItem value="ask">Ask for approval</SelectItem>
+            <SelectItem value="allow">Allow automatically</SelectItem>
+            <SelectItem value="deny">Deny automatically</SelectItem>
+          </SelectContent>
+        </Select>
+      </PolicyField>
+      <PolicyField label="Agents" hint="Request attribution, not a cryptographic identity boundary.">
+        <MultiSelectField values={form.agents} onChange={(value) => update("agents", value)} options={sources.agents} renderIcon={(value) => <AgentIcon name={value} className="h-4 w-4" />} aria-label="Policy agents" />
+      </PolicyField>
+      <PolicyField label={bindingsLocked ? "Credentials (fixed)" : "Credentials"} hint={bindingsLocked ? "Fixed by the exact binding set above." : undefined}>
+        <MultiSelectField values={form.handles} onChange={(value) => update("handles", value)} options={sources.handles} disabled={bindingsLocked} aria-label="Policy credentials" />
+      </PolicyField>
+      <PolicyField label="Commands">
+        <MultiSelectField values={form.commands} onChange={(value) => update("commands", value)} options={sources.commands} aria-label="Policy commands" />
+      </PolicyField>
+      <PolicyField label="Action kinds">
+        <MultiSelectField values={form.actionKinds} onChange={(value) => update("actionKinds", value)} options={policyActionKindOptions} allowCustom={false} aria-label="Policy action kinds" />
+      </PolicyField>
+      {advanced ? (
+        <>
+          <PolicyField label="Providers">
+            <MultiSelectField values={form.providers} onChange={(value) => update("providers", value)} options={sources.providers} aria-label="Policy providers" />
+          </PolicyField>
+          <PolicyField label="Credential types">
+            <MultiSelectField values={form.secretTypes} onChange={(value) => update("secretTypes", value)} options={policySecretTypeOptions} allowCustom={false} aria-label="Policy credential types" />
+          </PolicyField>
+          <PolicyField label="Minimum severity">
+            <Select value={form.minSeverity || "any"} onValueChange={(value) => update("minSeverity", value === "any" ? "" : value)}>
+              <SelectTrigger><SelectValue /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="any">Any severity</SelectItem>
+                <SelectItem value="low">Low and above</SelectItem>
+                <SelectItem value="medium">Medium and above</SelectItem>
+                <SelectItem value="high">High and above</SelectItem>
+                <SelectItem value="critical">Critical only</SelectItem>
+              </SelectContent>
+            </Select>
+          </PolicyField>
+          <PolicyField label={bindingsLocked ? "Injected environment variables (fixed)" : "Injected environment variables"} hint={bindingsLocked ? "Fixed by the exact binding set above." : undefined}>
+            <MultiSelectField values={form.injectEnvs} onChange={(value) => update("injectEnvs", value)} options={sources.injectEnvs} disabled={bindingsLocked} aria-label="Policy environment variables" />
+          </PolicyField>
+          <PolicyField label="Working directories">
+            <MultiSelectField values={form.workingDirs} onChange={(value) => update("workingDirs", value)} options={sources.workingDirs} aria-label="Policy working directories" />
+          </PolicyField>
+          <PolicyField label="SSH targets">
+            <MultiSelectField values={form.sshTargets} onChange={(value) => update("sshTargets", value)} options={sources.sshTargets} aria-label="Policy SSH targets" />
+          </PolicyField>
+          <PolicyField label="SSH ports">
+            <MultiSelectField values={form.sshPorts} onChange={(value) => update("sshPorts", value)} options={sources.sshPorts} aria-label="Policy SSH ports" />
+          </PolicyField>
+          <PolicyField label="Priority" hint="Lower values run first. Leave empty to add at the end.">
+            <Input value={form.priority} inputMode="numeric" onChange={(event) => update("priority", event.target.value.replace(/[^0-9]/g, ""))} placeholder="Auto" />
+          </PolicyField>
+        </>
+      ) : (
+        <Button type="button" variant="ghost" size="sm" className="justify-self-start text-muted-foreground sm:col-span-2" onClick={onShowAdvanced}>
+          <SlidersHorizontal className="mr-2 h-4 w-4" />More conditions
+        </Button>
+      )}
+    </div>
+  );
+}
+
+function PolicyField({ label, hint, className, children }: { label: string; hint?: string; className?: string; children: React.ReactNode }) {
+  return (
+    <div className={cn("min-w-0 space-y-1.5", className)}>
+      <div>
+        <div className="text-sm font-medium">{label}</div>
+        {hint ? <div className="text-xs text-muted-foreground">{hint}</div> : null}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function PolicyFlowPreview({ form, state }: { form: PolicyFormState; state: ConsoleState }) {
+  const handleLabels = form.handles.map((handle) => state.handles.find((item) => item.handle === handle)?.name || shortHandle(handle));
+  const decisionCopy = form.decision === "allow" ? "Runs automatically" : form.decision === "deny" ? "Blocked automatically" : "Requires approval";
+  const DecisionIcon = form.decision === "allow" ? ShieldCheck : form.decision === "deny" ? Ban : Clock3;
+  return (
+    <div className="grid gap-2 rounded-lg border bg-muted/30 p-3 text-sm sm:grid-cols-4" data-policy-flow-preview>
+      <PolicyFlowCell label="Agent" value={summarizePolicyValues(form.agents, "Any agent")} icon={<UsersRound className="h-4 w-4" />} />
+      <PolicyFlowCell label="Action" value={summarizePolicyValues(form.commands, form.actionKinds.includes("ssh_session") ? "SSH session" : "Any command")} icon={<CommandIcon className="h-4 w-4" />} />
+      <PolicyFlowCell label="Credential" value={summarizePolicyValues(handleLabels, "Any credential")} icon={<KeyRound className="h-4 w-4" />} />
+      <PolicyFlowCell label="Decision" value={decisionCopy} icon={<DecisionIcon className="h-4 w-4" />} />
+    </div>
+  );
+}
+
+function PolicyFlowCell({ label, value, icon }: { label: string; value: string; icon: React.ReactNode }) {
+  return (
+    <div className="min-w-0 rounded-md border bg-background/70 p-2">
+      <div className="flex items-center gap-1.5 text-xs text-muted-foreground">{icon}{label}</div>
+      <div className="mt-1 truncate font-medium">{value}</div>
+    </div>
+  );
+}
+
+function summarizePolicyValues(values: string[], fallback: string): string {
+  if (values.length === 0) return fallback;
+  if (values.length <= 2) return values.join(", ");
+  return `${values.slice(0, 2).join(", ")} +${values.length - 2}`;
 }
 
 function CommandPalette({

--- a/src/console-ui/src/components/MultiSelectField.tsx
+++ b/src/console-ui/src/components/MultiSelectField.tsx
@@ -1,0 +1,143 @@
+import * as React from "react";
+import { Check, ChevronsUpDown, Plus, X } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "@/components/ui/command";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+
+export interface MultiSelectOption {
+  value: string;
+  label?: string;
+  hint?: string;
+}
+
+export interface MultiSelectFieldProps {
+  values: string[];
+  onChange: (values: string[]) => void;
+  options: Array<MultiSelectOption | string>;
+  placeholder?: string;
+  emptyText?: string;
+  allowCustom?: boolean;
+  disabled?: boolean;
+  className?: string;
+  renderIcon?: (value: string) => React.ReactNode;
+  "aria-label"?: string;
+}
+
+export function MultiSelectField({
+  values,
+  onChange,
+  options,
+  placeholder = "Any (no restriction)",
+  emptyText = "No matches",
+  allowCustom = true,
+  disabled = false,
+  className,
+  renderIcon,
+  ...rest
+}: MultiSelectFieldProps) {
+  const [open, setOpen] = React.useState(false);
+  const [query, setQuery] = React.useState("");
+  const normalizedOptions = React.useMemo(() => options.map(asOption), [options]);
+  const labels = React.useMemo(() => new Map(normalizedOptions.map((option) => [option.value, option.label || option.value])), [normalizedOptions]);
+
+  const toggle = (value: string) => {
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    onChange(values.includes(trimmed) ? values.filter((item) => item !== trimmed) : [...values, trimmed]);
+  };
+
+  const filtered = normalizedOptions.filter((option) => {
+    const needle = query.trim().toLowerCase();
+    return `${option.value} ${option.label || ""}`.toLowerCase().includes(needle);
+  });
+  const customValue = query.trim();
+  const canAddCustom = allowCustom && customValue.length > 0 && !normalizedOptions.some(
+    (option) => option.value.toLowerCase() === customValue.toLowerCase()
+  ) && !values.some((value) => value.toLowerCase() === customValue.toLowerCase());
+
+  return (
+    <div className={cn("space-y-2", className)}>
+      {values.length ? (
+        <div className="flex flex-wrap gap-1" aria-label="Selected values">
+          {values.map((value) => (
+            <Badge key={value} variant="secondary" className="gap-1 pr-1">
+              {renderIcon ? <span className="flex items-center">{renderIcon(value)}</span> : null}
+              {labels.get(value) || value}
+              <button
+                type="button"
+                className="rounded-sm p-0.5 hover:bg-muted-foreground/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                aria-label={`Remove ${labels.get(value) || value}`}
+                disabled={disabled}
+                onClick={() => onChange(values.filter((item) => item !== value))}
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </Badge>
+          ))}
+        </div>
+      ) : null}
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            type="button"
+            variant="outline"
+            role="combobox"
+            aria-expanded={open}
+            disabled={disabled}
+            className="w-full justify-between font-normal"
+            {...rest}
+          >
+            <span className={cn("truncate text-left", values.length === 0 && "text-muted-foreground")}>
+              {values.length ? "Add or remove values" : placeholder}
+            </span>
+            <ChevronsUpDown className="h-4 w-4 shrink-0 opacity-50" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-[var(--radix-popover-trigger-width)] min-w-56 p-0" align="start">
+          <Command shouldFilter={false}>
+            <CommandInput placeholder="Search or type a value..." value={query} onValueChange={setQuery} />
+            <CommandList>
+              {filtered.length === 0 && !canAddCustom ? <CommandEmpty>{emptyText}</CommandEmpty> : null}
+              {canAddCustom ? (
+                <CommandGroup>
+                  <CommandItem
+                    value={`add-${customValue}`}
+                    onSelect={() => {
+                      toggle(customValue);
+                      setQuery("");
+                    }}
+                  >
+                    <Plus className="h-4 w-4" />
+                    Add &ldquo;{customValue}&rdquo;
+                  </CommandItem>
+                </CommandGroup>
+              ) : null}
+              {filtered.length ? (
+                <CommandGroup>
+                  {filtered.map((option) => {
+                    const selected = values.includes(option.value);
+                    return (
+                      <CommandItem key={option.value} value={option.value} onSelect={() => toggle(option.value)}>
+                        <Check className={cn("h-4 w-4", selected ? "opacity-100" : "opacity-0")} />
+                        {renderIcon ? <span className="flex items-center">{renderIcon(option.value)}</span> : null}
+                        <span className="flex-1 truncate">{option.label || option.value}</span>
+                        {option.hint ? <span className="text-xs text-muted-foreground">{option.hint}</span> : null}
+                      </CommandItem>
+                    );
+                  })}
+                </CommandGroup>
+              ) : null}
+            </CommandList>
+          </Command>
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+}
+
+function asOption(option: MultiSelectOption | string): MultiSelectOption {
+  return typeof option === "string" ? { value: option } : option;
+}

--- a/src/console-ui/src/lib/api.ts
+++ b/src/console-ui/src/lib/api.ts
@@ -5,7 +5,8 @@ import type {
   ApprovalPolicyDecision,
   AgentIntegrationMutation,
   ConsoleState,
-  RequestRecord
+  RequestRecord,
+  SecretSeverity
 } from "@/lib/types";
 
 interface ApiOptions {
@@ -58,6 +59,13 @@ export function approveRequest(
   });
 }
 
+export function approveRequestWithScopedPolicy(request: RequestRecord) {
+  return apiJson<{ request: RequestRecord; created: boolean }>(`/api/requests/${encodeURIComponent(request.id)}/approve-policy`, {
+    method: "POST",
+    body: {}
+  });
+}
+
 export function denyRequest(request: RequestRecord) {
   return apiJson<RequestRecord>(`/api/requests/${encodeURIComponent(request.id)}/deny`, {
     method: "POST",
@@ -85,22 +93,37 @@ export function saveApprovalSettings(body: { mode: ApprovalMode; durationMs: num
   return apiJson("/api/approval", { method: "POST", body });
 }
 
-export function addPolicy(body: {
+export interface PolicyInput {
   name: string;
   enabled: boolean;
-  priority: number;
+  priority?: number;
   decision: ApprovalPolicyDecision;
   agents?: string[];
   handles?: string[];
+  envBindings?: Array<{ handle: string; injectEnv: string }>;
   providers?: string[];
   secretTypes?: string[];
+  minSeverity?: SecretSeverity | null;
   actionKinds?: string[];
   commands?: string[];
   injectEnvs?: string[];
+  workingDirs?: string[];
   sshTargets?: string[];
+  sshPorts?: number[];
   durationMs?: number;
-}) {
+  expiresAt?: string | null;
+}
+
+export function addPolicy(body: PolicyInput) {
   return apiJson("/api/approval/policies", { method: "POST", body });
+}
+
+export function updatePolicy(id: string, body: Partial<PolicyInput>) {
+  return apiJson(`/api/approval/policies/${encodeURIComponent(id)}`, { method: "PUT", body });
+}
+
+export function arrangePolicies() {
+  return apiJson<{ reordered: number }>("/api/approval/policies/arrange", { method: "POST", body: {} });
 }
 
 export function setPolicyEnabled(id: string, enabled: boolean) {

--- a/src/console-ui/src/lib/format.ts
+++ b/src/console-ui/src/lib/format.ts
@@ -57,6 +57,19 @@ export function titleCase(value: string): string {
 export function policyConditionSummary(conditions: Record<string, unknown>): string {
   const parts: string[] = [];
   for (const [key, value] of Object.entries(conditions)) {
+    if (key === "envBindings" && Array.isArray(value) && value.length > 0) {
+      const bindings = value
+        .filter((binding): binding is { handle: string; injectEnv: string } => {
+          return Boolean(binding) && typeof binding === "object" &&
+            typeof (binding as { handle?: unknown }).handle === "string" &&
+            typeof (binding as { injectEnv?: unknown }).injectEnv === "string";
+        })
+        .map((binding) => `${binding.injectEnv} → ${shortHandle(binding.handle)}`);
+      if (bindings.length > 0) {
+        parts.push(`Credential bindings: ${bindings.slice(0, 2).join(", ")}${bindings.length > 2 ? ` +${bindings.length - 2}` : ""}`);
+      }
+      continue;
+    }
     if (Array.isArray(value) && value.length > 0) {
       parts.push(`${titleCase(key)}: ${value.slice(0, 2).join(", ")}${value.length > 2 ? ` +${value.length - 2}` : ""}`);
     } else if (typeof value === "string" && value) {

--- a/src/console-ui/src/lib/types.ts
+++ b/src/console-ui/src/lib/types.ts
@@ -225,6 +225,7 @@ export interface ApprovalPolicyRuleRecord {
   decision: ApprovalPolicyDecision;
   conditions: {
     handles?: string[];
+    envBindings?: Array<{ handle: string; injectEnv: string }>;
     secretTypes?: string[];
     providers?: string[];
     minSeverity?: SecretSeverity;

--- a/src/policy-order.ts
+++ b/src/policy-order.ts
@@ -1,0 +1,233 @@
+import type { ApprovalPolicyDecision, SecretSeverity } from "./types.js";
+
+export interface PolicyConditionsLike {
+  handles?: string[];
+  envBindings?: Array<{ handle: string; injectEnv: string }>;
+  secretTypes?: string[];
+  providers?: string[];
+  minSeverity?: SecretSeverity;
+  agents?: string[];
+  actionKinds?: string[];
+  commands?: string[];
+  injectEnvs?: string[];
+  workingDirs?: string[];
+  sshTargets?: string[];
+  sshPorts?: number[];
+}
+
+export interface PolicyRuleLike {
+  id: string;
+  priority: number;
+  decision: ApprovalPolicyDecision;
+  conditions: PolicyConditionsLike;
+  enabled: boolean;
+  expiresAt?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+const arrayFields: Array<keyof Pick<
+  PolicyConditionsLike,
+  "handles" | "secretTypes" | "providers" | "agents" | "actionKinds" | "commands" | "injectEnvs" | "workingDirs" | "sshTargets" | "sshPorts"
+>> = [
+  "handles",
+  "secretTypes",
+  "providers",
+  "agents",
+  "actionKinds",
+  "commands",
+  "injectEnvs",
+  "workingDirs",
+  "sshTargets",
+  "sshPorts"
+];
+
+const severityRanks: Record<SecretSeverity, number> = {
+  low: 0,
+  medium: 1,
+  high: 2,
+  critical: 3
+};
+
+const decisionRanks: Record<ApprovalPolicyDecision, number> = {
+  deny: 0,
+  ask: 1,
+  allow: 2
+};
+
+export function compareApprovalPolicyRules<T extends PolicyRuleLike>(left: T, right: T): number {
+  const priority = left.priority - right.priority;
+  if (priority) {
+    return priority;
+  }
+
+  const updated = right.updatedAt.localeCompare(left.updatedAt);
+  return updated || left.id.localeCompare(right.id);
+}
+
+export function approvalPolicyRuleCovers<T extends PolicyRuleLike>(broader: T, narrower: T): boolean {
+  if (!bindingSetCovers(broader.conditions.envBindings, narrower.conditions.envBindings)) {
+    return false;
+  }
+
+  for (const field of arrayFields) {
+    if (!listCovers(broader.conditions[field], narrower.conditions[field])) {
+      return false;
+    }
+  }
+
+  const broaderSeverity = broader.conditions.minSeverity;
+  const narrowerSeverity = narrower.conditions.minSeverity;
+  if (broaderSeverity && (!narrowerSeverity || severityRanks[broaderSeverity] > severityRanks[narrowerSeverity])) {
+    return false;
+  }
+
+  return true;
+}
+
+export function approvalPolicyRulesEquivalent<T extends PolicyRuleLike>(left: T, right: T): boolean {
+  return approvalPolicyRuleCovers(left, right) && approvalPolicyRuleCovers(right, left);
+}
+
+export function findShadowingPolicyRule<T extends PolicyRuleLike>(
+  rules: T[],
+  target: T,
+  now = new Date().toISOString()
+): T | undefined {
+  for (const candidate of [...rules].sort(compareApprovalPolicyRules)) {
+    if (candidate.id === target.id) {
+      break;
+    }
+    if (!candidate.enabled || isExpired(candidate, now)) {
+      continue;
+    }
+    if (approvalPolicyRuleCovers(candidate, target)) {
+      return candidate;
+    }
+  }
+
+  return undefined;
+}
+
+export function arrangeApprovalPolicyRules<T extends PolicyRuleLike>(
+  rules: T[],
+  now = new Date().toISOString()
+): { rules: T[]; reordered: number } {
+  const current = [...rules].sort(compareApprovalPolicyRules);
+  const originalIndex = new Map(current.map((rule, index) => [rule.id, index] as const));
+  const outgoing = new Map<string, Set<string>>(current.map((rule) => [rule.id, new Set<string>()]));
+  const indegree = new Map<string, number>(current.map((rule) => [rule.id, 0]));
+
+  for (const left of current) {
+    for (const right of current) {
+      if (left.id === right.id) {
+        continue;
+      }
+
+      if (approvalPolicyRuleCovers(left, right) && !approvalPolicyRuleCovers(right, left)) {
+        if (left.decision === "deny" && right.decision !== "deny") {
+          addOrderConstraint(outgoing, indegree, left.id, right.id);
+        } else {
+          addOrderConstraint(outgoing, indegree, right.id, left.id);
+        }
+        continue;
+      }
+
+      if (!approvalPolicyRulesEquivalent(left, right)) {
+        continue;
+      }
+
+      if (decisionRanks[left.decision] < decisionRanks[right.decision]) {
+        addOrderConstraint(outgoing, indegree, left.id, right.id);
+      }
+    }
+  }
+
+  const byId = new Map(current.map((rule) => [rule.id, rule] as const));
+  const ready = current.filter((rule) => indegree.get(rule.id) === 0);
+  const arranged: T[] = [];
+
+  while (ready.length) {
+    ready.sort((left, right) => (originalIndex.get(left.id) || 0) - (originalIndex.get(right.id) || 0));
+    const next = ready.shift();
+    if (!next) {
+      break;
+    }
+    arranged.push(next);
+
+    for (const childId of outgoing.get(next.id) || []) {
+      const nextIndegree = (indegree.get(childId) || 0) - 1;
+      indegree.set(childId, nextIndegree);
+      if (nextIndegree === 0) {
+        const child = byId.get(childId);
+        if (child) {
+          ready.push(child);
+        }
+      }
+    }
+  }
+
+  if (arranged.length !== current.length) {
+    return { rules: current, reordered: 0 };
+  }
+
+  const reordered = arranged.filter((rule, index) => current[index]?.id !== rule.id).length;
+  if (reordered === 0) {
+    return { rules: current, reordered };
+  }
+
+  return {
+    rules: arranged.map((rule, index) => ({
+      ...rule,
+      priority: (index + 1) * 10,
+      updatedAt: now
+    })),
+    reordered
+  };
+}
+
+function addOrderConstraint(
+  outgoing: Map<string, Set<string>>,
+  indegree: Map<string, number>,
+  beforeId: string,
+  afterId: string
+): void {
+  const children = outgoing.get(beforeId);
+  if (!children || children.has(afterId)) {
+    return;
+  }
+
+  children.add(afterId);
+  indegree.set(afterId, (indegree.get(afterId) || 0) + 1);
+}
+
+function listCovers(broader: unknown[] | undefined, narrower: unknown[] | undefined): boolean {
+  if (!broader?.length) {
+    return true;
+  }
+  if (!narrower?.length) {
+    return false;
+  }
+
+  const values = new Set(broader);
+  return narrower.every((value) => values.has(value));
+}
+
+function bindingSetCovers(
+  broader: Array<{ handle: string; injectEnv: string }> | undefined,
+  narrower: Array<{ handle: string; injectEnv: string }> | undefined
+): boolean {
+  if (!broader?.length) {
+    return true;
+  }
+  if (!narrower?.length || broader.length !== narrower.length) {
+    return false;
+  }
+
+  const values = new Set(broader.map((binding) => `${binding.handle}\u0000${binding.injectEnv}`));
+  return narrower.every((binding) => values.has(`${binding.handle}\u0000${binding.injectEnv}`));
+}
+
+function isExpired(rule: PolicyRuleLike, now: string): boolean {
+  return Boolean(rule.expiresAt && rule.expiresAt <= now);
+}

--- a/src/store.ts
+++ b/src/store.ts
@@ -4,8 +4,9 @@ import { access, chmod, lstat, mkdir, open, readFile, readdir, rename, rm, rmdir
 import os from "node:os";
 import path from "node:path";
 import { decryptSecret, encryptSecret, fingerprintSecret, shortId } from "./crypto.js";
-import { requestAgentIdentity, requestAgentName, type AgentIdentity, type AgentIdentityContext } from "./agent-context.js";
+import { agentNameFromReason, requestAgentIdentity, requestAgentName, type AgentIdentity, type AgentIdentityContext } from "./agent-context.js";
 import { normalizeOnePasswordReference, readOnePasswordReference } from "./onepassword.js";
+import { arrangeApprovalPolicyRules as arrangePolicyRules, compareApprovalPolicyRules } from "./policy-order.js";
 import { SGW_SSH_SESSION_COMMAND, normalizeSshPort, normalizeSshTarget, sshSessionIdentity } from "./ssh.js";
 import { ensureSgwHome, getSgwHome, getSgwRecoveryHome, getStorePath } from "./paths.js";
 import {
@@ -60,6 +61,20 @@ const storeMarkerName = ".store-initialized";
 const controlStateName = ".store-control.json";
 const pendingControlStateName = ".store-control.pending.json";
 const reusableExecutionPermits = new WeakMap<object, string>();
+const approvalPolicyConditionFields: Array<keyof ApprovalPolicyConditions> = [
+  "handles",
+  "envBindings",
+  "secretTypes",
+  "providers",
+  "minSeverity",
+  "agents",
+  "actionKinds",
+  "commands",
+  "injectEnvs",
+  "workingDirs",
+  "sshTargets",
+  "sshPorts"
+];
 
 const emptyStore = (): StoreFile => ({
   version: 1,
@@ -110,9 +125,30 @@ export interface AddApprovalPolicyRuleInput {
   durationMs?: number;
 }
 
+export interface UpdateApprovalPolicyRuleInput {
+  name?: string;
+  enabled?: boolean;
+  priority?: number;
+  decision?: ApprovalPolicyDecision;
+  conditions?: Partial<ApprovalPolicyConditions>;
+  expiresAt?: string | null;
+  durationMs?: number;
+}
+
 export interface SetApprovalPolicyRuleEnabledResult {
   id: string;
   enabled: boolean;
+}
+
+export interface ArrangeApprovalPolicyRulesResult {
+  rules: ApprovalPolicyRule[];
+  reordered: number;
+}
+
+export interface ApproveRequestWithPolicyResult {
+  request: RequestRecord;
+  rule: ApprovalPolicyRule;
+  created: boolean;
 }
 
 export interface ApproveRequestOptions {
@@ -609,7 +645,8 @@ export class SecretStore {
         return !request || !requestReferencesHandle(request, handle);
       });
       store.approvalPolicyRules = (store.approvalPolicyRules || []).filter((rule) => {
-        return !(rule.conditions.handles || []).includes(handle);
+        return !(rule.conditions.handles || []).includes(handle) &&
+          !(rule.conditions.envBindings || []).some((binding) => binding.handle === handle);
       });
       clearOnePasswordPolicyCaches(store);
 
@@ -709,25 +746,79 @@ export class SecretStore {
   async addApprovalPolicyRule(input: AddApprovalPolicyRuleInput): Promise<ApprovalPolicyRule> {
     return this.mutate((store) => {
       const now = new Date().toISOString();
+      const rule = addApprovalPolicyRuleInStore(store, input, now);
+      clearOnePasswordPolicyCaches(store);
+      return rule;
+    });
+  }
+
+  async updateApprovalPolicyRule(id: string, input: UpdateApprovalPolicyRuleInput): Promise<ApprovalPolicyRule> {
+    return this.mutate((store) => {
+      if (!hasApprovalPolicyUpdate(input)) {
+        throw new Error("Approval policy update must include at least one change.");
+      }
+
+      const rules = store.approvalPolicyRules || [];
+      const existing = rules.find((rule) => rule.id === id);
+      if (!existing) {
+        throw new Error(`Unknown approval policy: ${id}`);
+      }
+
+      const now = new Date().toISOString();
+      const existingConditions = normalizeApprovalPolicyConditions(existing.conditions);
+      if (exactBindingsWouldConflict(existingConditions, input.conditions)) {
+        throw new Error("Approval policies with exact credential bindings keep their bindings, credentials, and environment variables fixed. Create a new rule to change them.");
+      }
       const rule = normalizeApprovalPolicyRule(
         {
-          id: shortId("policy"),
-          name: input.name || defaultPolicyRuleName(input.decision),
-          enabled: input.enabled !== false,
-          priority: input.priority ?? nextPolicyPriority(store),
-          decision: input.decision,
-          conditions: normalizeApprovalPolicyConditions(input.conditions),
-          expiresAt: policyExpiresAt(input, now),
-          createdAt: now,
-          updatedAt: now
+          ...existing,
+          name: input.name === undefined ? existing.name : requirePolicyName(input.name),
+          enabled: input.enabled === undefined ? existing.enabled : requirePolicyEnabled(input.enabled),
+          priority: input.priority === undefined ? existing.priority : requirePolicyPriority(input.priority),
+          decision: input.decision === undefined ? existing.decision : requireApprovalPolicyDecision(input.decision),
+          conditions: input.conditions === undefined
+            ? existingConditions
+            : mergeApprovalPolicyConditions(existingConditions, input.conditions),
+          expiresAt: resolveUpdatedPolicyExpiresAt(existing, input, now),
+          updatedAt: existing.updatedAt
         },
-        now
+        existing.updatedAt
       );
+      if (sameApprovalPolicyRuleContent(existing, rule)) {
+        return existing;
+      }
 
-      store.approvalPolicyRules = sortApprovalPolicyRules([...(store.approvalPolicyRules || []), rule]);
+      rule.updatedAt = now;
+
+      store.approvalPolicyRules = sortApprovalPolicyRules(
+        rules.map((candidate) => candidate.id === id ? rule : candidate)
+      );
       clearOnePasswordPolicyCaches(store);
-      store.audit.push(audit("approval.policy.created", `Created approval policy ${rule.name}.`));
+      store.audit.push(audit("approval.policy.updated", `Updated approval policy ${rule.name}.`));
       return rule;
+    });
+  }
+
+  async arrangeApprovalPolicyRules(): Promise<ArrangeApprovalPolicyRulesResult> {
+    const current = await this.read();
+    const preview = arrangePolicyRules(current.approvalPolicyRules || []);
+    if (preview.reordered === 0) {
+      return preview;
+    }
+
+    return this.mutate((store) => {
+      const now = new Date().toISOString();
+      const arranged = arrangePolicyRules(store.approvalPolicyRules || [], now);
+      if (arranged.reordered === 0) {
+        return arranged;
+      }
+
+      store.approvalPolicyRules = arranged.rules;
+      clearOnePasswordPolicyCaches(store);
+      store.audit.push(
+        audit("approval.policy.arranged", `Auto-arranged ${arranged.reordered} approval polic${arranged.reordered === 1 ? "y" : "ies"}.`)
+      );
+      return arranged;
     });
   }
 
@@ -752,6 +843,9 @@ export class SecretStore {
       const rule = (store.approvalPolicyRules || []).find((item) => item.id === id);
       if (!rule) {
         throw new Error(`Unknown approval policy: ${id}`);
+      }
+      if (rule.enabled === enabled) {
+        return { id, enabled };
       }
 
       rule.enabled = enabled;
@@ -853,21 +947,57 @@ export class SecretStore {
 
   async approveRequest(id: string, options: ApproveRequestOptions = {}): Promise<RequestRecord> {
     return this.updateRequest(id, (request, store) => {
-      if (request.state === "approved" || request.state === "executing" || request.state === "executed") {
-        return;
+      approvePendingRequest(store, request, id, options);
+    });
+  }
+
+  async approveRequestWithScopedPolicy(id: string): Promise<ApproveRequestWithPolicyResult> {
+    return this.mutate((store) => {
+      const request = store.requests.find((item) => item.id === id);
+      if (!request) {
+        throw new Error(`Unknown request: ${id}`);
       }
       if (request.state !== "pending") {
         throw new Error(`Only pending requests can be approved. Current state: ${request.state}`);
       }
 
       const now = new Date().toISOString();
-      request.state = "approved";
-      request.approvedAt = now;
-      request.updatedAt = now;
-      request.approvalSource = "manual";
-      const grant = createApprovalGrant(store, request, now, options);
-      request.approvalGrantId = grant?.id;
-      store.audit.push(audit("request.approved", `Approved execution request ${id}.`, request.handle, id));
+      const secret = store.secrets.find((item) => item.handle === request.handle);
+      if (!secret) {
+        throw new Error(`Unknown secret handle: ${request.handle}`);
+      }
+      const agentName = durablePolicyAgentName(request);
+      let rule = matchingApprovalPolicyRuleForAction(store, secret, request.action, agentName, now);
+      let created = false;
+
+      if (rule?.decision !== "allow") {
+        const deny = blockingDenyPolicyRuleForAction(store, secret, request.action, agentName, now);
+        if (deny) {
+          throw new Error(`Approval policy ${deny.name} denies this request. Edit or disable it before creating an allow rule.`);
+        }
+
+        addApprovalPolicyRuleInStore(store, scopedAllowPolicyInput(request, agentName), now, {
+          handle: request.handle,
+          requestId: request.id
+        });
+        created = true;
+        const arranged = arrangePolicyRules(store.approvalPolicyRules || [], now);
+        store.approvalPolicyRules = arranged.rules;
+        rule = matchingApprovalPolicyRuleForAction(store, secret, request.action, agentName, now);
+        if (rule?.decision !== "allow") {
+          throw new Error("An existing policy takes precedence over this allow rule. Edit that policy before allowing this request.");
+        }
+
+        clearOnePasswordPolicyCaches(store);
+        if (arranged.reordered > 0) {
+          store.audit.push(
+            audit("approval.policy.arranged", `Auto-arranged ${arranged.reordered} approval polic${arranged.reordered === 1 ? "y" : "ies"}.`)
+          );
+        }
+      }
+
+      approvePendingRequest(store, request, id, { mode: "per-transaction", agentScope: "same-agent" }, now, rule);
+      return { request, rule, created };
     });
   }
 
@@ -2142,10 +2272,62 @@ function normalizeStoreFile(parsed: Partial<StoreFile>): StoreFile {
     approvalGrants: Array.isArray(parsed.approvalGrants)
       ? parsed.approvalGrants.filter(isValidApprovalGrant)
       : [],
-    approvalPolicyRules: Array.isArray(parsed.approvalPolicyRules)
-      ? sortApprovalPolicyRules(parsed.approvalPolicyRules.map((rule) => normalizeApprovalPolicyRule(rule)).filter(isValidApprovalPolicyRule))
-      : []
+    approvalPolicyRules: storedApprovalPolicyRules(parsed.approvalPolicyRules)
   };
+}
+
+function storedApprovalPolicyRules(value: unknown): ApprovalPolicyRule[] {
+  if (value === undefined) {
+    return [];
+  }
+  if (!Array.isArray(value)) {
+    throw new Error("approvalPolicyRules must be an array.");
+  }
+  return value.map((rule, index) => storedApprovalPolicyRule(rule, index));
+}
+
+function storedApprovalPolicyRule(value: unknown, index: number): ApprovalPolicyRule {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw invalidStoredApprovalPolicyRule(index, "rule must be an object.");
+  }
+
+  const rule = value as Partial<ApprovalPolicyRule>;
+  if (typeof rule.id !== "string" || !rule.id.trim()) {
+    throw invalidStoredApprovalPolicyRule(index, "id must be a non-empty string.");
+  }
+  if (typeof rule.name !== "string" || !rule.name.trim()) {
+    throw invalidStoredApprovalPolicyRule(index, "name must be a non-empty string.");
+  }
+  if (typeof rule.enabled !== "boolean") {
+    throw invalidStoredApprovalPolicyRule(index, "enabled must be a boolean.");
+  }
+  if (typeof rule.priority !== "number" || !Number.isFinite(rule.priority) || rule.priority < 0) {
+    throw invalidStoredApprovalPolicyRule(index, "priority must be a non-negative finite number.");
+  }
+  if (!isApprovalPolicyDecision(rule.decision)) {
+    throw invalidStoredApprovalPolicyRule(index, "decision must be allow, ask, or deny.");
+  }
+  if (!rule.conditions || typeof rule.conditions !== "object" || Array.isArray(rule.conditions)) {
+    throw invalidStoredApprovalPolicyRule(index, "conditions must be an object.");
+  }
+  if (!isCanonicalPolicyTimestamp(rule.createdAt) || !isCanonicalPolicyTimestamp(rule.updatedAt)) {
+    throw invalidStoredApprovalPolicyRule(index, "createdAt and updatedAt must be ISO timestamps.");
+  }
+  if (rule.expiresAt !== undefined && !isCanonicalPolicyTimestamp(rule.expiresAt)) {
+    throw invalidStoredApprovalPolicyRule(index, "expiresAt must be an ISO timestamp.");
+  }
+
+  try {
+    normalizeApprovalPolicyConditions(rule.conditions, true);
+  } catch (error) {
+    throw invalidStoredApprovalPolicyRule(index, errorMessage(error));
+  }
+
+  return rule as ApprovalPolicyRule;
+}
+
+function invalidStoredApprovalPolicyRule(index: number, message: string): Error {
+  return new Error(`Invalid approval policy at index ${index}: ${message}`);
 }
 
 function migrateRequestApprovalSources(requests: RequestRecord[], auditLog: AuditEvent[]): RequestRecord[] {
@@ -3035,7 +3217,8 @@ function matchingApprovalPolicyRule(
   secret: SecretRecord,
   action: CommandAction,
   agentName: string,
-  nowIso: string
+  nowIso: string,
+  envBindings: CommandEnvBinding[]
 ): ApprovalPolicyRule | undefined {
   const rules = sortApprovalPolicyRules(store.approvalPolicyRules || []);
   for (const rule of rules) {
@@ -3045,7 +3228,7 @@ function matchingApprovalPolicyRule(
     if (rule.expiresAt && rule.expiresAt <= nowIso) {
       continue;
     }
-    if (approvalPolicyMatches(rule, secret, action, agentName)) {
+    if (approvalPolicyMatches(rule, secret, action, agentName, envBindings)) {
       return rule;
     }
   }
@@ -3060,8 +3243,9 @@ function matchingApprovalPolicyRuleForAction(
   agentName: string,
   nowIso: string
 ): ApprovalPolicyRule | undefined {
+  const envBindings = policyEnvBindingsForAction(primarySecret.handle, action);
   const matched = [
-    matchingApprovalPolicyRule(store, primarySecret, policyActionForBinding(action, action.injectEnv), agentName, nowIso)
+    matchingApprovalPolicyRule(store, primarySecret, policyActionForBinding(action, action.injectEnv), agentName, nowIso, envBindings)
   ];
   for (const binding of action.env || []) {
     const secret = store.secrets.find((item) => item.handle === binding.handle);
@@ -3069,7 +3253,7 @@ function matchingApprovalPolicyRuleForAction(
       throw new Error(`Unknown secret handle: ${binding.handle}`);
     }
     matched.push(
-      matchingApprovalPolicyRule(store, secret, policyActionForBinding(action, binding.injectEnv), agentName, nowIso)
+      matchingApprovalPolicyRule(store, secret, policyActionForBinding(action, binding.injectEnv), agentName, nowIso, envBindings)
     );
   }
 
@@ -3088,6 +3272,40 @@ function matchingApprovalPolicyRuleForAction(
     : undefined;
 }
 
+function blockingDenyPolicyRuleForAction(
+  store: StoreFile,
+  primarySecret: SecretRecord,
+  action: CommandAction,
+  agentName: string,
+  nowIso: string
+): ApprovalPolicyRule | undefined {
+  const envBindings = policyEnvBindingsForAction(primarySecret.handle, action);
+  const secrets = [
+    { secret: primarySecret, action: policyActionForBinding(action, action.injectEnv) },
+    ...(action.env || []).map((binding) => {
+      const secret = store.secrets.find((item) => item.handle === binding.handle);
+      if (!secret) {
+        throw new Error(`Unknown secret handle: ${binding.handle}`);
+      }
+      return { secret, action: policyActionForBinding(action, binding.injectEnv) };
+    })
+  ];
+
+  for (const rule of sortApprovalPolicyRules(store.approvalPolicyRules || [])) {
+    if (!rule.enabled || rule.decision !== "deny" || !isValidApprovalPolicyRule(rule)) {
+      continue;
+    }
+    if (rule.expiresAt && rule.expiresAt <= nowIso) {
+      continue;
+    }
+    if (secrets.some((item) => approvalPolicyMatches(rule, item.secret, item.action, agentName, envBindings))) {
+      return rule;
+    }
+  }
+
+  return undefined;
+}
+
 function policyActionForBinding(action: CommandAction, injectEnv: string): CommandAction {
   return { ...action, injectEnv, env: [] };
 }
@@ -3096,10 +3314,14 @@ function approvalPolicyMatches(
   rule: ApprovalPolicyRule,
   secret: SecretRecord,
   action: CommandAction,
-  agentName: string
+  agentName: string,
+  envBindings: CommandEnvBinding[]
 ): boolean {
   const conditions = normalizeApprovalPolicyConditions(rule.conditions);
   if (conditions.handles?.length && !conditions.handles.includes(secret.handle)) {
+    return false;
+  }
+  if (conditions.envBindings?.length && !samePolicyEnvBindings(conditions.envBindings, envBindings)) {
     return false;
   }
   if (conditions.secretTypes?.length && !conditions.secretTypes.includes(secret.type)) {
@@ -3151,6 +3373,24 @@ function approvalPolicyMatches(
   return true;
 }
 
+function policyEnvBindingsForAction(primaryHandle: string, action: CommandAction): CommandEnvBinding[] {
+  return normalizePolicyEnvBindings([
+    { handle: primaryHandle, injectEnv: action.injectEnv },
+    ...(action.env || [])
+  ], true);
+}
+
+function samePolicyEnvBindings(expected: CommandEnvBinding[], actual: CommandEnvBinding[]): boolean {
+  if (expected.length !== actual.length) {
+    return false;
+  }
+
+  return expected.every((binding, index) => {
+    const candidate = actual[index];
+    return candidate?.handle === binding.handle && candidate.injectEnv === binding.injectEnv;
+  });
+}
+
 function requestCreationMessage(
   record: RequestRecord,
   grant: ApprovalGrant | undefined,
@@ -3169,6 +3409,102 @@ function requestCreationMessage(
   return `Created execution request ${record.id}${supersededCount ? ` and superseded ${supersededCount} older duplicate(s)` : ""}.`;
 }
 
+function addApprovalPolicyRuleInStore(
+  store: StoreFile,
+  input: AddApprovalPolicyRuleInput,
+  now: string,
+  auditContext: { handle?: string; requestId?: string } = {}
+): ApprovalPolicyRule {
+  const decision = requireApprovalPolicyDecision(input.decision);
+  const rule = normalizeApprovalPolicyRule(
+    {
+      id: shortId("policy"),
+      name: policyRuleName(input.name, decision),
+      enabled: input.enabled === undefined ? true : requirePolicyEnabled(input.enabled),
+      priority: input.priority === undefined ? nextPolicyPriority(store) : requirePolicyPriority(input.priority),
+      decision,
+      conditions: normalizeApprovalPolicyConditions(input.conditions, true),
+      expiresAt: policyExpiresAt(input, now),
+      createdAt: now,
+      updatedAt: now
+    },
+    now
+  );
+
+  store.approvalPolicyRules = sortApprovalPolicyRules([...(store.approvalPolicyRules || []), rule]);
+  store.audit.push(audit("approval.policy.created", `Created approval policy ${rule.name}.`, auditContext.handle, auditContext.requestId));
+  return rule;
+}
+
+function approvePendingRequest(
+  store: StoreFile,
+  request: RequestRecord,
+  id: string,
+  options: ApproveRequestOptions,
+  now = new Date().toISOString(),
+  policyRule?: ApprovalPolicyRule
+): void {
+  if (request.state === "approved" || request.state === "executing" || request.state === "executed") {
+    return;
+  }
+  if (request.state !== "pending") {
+    throw new Error(`Only pending requests can be approved. Current state: ${request.state}`);
+  }
+
+  request.state = "approved";
+  request.approvedAt = now;
+  request.updatedAt = now;
+  request.approvalSource = policyRule ? "policy" : "manual";
+  request.approvalPolicyRuleId = policyRule?.id;
+  const grant = createApprovalGrant(store, request, now, options);
+  request.approvalGrantId = grant?.id;
+  store.audit.push(
+    policyRule
+      ? audit("request.approved_by_policy", `Approved execution request ${id} with approval policy ${policyRule.name}.`, request.handle, id)
+      : audit("request.approved", `Approved execution request ${id}.`, request.handle, id)
+  );
+}
+
+function durablePolicyAgentName(request: RequestRecord): string {
+  const stored = request.agentName?.trim();
+  if (stored && (stored !== "Agent" || request.agentSource !== "unknown")) {
+    return stored;
+  }
+
+  const derived = agentNameFromReason(request.reason);
+  if (derived !== "Agent") {
+    return derived;
+  }
+
+  throw new Error("s-gw could not identify the requesting agent. Approve once or create a policy with an explicit agent condition.");
+}
+
+function scopedAllowPolicyInput(request: RequestRecord, agent: string): AddApprovalPolicyRuleInput {
+  const action = request.action;
+  const bindings = policyEnvBindingsForAction(request.handle, action);
+  const handles = uniqueStrings(bindings.map((binding) => binding.handle));
+  const injectEnvs = uniqueStrings(bindings.map((binding) => binding.injectEnv));
+  const actionLabel = action.kind === "ssh_session"
+    ? `SSH ${action.ssh?.target || "session"}`
+    : path.basename(action.command);
+
+  return {
+    name: `Allow ${agent || "agent"} to use ${actionLabel}`.slice(0, 120),
+    decision: "allow",
+    conditions: {
+      handles,
+      envBindings: bindings,
+      agents: [agent],
+      actionKinds: [action.kind],
+      commands: [action.command],
+      injectEnvs,
+      workingDirs: action.workingDir ? [action.workingDir] : [],
+      sshTargets: action.ssh?.target ? [action.ssh.target] : [],
+      sshPorts: action.ssh?.port ? [action.ssh.port] : []
+    }
+  };
+}
+
 function normalizeApprovalPolicyRule(rule: Partial<ApprovalPolicyRule>, nowIso = new Date().toISOString()): ApprovalPolicyRule {
   const decision = isApprovalPolicyDecision(rule.decision) ? rule.decision : "ask";
   return {
@@ -3184,20 +3520,220 @@ function normalizeApprovalPolicyRule(rule: Partial<ApprovalPolicyRule>, nowIso =
   };
 }
 
-function normalizeApprovalPolicyConditions(input?: Partial<ApprovalPolicyConditions>): ApprovalPolicyConditions {
+function normalizeApprovalPolicyConditions(
+  input?: Partial<ApprovalPolicyConditions>,
+  strict = false
+): ApprovalPolicyConditions {
+  if (input !== undefined && (!input || typeof input !== "object" || Array.isArray(input))) {
+    if (strict) {
+      throw new Error("conditions must be an object.");
+    }
+    return {};
+  }
+
+  const secretTypes = policyStringValues(input?.secretTypes, "secretTypes", strict);
+  const actionKinds = policyStringValues(input?.actionKinds, "actionKinds", strict);
+  const commands = policyStringValues(input?.commands, "commands", strict);
+  const minSeverity = normalizePolicySeverity(input?.minSeverity, strict);
+
   return {
-    handles: optionalStrings(input?.handles),
-    secretTypes: optionalSecretTypes(input?.secretTypes),
-    providers: optionalStrings(input?.providers).map((provider) => provider.toLowerCase()),
-    minSeverity: isSecretSeverity(input?.minSeverity) ? input.minSeverity : undefined,
-    agents: optionalStrings(input?.agents).map((agent) => agent.toLowerCase()),
-    actionKinds: optionalActionKinds(input?.actionKinds),
-    commands: optionalStrings(input?.commands).map((command) => safeNormalizeCommandGrant(command)).filter(Boolean) as string[],
-    injectEnvs: optionalStrings(input?.injectEnvs),
-    workingDirs: optionalStrings(input?.workingDirs).map((dir) => path.resolve(dir)),
-    sshTargets: optionalStrings(input?.sshTargets).map((target) => normalizeSshTarget(target)),
-    sshPorts: optionalPorts(input?.sshPorts)
+    handles: policyStringValues(input?.handles, "handles", strict),
+    envBindings: normalizePolicyEnvBindings(input?.envBindings, strict),
+    secretTypes: normalizePolicySecretTypes(secretTypes, strict),
+    providers: policyStringValues(input?.providers, "providers", strict).map((provider) => provider.toLowerCase()),
+    minSeverity,
+    agents: policyStringValues(input?.agents, "agents", strict).map((agent) => agent.toLowerCase()),
+    actionKinds: normalizePolicyActionKinds(actionKinds, strict),
+    commands: strict
+      ? commands.map((command) => normalizeCommandGrant(command))
+      : commands.map((command) => safeNormalizeCommandGrant(command)).filter(Boolean) as string[],
+    injectEnvs: policyStringValues(input?.injectEnvs, "injectEnvs", strict),
+    workingDirs: policyStringValues(input?.workingDirs, "workingDirs", strict).map((dir) => path.resolve(dir)),
+    sshTargets: policyStringValues(input?.sshTargets, "sshTargets", strict).map((target) => normalizeSshTarget(target)),
+    sshPorts: normalizePolicyPorts(input?.sshPorts, strict)
   };
+}
+
+function mergeApprovalPolicyConditions(
+  existing: ApprovalPolicyConditions,
+  patch: Partial<ApprovalPolicyConditions>
+): ApprovalPolicyConditions {
+  const current = normalizeApprovalPolicyConditions(existing);
+  const normalizedPatch = normalizeApprovalPolicyConditions(patch, true);
+  const merged: ApprovalPolicyConditions = { ...current };
+  for (const field of approvalPolicyConditionFields) {
+    if (hasOwn(patch, field)) {
+      merged[field] = normalizedPatch[field] as never;
+    }
+  }
+
+  return merged;
+}
+
+function hasApprovalPolicyUpdate(input: UpdateApprovalPolicyRuleInput): boolean {
+  if (
+    input.name !== undefined ||
+    input.enabled !== undefined ||
+    input.priority !== undefined ||
+    input.decision !== undefined ||
+    input.expiresAt !== undefined ||
+    input.durationMs !== undefined
+  ) {
+    return true;
+  }
+
+  const conditions = input.conditions;
+  if (conditions === undefined) {
+    return false;
+  }
+  if (!conditions || typeof conditions !== "object" || Array.isArray(conditions)) {
+    return true;
+  }
+
+  return approvalPolicyConditionFields.some((field) => hasOwn(conditions, field));
+}
+
+function exactBindingsWouldConflict(
+  existing: ApprovalPolicyConditions,
+  patch: Partial<ApprovalPolicyConditions> | undefined
+): boolean {
+  if (!existing.envBindings?.length || !patch || typeof patch !== "object" || Array.isArray(patch)) {
+    return false;
+  }
+
+  return hasOwn(patch, "envBindings") || hasOwn(patch, "handles") || hasOwn(patch, "injectEnvs");
+}
+
+function sameApprovalPolicyRuleContent(left: ApprovalPolicyRule, right: ApprovalPolicyRule): boolean {
+  return left.name === right.name &&
+    left.enabled === right.enabled &&
+    left.priority === right.priority &&
+    left.decision === right.decision &&
+    left.expiresAt === right.expiresAt &&
+    JSON.stringify(normalizeApprovalPolicyConditions(left.conditions)) ===
+      JSON.stringify(normalizeApprovalPolicyConditions(right.conditions));
+}
+
+function policyStringValues(value: unknown, field: string, strict: boolean): string[] {
+  if (value === undefined) {
+    return [];
+  }
+  if (!Array.isArray(value) || !value.every((item) => typeof item === "string")) {
+    if (strict) {
+      throw new Error(`${field} must be an array of strings.`);
+    }
+    return [];
+  }
+  if (strict && value.some((item) => !item.trim())) {
+    throw new Error(`${field} must not contain empty strings.`);
+  }
+
+  return uniqueStrings(value);
+}
+
+function normalizePolicyEnvBindings(value: unknown, strict: boolean): CommandEnvBinding[] {
+  if (value === undefined) {
+    return [];
+  }
+  if (!Array.isArray(value)) {
+    if (strict) {
+      throw new Error("envBindings must be an array of handle and environment-variable pairs.");
+    }
+    return [];
+  }
+
+  const bindings: CommandEnvBinding[] = [];
+  const seenEnvs = new Set<string>();
+  const seenPairs = new Set<string>();
+  for (const item of value) {
+    const handle = typeof item?.handle === "string" ? item.handle.trim() : "";
+    const injectEnv = typeof item?.injectEnv === "string" ? item.injectEnv.trim() : "";
+    if (!handle || handle.includes("\0") || !/^[A-Za-z_][A-Za-z0-9_]*$/.test(injectEnv)) {
+      if (strict) {
+        throw new Error("envBindings must contain non-empty handles and valid environment-variable names.");
+      }
+      continue;
+    }
+    if (seenEnvs.has(injectEnv)) {
+      if (strict) {
+        throw new Error(`Environment variable ${injectEnv} is bound more than once.`);
+      }
+      continue;
+    }
+
+    const key = `${handle}\0${injectEnv}`;
+    if (seenPairs.has(key)) {
+      continue;
+    }
+    seenEnvs.add(injectEnv);
+    seenPairs.add(key);
+    bindings.push({ handle, injectEnv });
+  }
+
+  return bindings.sort((left, right) => {
+    const envOrder = left.injectEnv.localeCompare(right.injectEnv);
+    return envOrder || left.handle.localeCompare(right.handle);
+  });
+}
+
+function normalizePolicySecretTypes(values: string[], strict: boolean): SecretType[] {
+  const types = values.filter(isSecretType);
+  if (strict && types.length !== values.length) {
+    throw new Error("secretTypes contains an unsupported credential type.");
+  }
+  return types;
+}
+
+function normalizePolicyActionKinds(values: string[], strict: boolean): ApprovalPolicyActionKind[] {
+  const kinds = values.filter((value): value is ApprovalPolicyActionKind => value === "env_command" || value === "ssh_session");
+  if (strict && kinds.length !== values.length) {
+    throw new Error("actionKinds must contain env_command or ssh_session.");
+  }
+  return kinds;
+}
+
+function normalizePolicySeverity(value: unknown, strict: boolean): SecretSeverity | undefined {
+  if (value === undefined || value === null || value === "") {
+    return undefined;
+  }
+  if (isSecretSeverity(value)) {
+    return value;
+  }
+  if (strict) {
+    throw new Error("minSeverity must be low, medium, high, or critical.");
+  }
+  return undefined;
+}
+
+function normalizePolicyPorts(value: unknown, strict: boolean): number[] {
+  if (value === undefined) {
+    return [];
+  }
+  if (!Array.isArray(value)) {
+    if (strict) {
+      throw new Error("sshPorts must be an array of port numbers.");
+    }
+    return [];
+  }
+
+  const ports: number[] = [];
+  for (const item of value) {
+    const port = Number(item);
+    if (!Number.isInteger(port) || port < 1 || port > 65535) {
+      if (strict) {
+        throw new Error("sshPorts must contain integers from 1 through 65535.");
+      }
+      continue;
+    }
+    if (!ports.includes(port)) {
+      ports.push(port);
+    }
+  }
+  return ports;
+}
+
+function hasOwn(value: object, key: PropertyKey): boolean {
+  return Object.prototype.hasOwnProperty.call(value, key);
 }
 
 function safeNormalizeCommandGrant(command: string): string | undefined {
@@ -3227,10 +3763,7 @@ function isApprovalPolicyDecision(value: unknown): value is ApprovalPolicyDecisi
 }
 
 function sortApprovalPolicyRules(rules: ApprovalPolicyRule[]): ApprovalPolicyRule[] {
-  return [...rules].sort((a, b) => {
-    const priority = a.priority - b.priority;
-    return priority || b.updatedAt.localeCompare(a.updatedAt);
-  });
+  return [...rules].sort(compareApprovalPolicyRules);
 }
 
 function nextPolicyPriority(store: StoreFile): number {
@@ -3250,14 +3783,14 @@ function defaultPolicyRuleName(decision: ApprovalPolicyDecision): string {
 }
 
 function policyExpiresAt(input: AddApprovalPolicyRuleInput, nowIso: string): string | undefined {
-  const explicit = normalizePolicyExpiresAt(input.expiresAt);
+  const explicit = requirePolicyExpiresAt(input.expiresAt);
   if (explicit) {
     return explicit;
   }
   if (input.durationMs === undefined) {
     return undefined;
   }
-  return new Date(Date.parse(nowIso) + clampApprovalDuration(input.durationMs)).toISOString();
+  return new Date(Date.parse(nowIso) + requirePolicyDuration(input.durationMs)).toISOString();
 }
 
 function normalizePolicyExpiresAt(value: unknown): string | undefined {
@@ -3268,49 +3801,87 @@ function normalizePolicyExpiresAt(value: unknown): string | undefined {
   return Number.isFinite(parsed) ? new Date(parsed).toISOString() : undefined;
 }
 
+function isCanonicalPolicyTimestamp(value: unknown): value is string {
+  return typeof value === "string" && normalizePolicyExpiresAt(value) === value;
+}
+
+function resolveUpdatedPolicyExpiresAt(
+  existing: ApprovalPolicyRule,
+  input: UpdateApprovalPolicyRuleInput,
+  nowIso: string
+): string | undefined {
+  if (input.expiresAt === null) {
+    return undefined;
+  }
+  if (input.expiresAt !== undefined) {
+    return requirePolicyExpiresAt(input.expiresAt);
+  }
+  if (input.durationMs !== undefined) {
+    return new Date(Date.parse(nowIso) + requirePolicyDuration(input.durationMs)).toISOString();
+  }
+  return existing.expiresAt;
+}
+
+function requirePolicyExpiresAt(value: unknown): string | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+
+  const normalized = normalizePolicyExpiresAt(value);
+  if (!normalized) {
+    throw new Error("expiresAt must be a valid ISO timestamp.");
+  }
+  return normalized;
+}
+
+function policyRuleName(name: string | undefined, decision: ApprovalPolicyDecision): string {
+  if (name === undefined) {
+    return defaultPolicyRuleName(decision);
+  }
+  return requirePolicyName(name);
+}
+
+function requirePolicyName(name: string): string {
+  const trimmed = name.trim();
+  if (!trimmed) {
+    throw new Error("Policy name is required.");
+  }
+  return trimmed.slice(0, 120);
+}
+
+function requireApprovalPolicyDecision(value: unknown): ApprovalPolicyDecision {
+  if (!isApprovalPolicyDecision(value)) {
+    throw new Error("decision must be allow, ask, or deny.");
+  }
+  return value;
+}
+
+function requirePolicyEnabled(value: unknown): boolean {
+  if (typeof value !== "boolean") {
+    throw new Error("enabled must be a boolean.");
+  }
+  return value;
+}
+
+function requirePolicyPriority(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    throw new Error("priority must be a non-negative finite number.");
+  }
+  return Math.min(Math.floor(value), 10_000);
+}
+
+function requirePolicyDuration(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    throw new Error("durationMs must be a positive finite number.");
+  }
+  return clampApprovalDuration(value);
+}
+
 function normalizePolicyPriority(value: unknown): number {
   if (typeof value !== "number" || !Number.isFinite(value)) {
     return 100;
   }
   return Math.max(0, Math.min(10_000, Math.floor(value)));
-}
-
-function optionalStrings(values: unknown): string[] {
-  if (!Array.isArray(values)) {
-    return [];
-  }
-  return uniqueStrings(values.filter((value): value is string => typeof value === "string"));
-}
-
-function optionalSecretTypes(values: unknown): SecretType[] {
-  if (!Array.isArray(values)) {
-    return [];
-  }
-  return uniqueStrings(values.filter((value): value is SecretType => isSecretType(value))) as SecretType[];
-}
-
-function optionalActionKinds(values: unknown): ApprovalPolicyActionKind[] {
-  if (!Array.isArray(values)) {
-    return [];
-  }
-  return uniqueStrings(values.filter((value): value is ApprovalPolicyActionKind => {
-    return value === "env_command" || value === "ssh_session";
-  })) as ApprovalPolicyActionKind[];
-}
-
-function optionalPorts(values: unknown): number[] {
-  if (!Array.isArray(values)) {
-    return [];
-  }
-  const out: number[] = [];
-  for (const value of values) {
-    const port = Number(value);
-    if (!Number.isInteger(port) || port < 1 || port > 65535 || out.includes(port)) {
-      continue;
-    }
-    out.push(port);
-  }
-  return out;
 }
 
 function isSecretType(value: unknown): value is SecretType {

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,6 +39,7 @@ export interface ApprovalGrant {
 
 export interface ApprovalPolicyConditions {
   handles?: string[];
+  envBindings?: CommandEnvBinding[];
   secretTypes?: SecretType[];
   providers?: string[];
   minSeverity?: SecretSeverity;

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -90,6 +90,109 @@ describe("CLI unknown-command behavior (end to end)", () => {
     }
   });
 
+  it("updates and auto-arranges approval policies, and documents both commands", async () => {
+    const home = await mkdtemp(path.join(os.tmpdir(), "sgw-cli-policy-"));
+    const recoveryHome = `${home}-recovery`;
+    const cargoTarget = `${home}-cargo`;
+    const env = {
+      ...process.env,
+      SGW_HOME: home,
+      SGW_RECOVERY_HOME: recoveryHome,
+      CARGO_TARGET_DIR: cargoTarget,
+      SGW_MASTER_PASSPHRASE: "cli-policy-test-passphrase",
+      SGW_DISABLE_KEYCHAIN: "1",
+      SGW_DISABLE_ONEPASSWORD_BACKUP: "1"
+    };
+    const run = (args: string[]) => execFileSync(tsxBin, ["src/cli.ts", ...args], {
+      cwd: repoRoot,
+      env,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"]
+    });
+
+    try {
+      const broad = JSON.parse(run([
+        "approval",
+        "policy",
+        "add",
+        "--name",
+        "Codex broad ask",
+        "--decision",
+        "ask",
+        "--priority",
+        "10",
+        "--agent",
+        "Codex"
+      ]));
+      const specific = JSON.parse(run([
+        "approval",
+        "policy",
+        "add",
+        "--name",
+        "Codex AWS allow",
+        "--decision",
+        "allow",
+        "--priority",
+        "20",
+        "--agent",
+        "Codex",
+        "--binding",
+        "SGW_CLI_POLICY=s-gw:api-token:cli",
+        "--expires-at",
+        "2030-01-01T00:00:00.000Z"
+      ]));
+
+      let emptyUpdateError: { stderr?: string } | undefined;
+      try {
+        run(["approval", "policy", "update", "--id", specific.id]);
+      } catch (error) {
+        emptyUpdateError = error as { stderr?: string };
+      }
+      expect(emptyUpdateError?.stderr).toContain("at least one change");
+
+      const updated = JSON.parse(run([
+        "approval",
+        "policy",
+        "update",
+        "--id",
+        specific.id,
+        "--name",
+        "Codex AWS deny",
+        "--decision",
+        "deny",
+        "--command",
+        "aws",
+        "--clear-expiry"
+      ]));
+      expect(updated).toMatchObject({
+        id: specific.id,
+        name: "Codex AWS deny",
+        decision: "deny"
+      });
+      expect(updated.conditions).toMatchObject({
+        agents: ["codex"],
+        commands: ["aws"],
+        envBindings: [{ handle: "s-gw:api-token:cli", injectEnv: "SGW_CLI_POLICY" }]
+      });
+      expect(updated.expiresAt).toBeUndefined();
+
+      const arranged = JSON.parse(run(["approval", "policy", "arrange"]));
+      expect(arranged.reordered).toBeGreaterThan(0);
+      expect(arranged.rules.map((rule: { id: string }) => rule.id)).toEqual([specific.id, broad.id]);
+
+      const listed = JSON.parse(run(["approval", "policy", "list"]));
+      expect(listed.map((rule: { id: string }) => rule.id)).toEqual([specific.id, broad.id]);
+
+      const help = run(["help"]);
+      expect(help).toContain("s-gw approval policy update --id POLICY_ID");
+      expect(help).toContain("s-gw approval policy arrange");
+    } finally {
+      await rm(home, { recursive: true, force: true });
+      await rm(recoveryHome, { recursive: true, force: true });
+      await rm(cargoTarget, { recursive: true, force: true });
+    }
+  });
+
   it("exits non-zero and prints a suggestion to stderr for a typo", async () => {
     const home = await mkdtemp(path.join(os.tmpdir(), "sgw-cli-typo-"));
     let stderr = "";

--- a/tests/console-browser-e2e.test.ts
+++ b/tests/console-browser-e2e.test.ts
@@ -211,6 +211,152 @@ describeBrowser("React local console (real headless Chrome)", () => {
     expect(launched.approvePostCount()).toBe(1);
   }, 45_000);
 
+  it("creates a scoped policy from the approval sheet without widening access", async () => {
+    process.env.SGW_MASTER_PASSPHRASE = "browser scoped policy passphrase";
+    running = await startConsoleServer({ port: 0 });
+
+    const created = await api<{ handle: string }>("api/secrets", {
+      name: "react-scoped-policy",
+      type: "api-token",
+      value: "react-scoped-policy-secret-value-1234567890",
+      injectEnv: "SGW_REACT_SCOPED_POLICY_TOKEN",
+      allowedCommands: [process.execPath]
+    });
+    const request = await api<{ id: string; state: string }>("api/requests", {
+      handle: created.handle,
+      command: process.execPath,
+      args: ["-e", "console.log('scoped policy')"],
+      injectEnv: "SGW_REACT_SCOPED_POLICY_TOKEN",
+      workingDir: repoRoot,
+      reason: "Scoped policy browser e2e",
+      agentName: "Codex"
+    });
+    expect(request.state).toBe("pending");
+
+    const launched = await launchChrome(new URL("approvals", running.url).toString());
+    cdp = launched.cdp;
+    await waitFor(
+      () => cdp!.eval<boolean>("document.querySelectorAll('tbody tr').length > 0"),
+      "scoped policy request row"
+    );
+    await cdp.eval("document.querySelector('tbody tr').dispatchEvent(new MouseEvent('click', { bubbles: true }))");
+    await waitFor(
+      () => cdp!.eval<boolean>(`Boolean(document.querySelector('[data-approve="${request.id}"]'))`),
+      "scoped policy approval sheet"
+    );
+    await cdp.eval(`(() => {
+      const button = [...document.querySelectorAll('button')]
+        .find((item) => item.textContent?.trim().startsWith('Allow for'));
+      button?.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+      return Boolean(button);
+    })()`);
+    await waitFor(
+      () => cdp!.eval<boolean>(`Boolean(document.querySelector('[data-approve-policy="${request.id}"]'))`),
+      "scoped policy approval action"
+    );
+    await clickElement(cdp, `[data-approve-policy="${request.id}"]`);
+
+    await waitFor(async () => {
+      const state = await api<{
+        requests: Array<{ id: string; state: string }>;
+        approvalPolicyRules: Array<unknown>;
+      }>("api/state");
+      return state.requests.find((item) => item.id === request.id)?.state === "approved"
+        && state.approvalPolicyRules.length === 1;
+    }, "scoped policy approval");
+
+    const state = await api<{
+      approvalPolicyRules: Array<{
+        id: string;
+        decision: string;
+        conditions: {
+          handles?: string[];
+          agents?: string[];
+          actionKinds?: string[];
+          commands?: string[];
+          injectEnvs?: string[];
+          workingDirs?: string[];
+        };
+      }>;
+    }>("api/state");
+    const rule = state.approvalPolicyRules[0];
+    expect(rule).toBeDefined();
+    if (!rule) {
+      throw new Error("Expected the approval sheet to create one scoped policy rule.");
+    }
+    expect(rule.decision).toBe("allow");
+    expect(rule.conditions).toMatchObject({
+      handles: [created.handle],
+      agents: ["codex"],
+      actionKinds: ["env_command"],
+      commands: [process.execPath],
+      injectEnvs: ["SGW_REACT_SCOPED_POLICY_TOKEN"],
+      workingDirs: [repoRoot]
+    });
+
+    const matchingRequest = await api<{
+      state: string;
+      approvalSource?: string;
+      approvalPolicyRuleId?: string;
+    }>("api/requests", {
+      handle: created.handle,
+      command: process.execPath,
+      args: ["-e", "console.log('matching scope')"],
+      injectEnv: "SGW_REACT_SCOPED_POLICY_TOKEN",
+      workingDir: repoRoot,
+      reason: "Matching scoped policy browser e2e",
+      agentName: "Codex"
+    });
+    expect(matchingRequest).toMatchObject({
+      state: "approved",
+      approvalSource: "policy",
+      approvalPolicyRuleId: rule.id
+    });
+
+    const differentAgent = await api<{ state: string }>("api/requests", {
+      handle: created.handle,
+      command: process.execPath,
+      args: ["-e", "console.log('different agent')"],
+      injectEnv: "SGW_REACT_SCOPED_POLICY_TOKEN",
+      workingDir: repoRoot,
+      reason: "Different agent scoped policy browser e2e",
+      agentName: "Claude"
+    });
+    expect(differentAgent.state).toBe("pending");
+
+    const differentDirectory = await api<{ state: string }>("api/requests", {
+      handle: created.handle,
+      command: process.execPath,
+      args: ["-e", "console.log('different directory')"],
+      injectEnv: "SGW_REACT_SCOPED_POLICY_TOKEN",
+      workingDir: path.join(repoRoot, "other-directory"),
+      reason: "Different directory scoped policy browser e2e",
+      agentName: "Codex"
+    });
+    expect(differentDirectory.state).toBe("pending");
+
+    await cdp.send("Page.navigate", { url: new URL("policies", running.url).toString() });
+    await waitFor(
+      () => cdp!.eval<boolean>(`Boolean(document.querySelector('[data-policy-edit="${rule.id}"]'))`),
+      "scoped policy edit action"
+    );
+    await clickElement(cdp, `[data-policy-edit="${rule.id}"]`);
+    await waitFor(
+      () => cdp!.eval<boolean>("document.body.innerText.includes('Exact credential bindings')"),
+      "exact binding editor notice"
+    );
+    const lockedFields = await cdp.eval<{ credentialsLocked: boolean; envLocked: boolean }>(`(() => {
+      const dialog = document.querySelector('[role="dialog"]');
+      return {
+        credentialsLocked: Boolean(dialog?.querySelector('[aria-label="Policy credentials"]')?.disabled),
+        envLocked: Boolean(dialog?.querySelector('[aria-label="Policy environment variables"]')?.disabled)
+      };
+    })()`);
+    expect(lockedFields).toEqual({ credentialsLocked: true, envLocked: true });
+
+    expect(launched.approvePostCount()).toBe(0);
+  }, 45_000);
+
   it("closes an approval sheet when another surface already approved the request", async () => {
     process.env.SGW_MASTER_PASSPHRASE = "browser stale approval passphrase";
     running = await startConsoleServer({ port: 0 });

--- a/tests/console-server.test.ts
+++ b/tests/console-server.test.ts
@@ -372,7 +372,7 @@ describe("local console server", () => {
     expect(afterRevoke.state).toBe("pending");
   });
 
-  it("manages approval policy rules through the console API", async () => {
+  it("updates and auto-arranges approval policy rules through the console API", async () => {
     running = await startConsoleServer({ port: 0 });
 
     const created = await fetchJson("api/approval/policies", {
@@ -380,16 +380,23 @@ describe("local console server", () => {
       body: {
         name: "Console Codex allow",
         decision: "allow",
-        priority: 10,
-        durationMs: 15 * 60 * 1000,
+        priority: 200,
+        expiresAt: "2030-01-01T00:00:00.000Z",
         agents: ["Codex"],
+        envBindings: [{ handle: "s-gw:api-token:console", injectEnv: "SGW_CONSOLE_POLICY_TOKEN" }],
         actionKinds: ["env_command"],
         commands: [process.execPath],
-        injectEnvs: ["SGW_CONSOLE_POLICY_TOKEN"]
+        injectEnvs: ["SGW_CONSOLE_POLICY_TOKEN"],
+        sshPorts: [2222]
       }
     });
     expect(created.id).toMatch(/^policy_/);
     expect(created.conditions.agents).toEqual(["codex"]);
+    expect(created.conditions.envBindings).toEqual([
+      { handle: "s-gw:api-token:console", injectEnv: "SGW_CONSOLE_POLICY_TOKEN" }
+    ]);
+    expect(created.conditions.sshPorts).toEqual([2222]);
+    const createdAt = created.createdAt;
 
     const state = await fetchJson("api/state");
     expect(state.approvalPolicyRules.map((rule: { id: string }) => rule.id)).toContain(created.id);
@@ -400,6 +407,56 @@ describe("local console server", () => {
     });
     expect(disabled.enabled).toBe(false);
 
+    const updated = await fetchJson(`api/approval/policies/${created.id}`, {
+      method: "PUT",
+      body: {
+        name: "Console Claude deny aws",
+        enabled: true,
+        decision: "deny",
+        agents: ["Claude"],
+        sshPorts: [2200, 2222]
+      }
+    });
+    expect(updated).toMatchObject({
+      id: created.id,
+      createdAt,
+      name: "Console Claude deny aws",
+      enabled: true,
+      decision: "deny"
+    });
+    expect(updated.conditions).toMatchObject({
+      agents: ["claude"],
+      envBindings: [{ handle: "s-gw:api-token:console", injectEnv: "SGW_CONSOLE_POLICY_TOKEN" }],
+      commands: [process.execPath],
+      injectEnvs: ["SGW_CONSOLE_POLICY_TOKEN"],
+      sshPorts: [2200, 2222]
+    });
+    expect(updated.expiresAt).toBe("2030-01-01T00:00:00.000Z");
+
+    const noExpiry = await fetchJson(`api/approval/policies/${created.id}`, {
+      method: "PUT",
+      body: { expiresAt: null }
+    });
+    expect(noExpiry.expiresAt).toBeUndefined();
+    expect(noExpiry.conditions.agents).toEqual(["claude"]);
+
+    const broad = await fetchJson("api/approval/policies", {
+      method: "POST",
+      body: {
+        name: "Console Claude broad ask",
+        decision: "ask",
+        priority: 10,
+        agents: ["Claude"]
+      }
+    });
+    const arranged = await fetchJson("api/approval/policies/arrange", { method: "POST", body: {} });
+    expect(arranged.reordered).toBeGreaterThan(0);
+    expect(arranged.rules.map((rule: { id: string }) => rule.id)).toEqual([created.id, broad.id]);
+
+    const ordered = await fetchJson("api/approval/policies");
+    expect(ordered.map((rule: { id: string }) => rule.id)).toEqual([created.id, broad.id]);
+
+    await fetchJson(`api/approval/policies/${broad.id}`, { method: "DELETE" });
     const deleted = await fetchJson(`api/approval/policies/${created.id}`, {
       method: "DELETE"
     });
@@ -407,6 +464,97 @@ describe("local console server", () => {
 
     const policies = await fetchJson("api/approval/policies");
     expect(policies).toHaveLength(0);
+  });
+
+  it("rejects malformed policy constraints without widening an existing rule", async () => {
+    running = await startConsoleServer({ port: 0 });
+    const created = await fetchJson("api/approval/policies", {
+      method: "POST",
+      body: {
+        name: "Narrow console policy",
+        decision: "allow",
+        commands: [process.execPath],
+        sshPorts: [22]
+      }
+    });
+    const scoped = await fetchJson("api/approval/policies", {
+      method: "POST",
+      body: {
+        name: "Exact binding policy",
+        decision: "allow",
+        envBindings: [{ handle: "s-gw:api-token:exact", injectEnv: "SGW_EXACT_TOKEN" }]
+      }
+    });
+    const before = await fetchJson("api/approval/policies");
+
+    const emptyUpdate = await fetch(consoleUrl(`api/approval/policies/${created.id}`), {
+      method: "PUT",
+      headers: authHeaders(),
+      body: "{}"
+    });
+    expect(emptyUpdate.status).toBe(400);
+    expect((await emptyUpdate.json()).error).toMatch(/at least one change/i);
+
+    const badExpiry = await fetch(consoleUrl(`api/approval/policies/${created.id}`), {
+      method: "PUT",
+      headers: authHeaders(),
+      body: JSON.stringify({ expiresAt: "" })
+    });
+    expect(badExpiry.status).toBe(400);
+    expect((await badExpiry.json()).error).toMatch(/expiresAt/i);
+
+    const badPort = await fetch(consoleUrl("api/approval/policies"), {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({
+        name: "Invalid port policy",
+        decision: "allow",
+        sshPorts: [0]
+      })
+    });
+    expect(badPort.status).toBe(400);
+    expect((await badPort.json()).error).toMatch(/sshPorts/i);
+
+    const blankCommand = await fetch(consoleUrl("api/approval/policies"), {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({
+        name: "Blank command policy",
+        decision: "allow",
+        commands: [""]
+      })
+    });
+    expect(blankCommand.status).toBe(400);
+    expect((await blankCommand.json()).error).toMatch(/commands.*non-empty/i);
+
+    const typoedConstraint = await fetch(consoleUrl("api/approval/policies"), {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({
+        name: "Typoed command policy",
+        decision: "allow",
+        command: process.execPath
+      })
+    });
+    expect(typoedConstraint.status).toBe(400);
+    expect((await typoedConstraint.json()).error).toMatch(/unsupported approval policy field.*command/i);
+
+    const changedBindings = await fetch(consoleUrl(`api/approval/policies/${scoped.id}`), {
+      method: "PUT",
+      headers: authHeaders(),
+      body: JSON.stringify({ envBindings: [] })
+    });
+    expect(changedBindings.status).toBe(409);
+    expect((await changedBindings.json()).error).toMatch(/exact credential bindings/i);
+
+    const clearedByNull = await fetch(consoleUrl(`api/approval/policies/${created.id}`), {
+      method: "PUT",
+      headers: authHeaders(),
+      body: JSON.stringify({ commands: null })
+    });
+    expect(clearedByNull.status).toBe(400);
+    expect((await clearedByNull.json()).error).toMatch(/commands.*array/i);
+    expect(await fetchJson("api/approval/policies")).toEqual(before);
   });
 
   it("builds an agent to credential to action usage flow without exposing secret values", async () => {

--- a/tests/console-ui-source.test.ts
+++ b/tests/console-ui-source.test.ts
@@ -122,6 +122,52 @@ describe("React console source contracts", () => {
     expect(app).not.toContain("PolicyEnabledStatus");
   });
 
+  it("keeps scoped policy approval atomic and narrowly bound to the request", async () => {
+    const [app, api, server, store] = await Promise.all([
+      readFile(path.join(repoRoot, "src/console-ui/src/App.tsx"), "utf8"),
+      readFile(path.join(repoRoot, "src/console-ui/src/lib/api.ts"), "utf8"),
+      readFile(path.join(repoRoot, "src/console-server.ts"), "utf8"),
+      readFile(path.join(repoRoot, "src/store.ts"), "utf8")
+    ]);
+    const approvalSheet = app.slice(
+      app.indexOf("function ApprovalSheet"),
+      app.indexOf("function CredentialSheet")
+    );
+
+    expect(approvalSheet).toContain("approveRequestWithScopedPolicy(request)");
+    expect(approvalSheet).toContain('data-approve-policy={request?.id}');
+    expect(approvalSheet).toContain("Always allow this request scope");
+    expect(approvalSheet).not.toContain("addPolicy(");
+    expect(approvalSheet).not.toContain("arrangePolicies(");
+    expect(api).toContain("/approve-policy");
+    expect(server).toContain('if (action === "approve-policy")');
+    expect(server).toContain("store.approveRequestWithScopedPolicy(id)");
+    expect(store).toContain("async approveRequestWithScopedPolicy");
+    expect(store).toContain("scopedAllowPolicyInput(request, agentName)");
+    expect(store).toContain("blockingDenyPolicyRuleForAction");
+    expect(store).toContain("approvePendingRequest(store, request, id, { mode: \"per-transaction\", agentScope: \"same-agent\" }, now, rule)");
+    expect(store).toContain("handles,");
+    expect(store).toContain("envBindings: bindings,");
+    expect(store).toContain("agents: [agent]");
+    expect(store).toContain("actionKinds: [action.kind]");
+    expect(store).toContain("commands: [action.command]");
+    expect(store).toContain("injectEnvs,");
+    expect(store).toContain("workingDirs: action.workingDir ? [action.workingDir] : []");
+  });
+
+  it("keeps exact credential bindings visible and fixed in the policy editor", async () => {
+    const [app, store] = await Promise.all([
+      readFile(path.join(repoRoot, "src/console-ui/src/App.tsx"), "utf8"),
+      readFile(path.join(repoRoot, "src/store.ts"), "utf8")
+    ]);
+
+    expect(app).toContain("Exact credential bindings");
+    expect(app).toContain("bindingsLocked");
+    expect(app).toContain('label={bindingsLocked ? "Credentials (fixed)" : "Credentials"}');
+    expect(app).toContain('label={bindingsLocked ? "Injected environment variables (fixed)" : "Injected environment variables"}');
+    expect(store).toContain("exactBindingsWouldConflict");
+  });
+
   it("keeps settings sections compact and approval durations readable", async () => {
     const [app, tabs] = await Promise.all([
       readFile(path.join(repoRoot, "src/console-ui/src/App.tsx"), "utf8"),

--- a/tests/policy-order.test.ts
+++ b/tests/policy-order.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import {
+  approvalPolicyRuleCovers,
+  arrangeApprovalPolicyRules,
+  compareApprovalPolicyRules,
+  findShadowingPolicyRule
+} from "../src/policy-order.js";
+import type { ApprovalPolicyRule } from "../src/types.js";
+
+function rule(
+  id: string,
+  priority: number,
+  conditions: ApprovalPolicyRule["conditions"],
+  decision: ApprovalPolicyRule["decision"] = "allow"
+): ApprovalPolicyRule {
+  return {
+    id,
+    name: id,
+    priority,
+    decision,
+    conditions,
+    enabled: true,
+    createdAt: `2026-07-16T00:00:0${id.length}Z`,
+    updatedAt: "2026-07-16T00:00:00Z"
+  };
+}
+
+describe("approval policy ordering", () => {
+  it("recognizes semantic containment without treating case-sensitive commands as equivalent", () => {
+    const broad = rule("broad", 10, { agents: ["codex"], minSeverity: "low" });
+    const narrow = rule("narrow", 20, { agents: ["codex"], commands: ["/usr/bin/aws"], minSeverity: "high" });
+    const differentCommand = rule("different-command", 20, { agents: ["codex"], commands: ["/usr/bin/AWS"], minSeverity: "high" });
+
+    expect(approvalPolicyRuleCovers(broad, narrow)).toBe(true);
+    expect(approvalPolicyRuleCovers(narrow, broad)).toBe(false);
+    expect(approvalPolicyRuleCovers(narrow, differentCommand)).toBe(false);
+  });
+
+  it("requires an exact credential-binding set when a rule has one", () => {
+    const broad = rule("broad", 10, {});
+    const paired = rule("paired", 20, {
+      envBindings: [
+        { handle: "s-gw:api-token:one", injectEnv: "ONE_TOKEN" },
+        { handle: "s-gw:api-token:two", injectEnv: "TWO_TOKEN" }
+      ]
+    });
+    const subset = rule("subset", 30, {
+      envBindings: [{ handle: "s-gw:api-token:one", injectEnv: "ONE_TOKEN" }]
+    });
+    const samePair = rule("same-pair", 40, {
+      envBindings: [
+        { handle: "s-gw:api-token:two", injectEnv: "TWO_TOKEN" },
+        { handle: "s-gw:api-token:one", injectEnv: "ONE_TOKEN" }
+      ]
+    });
+
+    expect(approvalPolicyRuleCovers(broad, paired)).toBe(true);
+    expect(approvalPolicyRuleCovers(paired, subset)).toBe(false);
+    expect(approvalPolicyRuleCovers(paired, samePair)).toBe(true);
+  });
+
+  it("preserves the established last-updated-first order for equal priorities", () => {
+    const older = { ...rule("older", 100, {}), updatedAt: "2026-07-16T00:00:00Z" };
+    const newer = { ...rule("newer", 100, {}), updatedAt: "2026-07-16T00:01:00Z" };
+
+    expect([older, newer].sort(compareApprovalPolicyRules).map((item) => item.id)).toEqual(["newer", "older"]);
+  });
+
+  it("moves a narrower rule ahead of its broader parent while keeping unrelated order stable", () => {
+    const broad = rule("broad", 10, { agents: ["codex"] }, "ask");
+    const unrelated = rule("unrelated", 20, { agents: ["claude"] });
+    const narrow = rule("narrow", 30, { agents: ["codex"], commands: ["/usr/bin/aws"] }, "allow");
+
+    const arranged = arrangeApprovalPolicyRules([broad, unrelated, narrow], "2026-07-16T01:00:00Z");
+
+    expect(arranged.rules.map((item) => item.id)).toEqual(["unrelated", "narrow", "broad"]);
+    expect(arranged.rules.map((item) => item.priority)).toEqual([10, 20, 30]);
+    expect(arranged.reordered).toBe(3);
+  });
+
+  it("keeps deny guardrails ahead of narrower allow rules", () => {
+    const deny = rule("deny", 10, { agents: ["codex"] }, "deny");
+    const allow = rule("allow", 20, { agents: ["codex"], commands: ["/usr/bin/aws"] }, "allow");
+
+    expect(arrangeApprovalPolicyRules([deny, allow]).rules.map((item) => item.id)).toEqual(["deny", "allow"]);
+  });
+
+  it("keeps unrelated rules untouched and prefers deny then ask for equivalent scope", () => {
+    const first = rule("first", 10, { agents: ["codex"] });
+    const second = rule("second", 20, { agents: ["claude"] });
+    expect(arrangeApprovalPolicyRules([first, second]).reordered).toBe(0);
+
+    const allow = rule("allow", 10, { agents: ["codex"] }, "allow");
+    const ask = rule("ask", 20, { agents: ["codex"] }, "ask");
+    const deny = rule("deny", 30, { agents: ["codex"] }, "deny");
+    expect(arrangeApprovalPolicyRules([allow, ask, deny]).rules.map((item) => item.id)).toEqual(["deny", "ask", "allow"]);
+  });
+
+  it("reports only an earlier live covering rule as shadowing", () => {
+    const broad = rule("broad", 10, { agents: ["codex"] });
+    const narrow = rule("narrow", 20, { agents: ["codex"], commands: ["/usr/bin/aws"] });
+    const expired = { ...broad, id: "expired", priority: 5, expiresAt: "2026-07-15T00:00:00Z" };
+
+    expect(findShadowingPolicyRule([expired, narrow], narrow, "2026-07-16T00:00:00Z")).toBeUndefined();
+    expect(findShadowingPolicyRule([broad, narrow], narrow, "2026-07-16T00:00:00Z")?.id).toBe("broad");
+  });
+});

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { executeApprovedRequest, executeReusablePermit } from "../src/executor.js";
 import { buildEnvCommandAction, scanLocalText } from "../src/gateway.js";
 import { tokenForHandle } from "../src/scanner.js";
+import { buildSshSessionAction, SGW_SSH_SESSION_COMMAND } from "../src/ssh.js";
 import { SecretStore } from "../src/store.js";
 
 let tmpHome = "";
@@ -93,6 +94,74 @@ describe("SecretStore", () => {
     expect(handles).toHaveLength(1);
     expect(JSON.stringify(handles)).not.toContain(rawSecret);
     expect(handles[0].policy.injectEnv).toBe("API_TOKEN");
+  });
+
+  it("fails closed without broadening a malformed stored policy", async () => {
+    const store = new SecretStore();
+    const raw = `${JSON.stringify({
+      version: 1,
+      secrets: [],
+      requests: [],
+      audit: [],
+      approvalSettings: { mode: "per-transaction", durationMs: 15 * 60 * 1000 },
+      approvalGrants: [],
+      approvalPolicyRules: [{
+        id: "policy_invalid_command",
+        name: "Invalid command policy",
+        enabled: true,
+        priority: 100,
+        decision: "allow",
+        conditions: { commands: ["relative/tool"] },
+        createdAt: "2030-01-01T00:00:00.000Z",
+        updatedAt: "2030-01-01T00:00:00.000Z"
+      }]
+    }, null, 2)}\n`;
+    await writeFile(store.storePath, raw, { mode: 0o600 });
+
+    await expect(store.addSecret({
+      name: "unrelated credential",
+      type: "api-token",
+      value: fakeOpenAiToken("invalid_stored_policy"),
+      policy: { injectEnv: "UNRELATED_TOKEN" }
+    })).rejects.toThrow(/invalid approval policy.*relative command/i);
+
+    const recoveryDir = path.join(tmpHome, "recovery", "automatic");
+    const preserved = (await readdir(recoveryDir)).find((entry) => entry.includes("store-invalid"));
+    expect(preserved).toBeDefined();
+    expect(await readFile(path.join(recoveryDir, preserved!), "utf8")).toBe(raw);
+  });
+
+  it("preserves legacy policy conditions during unrelated writes", async () => {
+    const store = new SecretStore();
+    const policy = {
+      id: "policy_legacy_condition",
+      name: "Legacy command policy",
+      enabled: true,
+      priority: 100,
+      decision: "allow",
+      conditions: { commands: [process.execPath] },
+      createdAt: "2030-01-01T00:00:00.000Z",
+      updatedAt: "2030-01-01T00:00:00.000Z"
+    };
+    await writeFile(store.storePath, `${JSON.stringify({
+      version: 1,
+      secrets: [],
+      requests: [],
+      audit: [],
+      approvalSettings: { mode: "per-transaction", durationMs: 15 * 60 * 1000 },
+      approvalGrants: [],
+      approvalPolicyRules: [policy]
+    }, null, 2)}\n`, { mode: 0o600 });
+
+    await store.addSecret({
+      name: "unrelated legacy credential",
+      type: "api-token",
+      value: fakeOpenAiToken("legacy_policy"),
+      policy: { injectEnv: "LEGACY_POLICY_TOKEN" }
+    });
+
+    const persisted = JSON.parse(await readFile(store.storePath, "utf8"));
+    expect(persisted.approvalPolicyRules).toEqual([policy]);
   });
 
   it("updates the injection environment without reading the secret", async () => {
@@ -2012,6 +2081,429 @@ describe("SecretStore", () => {
     expect(result.stdout).not.toContain("policy-codex-secret-value");
   });
 
+  it("preserves omitted policy conditions and rejects invalid policy updates", async () => {
+    const store = new SecretStore();
+    const rule = await store.addApprovalPolicyRule({
+      name: "Narrow policy",
+      decision: "allow",
+      expiresAt: "2031-04-05T06:07:08.000Z",
+      conditions: {
+        agents: ["Codex"],
+        envBindings: [{ handle: "s-gw:api-token:policy", injectEnv: "SGW_NARROW_TOKEN" }],
+        commands: [process.execPath],
+        injectEnvs: ["SGW_NARROW_TOKEN"],
+        minSeverity: "high",
+        sshPorts: [22]
+      }
+    });
+
+    const renamed = await store.updateApprovalPolicyRule(rule.id, {
+      name: "Renamed narrow policy",
+      conditions: { providers: ["GitHub"] }
+    });
+    expect(renamed.conditions).toMatchObject({
+      agents: ["codex"],
+      envBindings: [{ handle: "s-gw:api-token:policy", injectEnv: "SGW_NARROW_TOKEN" }],
+      commands: [process.execPath],
+      injectEnvs: ["SGW_NARROW_TOKEN"],
+      minSeverity: "high",
+      sshPorts: [22],
+      providers: ["github"]
+    });
+    expect(renamed.expiresAt).toBe("2031-04-05T06:07:08.000Z");
+
+    const cleared = await store.updateApprovalPolicyRule(rule.id, {
+      conditions: { minSeverity: undefined, commands: [] }
+    });
+    expect(cleared.conditions.minSeverity).toBeUndefined();
+    expect(cleared.conditions.commands).toEqual([]);
+    expect(cleared.conditions.sshPorts).toEqual([22]);
+
+    const beforeInvalidUpdates = await store.listApprovalPolicyRules();
+    await expect(store.updateApprovalPolicyRule(rule.id, {})).rejects.toThrow(/at least one change/i);
+    await expect(store.updateApprovalPolicyRule(rule.id, {
+      conditions: { handles: [] }
+    })).rejects.toThrow(/exact credential bindings/i);
+    await expect(store.updateApprovalPolicyRule(rule.id, {
+      conditions: { injectEnvs: [] }
+    })).rejects.toThrow(/exact credential bindings/i);
+    await expect(store.updateApprovalPolicyRule(rule.id, {
+      conditions: { envBindings: [] }
+    })).rejects.toThrow(/exact credential bindings/i);
+    await expect(store.updateApprovalPolicyRule(rule.id, {
+      conditions: { envBindings: [{ handle: "s-gw:api-token:replacement", injectEnv: "SGW_REPLACEMENT_TOKEN" }] }
+    })).rejects.toThrow(/exact credential bindings/i);
+    await expect(store.addApprovalPolicyRule({
+      name: "Relative command",
+      decision: "allow",
+      conditions: { commands: ["relative/tool"] }
+    })).rejects.toThrow(/relative command paths/i);
+    await expect(store.addApprovalPolicyRule({
+      name: "Malformed conditions",
+      decision: "allow",
+      conditions: "not-an-object" as unknown as { handles: string[] }
+    })).rejects.toThrow(/conditions must be an object/i);
+    await expect(store.updateApprovalPolicyRule(rule.id, {
+      conditions: { sshPorts: [0] }
+    })).rejects.toThrow(/sshPorts/i);
+    await expect(store.updateApprovalPolicyRule(rule.id, {
+      expiresAt: "not-a-timestamp"
+    })).rejects.toThrow(/expiresAt/i);
+    await expect(store.updateApprovalPolicyRule(rule.id, {
+      priority: -1
+    })).rejects.toThrow(/priority/i);
+    await expect(store.addApprovalPolicyRule({
+      name: "Invalid duration",
+      decision: "allow",
+      durationMs: 0
+    })).rejects.toThrow(/durationMs/i);
+    expect(await store.listApprovalPolicyRules()).toEqual(beforeInvalidUpdates);
+  });
+
+  it("does not persist or reprioritize unchanged approval policy saves", async () => {
+    vi.useFakeTimers();
+    try {
+      const store = new SecretStore();
+      const record = await store.addSecret({
+        name: "unchanged policy token",
+        type: "api-token",
+        value: "unchanged-policy-secret-value-123456789",
+        policy: { injectEnv: "SGW_UNCHANGED_POLICY", allowedCommands: [process.execPath] }
+      });
+      const conditions = {
+        handles: [record.handle],
+        agents: ["Codex"],
+        commands: [process.execPath]
+      };
+
+      vi.setSystemTime(new Date("2030-01-01T00:00:00.000Z"));
+      const allow = await store.addApprovalPolicyRule({
+        name: "Allow unchanged policy",
+        decision: "allow",
+        priority: 100,
+        conditions
+      });
+      vi.setSystemTime(new Date("2030-01-01T00:00:01.000Z"));
+      const deny = await store.addApprovalPolicyRule({
+        name: "Deny unchanged policy",
+        decision: "deny",
+        priority: 100,
+        conditions
+      });
+
+      const beforeRules = await store.listApprovalPolicyRules();
+      expect(beforeRules.map((rule) => rule.id)).toEqual([deny.id, allow.id]);
+      const beforeStore = await readFile(store.storePath, "utf8");
+      const beforeAudit = await store.auditLog();
+      const headPath = path.join(await externalControlPlaneDir(), "head.json");
+      const beforeHead = await readFile(headPath, "utf8");
+
+      vi.setSystemTime(new Date("2030-01-01T00:00:02.000Z"));
+      const saved = await store.updateApprovalPolicyRule(allow.id, {
+        name: allow.name,
+        enabled: allow.enabled,
+        priority: allow.priority,
+        decision: allow.decision,
+        expiresAt: allow.expiresAt || null,
+        conditions: allow.conditions
+      });
+      expect(saved.updatedAt).toBe(allow.updatedAt);
+      expect(await store.setApprovalPolicyRuleEnabled(deny.id, true)).toEqual({ id: deny.id, enabled: true });
+
+      expect((await store.listApprovalPolicyRules()).map((rule) => rule.id)).toEqual(beforeRules.map((rule) => rule.id));
+      expect(await readFile(store.storePath, "utf8")).toBe(beforeStore);
+      expect(await store.auditLog()).toEqual(beforeAudit);
+      expect(await readFile(headPath, "utf8")).toBe(beforeHead);
+
+      const request = await store.createRequest(
+        record.handle,
+        buildEnvCommandAction({ command: process.execPath, args: ["-e", "0"], injectEnv: "SGW_UNCHANGED_POLICY" }),
+        "Codex unchanged policy request"
+      );
+      expect(request.state).toBe("denied");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("arranges narrower policy rules before the scopes they override", async () => {
+    const store = new SecretStore();
+    const record = await store.addSecret({
+      name: "arranged policy token",
+      type: "api-token",
+      value: "arranged-policy-secret-value-123456789",
+      policy: { injectEnv: "SGW_ARRANGED_POLICY", allowedCommands: [process.execPath] }
+    });
+    const broad = await store.addApprovalPolicyRule({
+      name: "Allow Codex commands",
+      decision: "allow",
+      priority: 10,
+      conditions: { agents: ["Codex"], commands: [process.execPath] }
+    });
+    const narrow = await store.addApprovalPolicyRule({
+      name: "Ask for this credential",
+      decision: "ask",
+      priority: 30,
+      conditions: { handles: [record.handle], agents: ["Codex"], commands: [process.execPath] }
+    });
+
+    const arranged = await store.arrangeApprovalPolicyRules();
+    expect(arranged.reordered).toBe(2);
+    expect(arranged.rules.map((item) => item.id)).toEqual([narrow.id, broad.id]);
+
+    const request = await store.createRequest(
+      record.handle,
+      buildEnvCommandAction({ command: process.execPath, args: ["-e", "0"], injectEnv: "SGW_ARRANGED_POLICY" }),
+      "Codex arranged policy run"
+    );
+    expect(request.state).toBe("pending");
+    expect(request.approvalPolicyRuleId).toBe(narrow.id);
+  });
+
+  it("creates a narrowly scoped allow policy and approves the current request atomically", async () => {
+    const store = new SecretStore();
+    const record = await store.addSecret({
+      name: "scoped policy token",
+      type: "api-token",
+      value: "scoped-policy-secret-value-123456789",
+      policy: { injectEnv: "SGW_SCOPED_POLICY", allowedCommands: [process.execPath] }
+    });
+    const action = buildEnvCommandAction({
+      command: process.execPath,
+      args: ["-e", "0"],
+      injectEnv: "SGW_SCOPED_POLICY",
+      workingDir: tmpHome
+    });
+    const pending = await store.createRequest(record.handle, action, "Codex scoped policy run");
+
+    const approved = await store.approveRequestWithScopedPolicy(pending.id);
+    expect(approved.created).toBe(true);
+    expect(approved.request.state).toBe("approved");
+    expect(approved.request.approvalSource).toBe("policy");
+    expect(approved.request.approvalPolicyRuleId).toBe(approved.rule.id);
+    expect(approved.rule.conditions).toMatchObject({
+      handles: [record.handle],
+      envBindings: [{ handle: record.handle, injectEnv: "SGW_SCOPED_POLICY" }],
+      agents: ["codex"],
+      actionKinds: ["env_command"],
+      commands: [process.execPath],
+      injectEnvs: ["SGW_SCOPED_POLICY"],
+      workingDirs: [tmpHome]
+    });
+
+    const matching = await store.createRequest(record.handle, action, "Codex scoped policy retry");
+    expect(matching.state).toBe("approved");
+    expect(matching.approvalPolicyRuleId).toBe(approved.rule.id);
+
+    const differentDirectory = await store.createRequest(
+      record.handle,
+      buildEnvCommandAction({
+        command: process.execPath,
+        args: ["-e", "0"],
+        injectEnv: "SGW_SCOPED_POLICY",
+        workingDir: path.join(tmpHome, "different-directory")
+      }),
+      "Codex different directory"
+    );
+    expect(differentDirectory.state).toBe("pending");
+
+    await store.setApprovalPolicyRuleEnabled(approved.rule.id, false);
+    await expect(executeApprovedRequest(store, pending.id, { engine: "typescript" })).rejects.toThrow(/policy.*changed|no longer allows/i);
+  });
+
+  it("keeps a scoped policy tied to the full credential binding set", async () => {
+    const store = new SecretStore();
+    const primary = await store.addSecret({
+      name: "binding primary token",
+      type: "api-token",
+      value: "binding-primary-secret-value-123456789",
+      policy: { injectEnv: "SGW_BINDING_PRIMARY", allowedCommands: [process.execPath] }
+    });
+    const secondary = await store.addSecret({
+      name: "binding secondary token",
+      type: "api-token",
+      value: "binding-secondary-secret-value-123456789",
+      policy: { allowedCommands: [process.execPath] }
+    });
+    const third = await store.addSecret({
+      name: "binding third token",
+      type: "api-token",
+      value: "binding-third-secret-value-123456789",
+      policy: { allowedCommands: [process.execPath] }
+    });
+    const action = buildEnvCommandAction({
+      command: process.execPath,
+      args: ["-e", "0"],
+      injectEnv: "SGW_BINDING_PRIMARY",
+      env: [{ handle: secondary.handle, injectEnv: "SGW_BINDING_SECONDARY" }]
+    });
+    const pending = await store.createRequest(primary.handle, action, "Codex binding policy run");
+    const approved = await store.approveRequestWithScopedPolicy(pending.id);
+
+    expect(approved.rule.conditions.envBindings).toEqual([
+      { handle: primary.handle, injectEnv: "SGW_BINDING_PRIMARY" },
+      { handle: secondary.handle, injectEnv: "SGW_BINDING_SECONDARY" }
+    ]);
+
+    const matching = await store.createRequest(primary.handle, action, "Codex binding policy retry");
+    expect(matching.state).toBe("approved");
+    expect(matching.approvalPolicyRuleId).toBe(approved.rule.id);
+
+    const primaryOnly = await store.createRequest(
+      primary.handle,
+      buildEnvCommandAction({
+        command: process.execPath,
+        args: ["-e", "0"],
+        injectEnv: "SGW_BINDING_PRIMARY"
+      }),
+      "Codex primary-only binding"
+    );
+    expect(primaryOnly.state).toBe("pending");
+
+    const mixedBinding = await store.createRequest(
+      primary.handle,
+      buildEnvCommandAction({
+        command: process.execPath,
+        args: ["-e", "0"],
+        injectEnv: "SGW_BINDING_PRIMARY",
+        env: [{ handle: secondary.handle, injectEnv: "SGW_BINDING_OTHER" }]
+      }),
+      "Codex mixed binding"
+    );
+    expect(mixedBinding.state).toBe("pending");
+
+    const extraBinding = await store.createRequest(
+      primary.handle,
+      buildEnvCommandAction({
+        command: process.execPath,
+        args: ["-e", "0"],
+        injectEnv: "SGW_BINDING_PRIMARY",
+        env: [
+          { handle: secondary.handle, injectEnv: "SGW_BINDING_SECONDARY" },
+          { handle: third.handle, injectEnv: "SGW_BINDING_THIRD" }
+        ]
+      }),
+      "Codex extra binding"
+    );
+    expect(extraBinding.state).toBe("pending");
+  });
+
+  it("uses an existing matching allow policy without creating a duplicate", async () => {
+    const store = new SecretStore();
+    const record = await store.addSecret({
+      name: "existing scoped policy token",
+      type: "api-token",
+      value: "existing-scoped-policy-secret-value-123456789",
+      policy: { injectEnv: "SGW_EXISTING_POLICY", allowedCommands: [process.execPath] }
+    });
+    const action = buildEnvCommandAction({
+      command: process.execPath,
+      args: ["-e", "0"],
+      injectEnv: "SGW_EXISTING_POLICY"
+    });
+    const pending = await store.createRequest(record.handle, action, "Codex pending before policy");
+    const rule = await store.addApprovalPolicyRule({
+      name: "Existing Codex policy",
+      decision: "allow",
+      conditions: {
+        handles: [record.handle],
+        envBindings: [{ handle: record.handle, injectEnv: "SGW_EXISTING_POLICY" }],
+        agents: ["Codex"],
+        actionKinds: ["env_command"],
+        commands: [process.execPath],
+        injectEnvs: ["SGW_EXISTING_POLICY"]
+      }
+    });
+
+    const approved = await store.approveRequestWithScopedPolicy(pending.id);
+    expect(approved.created).toBe(false);
+    expect(approved.rule.id).toBe(rule.id);
+    expect(approved.request.approvalSource).toBe("policy");
+    expect(approved.request.approvalPolicyRuleId).toBe(rule.id);
+    expect(await store.listApprovalPolicyRules()).toHaveLength(1);
+  });
+
+  it("refuses to create a durable policy when the requesting agent is unknown", async () => {
+    const store = new SecretStore();
+    const record = await store.addSecret({
+      name: "unknown agent token",
+      type: "api-token",
+      value: "unknown-agent-secret-value-123456789",
+      policy: { injectEnv: "SGW_UNKNOWN_AGENT", allowedCommands: [process.execPath] }
+    });
+    const pending = await store.createRequest(
+      record.handle,
+      buildEnvCommandAction({ command: process.execPath, args: ["-e", "0"], injectEnv: "SGW_UNKNOWN_AGENT" }),
+      "generic durable policy run",
+      { env: { SGW_DISABLE_PROCESS_AGENT_DETECTION: "1" } }
+    );
+    expect(pending.agentName).toBe("Agent");
+    expect(pending.agentSource).toBe("unknown");
+
+    await expect(store.approveRequestWithScopedPolicy(pending.id)).rejects.toThrow(/could not identify the requesting agent/i);
+    expect(await store.listApprovalPolicyRules()).toEqual([]);
+    expect((await store.getRequest(pending.id)).state).toBe("pending");
+  });
+
+  it("does not let a scoped allow rule bypass an existing deny policy", async () => {
+    const store = new SecretStore();
+    const record = await store.addSecret({
+      name: "deny policy token",
+      type: "api-token",
+      value: "deny-policy-secret-value-123456789",
+      policy: { injectEnv: "SGW_DENY_POLICY", allowedCommands: [process.execPath] }
+    });
+    const action = buildEnvCommandAction({ command: process.execPath, args: ["-e", "0"], injectEnv: "SGW_DENY_POLICY" });
+    const pending = await store.createRequest(record.handle, action, "Codex denied policy run");
+    await store.addApprovalPolicyRule({
+      name: "Deny Codex commands",
+      decision: "deny",
+      conditions: {
+        agents: ["Codex"],
+        commands: [process.execPath]
+      }
+    });
+
+    const before = await store.listApprovalPolicyRules();
+    await expect(store.approveRequestWithScopedPolicy(pending.id)).rejects.toThrow(/denies this request/i);
+    expect(await store.listApprovalPolicyRules()).toEqual(before);
+    expect((await store.getRequest(pending.id))?.state).toBe("pending");
+  });
+
+  it("preserves SSH command, target, and port when creating a scoped policy", async () => {
+    const store = new SecretStore();
+    const record = await store.addSecret({
+      name: "scoped SSH key",
+      type: "private-key",
+      value: "scoped-ssh-private-key-value-123456789",
+      policy: { injectEnv: "SGW_SCOPED_SSH", allowedCommands: [SGW_SSH_SESSION_COMMAND] }
+    });
+    const action = buildSshSessionAction({
+      target: "deploy@example.test",
+      port: 2222,
+      injectEnv: "SGW_SCOPED_SSH"
+    });
+    const pending = await store.createRequest(record.handle, action, "Codex SSH scoped policy run");
+
+    const approved = await store.approveRequestWithScopedPolicy(pending.id);
+    expect(approved.rule.conditions).toMatchObject({
+      actionKinds: ["ssh_session"],
+      commands: [SGW_SSH_SESSION_COMMAND],
+      sshTargets: ["deploy@example.test"],
+      sshPorts: [2222]
+    });
+
+    const matching = await store.createRequest(record.handle, action, "Codex SSH scoped policy retry");
+    expect(matching.state).toBe("approved");
+
+    const differentPort = await store.createRequest(
+      record.handle,
+      buildSshSessionAction({ target: "deploy@example.test", port: 2223, injectEnv: "SGW_SCOPED_SSH" }),
+      "Codex SSH other port"
+    );
+    expect(differentPort.state).toBe("pending");
+  });
+
   it("blocks an auto-approved request after its policy is disabled", async () => {
     const store = new SecretStore();
     const record = await store.addSecret({
@@ -2309,9 +2801,12 @@ describe("SecretStore", () => {
     });
     const pending = await store.createRequest(record.handle, action, "Claude pending before delete");
     await store.addApprovalPolicyRule({
-      name: "Delete scoped policy",
+      name: "Delete binding policy",
       decision: "allow",
-      conditions: { handles: [record.handle], agents: ["Codex"] }
+      conditions: {
+        envBindings: [{ handle: record.handle, injectEnv: "SGW_DELETE_TOKEN" }],
+        agents: ["Codex"]
+      }
     });
 
     const deleted = await store.deleteSecret(record.handle);


### PR DESCRIPTION
Improves policy authoring and review across the console, API, and CLI.

- Adds scoped request approval, policy editing, ordering, and shadow visibility.
- Preserves exact credential binding sets and fails closed on malformed policy input or stored rules.
- Avoids control-plane writes for no-op policy changes.

Verification: npm run check, npm run build, targeted policy/API/browser tests, full npm test, and npm audit --omit=dev.