### PR TITLE
Add demo data and repair legacy upgrades

### DIFF
--- a/native/macos-app/Sources/SgwMac/Services/UpdateChecker.swift
+++ b/native/macos-app/Sources/SgwMac/Services/UpdateChecker.swift
@@ -20,7 +20,8 @@ struct ReleaseInfo: Identifiable, Equatable, Sendable {
         assetName.lowercased().hasSuffix(".dmg")
     }
     var canInstallPackage: Bool {
-        assetName.lowercased().hasSuffix(".tgz") && hasVerifiedAsset
+        let expected = "s-gw-\(UpdateChecker.parseVersion(version)).tgz"
+        return assetName.caseInsensitiveCompare(expected) == .orderedSame && hasVerifiedAsset
     }
 }
 
@@ -245,7 +246,7 @@ actor UpdateChecker: UpdateChecking {
     }
 
     func downloadAndInstall(_ release: ReleaseInfo, progress: @Sendable @escaping (UpdateState) -> Void) async -> String? {
-        guard release.assetName.lowercased().hasSuffix(".tgz"), let assetURL = URL(string: release.assetURL) else {
+        guard release.canInstallPackage, let assetURL = URL(string: release.assetURL) else {
             return "This release does not include an installable s-gw package asset."
         }
         guard let checksumURL = URL(string: release.checksumAssetURL) else {
@@ -509,7 +510,7 @@ actor UpdateChecker: UpdateChecking {
         }
     }
 
-    private static func parseVersion(_ tag: String) -> String {
+    static func parseVersion(_ tag: String) -> String {
         var cleaned = tag.trimmingCharacters(in: .whitespacesAndNewlines)
         if cleaned.lowercased().hasPrefix("v") {
             cleaned.removeFirst()

--- a/native/macos-app/Tests/AppStateGuardTests.swift
+++ b/native/macos-app/Tests/AppStateGuardTests.swift
@@ -551,8 +551,20 @@ struct AppStateGuardTests {
     ) == asset, "release selection should bind the package name to the release version")
     check(UpdateChecker.packageAssetName(
       for: "9.4.0",
-      assetNames: ["unrelated.tgz"]
-    ) == nil, "an unrelated tarball must not be selected for installation")
+      assetNames: ["0-s-gw-legacy-9.4.0.tgz", "unrelated.tgz"]
+    ) == nil, "the legacy bridge and unrelated tarballs must not be selected for installation")
+    let bridgeRelease = ReleaseInfo(
+      tag: "v9.4.0",
+      version: "9.4.0",
+      assetName: "0-s-gw-legacy-9.4.0.tgz",
+      assetURL: "https://example.com/0-s-gw-legacy-9.4.0.tgz",
+      checksumAssetName: "0-s-gw-legacy-9.4.0.tgz.sha256",
+      checksumAssetURL: "https://example.com/0-s-gw-legacy-9.4.0.tgz.sha256",
+      htmlURL: "https://example.com/release",
+      notes: ""
+    )
+    check(!bridgeRelease.canInstallPackage,
+          "a preselected legacy bridge must still fail closed before download")
     check(UpdateChecker.checksumAssetName(for: asset, assetNames: [manifest]) == manifest,
           "SHA256SUMS.txt should be accepted when no per-file checksum is present")
     check(UpdateChecker.checksumAssetName(for: asset, assetNames: ["SHA256SUMS"]) == "SHA256SUMS",

--- a/src/console-ui/src/App.tsx
+++ b/src/console-ui/src/App.tsx
@@ -162,6 +162,7 @@ import {
   type PanelId
 } from "@/lib/layout";
 import { credentialBackendLabel, credentialProviderPresentation } from "@/lib/credential-presentation";
+import { addDemoData, DEMO_DATA_STORAGE_KEY } from "@/lib/demo-data";
 import { findShadowingPolicyRule } from "../../policy-order";
 import {
   commandName,
@@ -332,6 +333,7 @@ function ConsoleShell({ ctx, theme, setTheme }: { ctx: ConsoleContext; theme: st
   const [approval, setApproval] = React.useState<RequestRecord | null>(null);
   const [credential, setCredential] = React.useState<HandleSummary | null>(null);
   const [overviewLayouts, setOverviewLayouts] = React.useState<Layouts>(() => readSavedLayouts());
+  const [demoEnabled, setDemoEnabled] = React.useState(() => localStorage.getItem(DEMO_DATA_STORAGE_KEY) === "1");
   const nativeShell = isNativeShellRoute();
 
   React.useEffect(() => {
@@ -341,7 +343,7 @@ function ConsoleShell({ ctx, theme, setTheme }: { ctx: ConsoleContext; theme: st
   }, []);
 
   React.useEffect(() => {
-    if (!approval || !ctx.state) return;
+    if (!approval || approval.demo || !ctx.state) return;
     const current = ctx.state.requests.find((request) => request.id === approval.id);
     if (current?.state === "pending") {
       if (current !== approval) setApproval(current);
@@ -374,7 +376,20 @@ function ConsoleShell({ ctx, theme, setTheme }: { ctx: ConsoleContext; theme: st
     window.history.pushState({}, "", `${path}${shellQuery}`);
   }, []);
 
-  const state = ctx.state;
+  const state = React.useMemo(
+    () => ctx.state && demoEnabled ? addDemoData(ctx.state) : ctx.state,
+    [ctx.state, demoEnabled]
+  );
+  const displayCtx = React.useMemo(() => ({ ...ctx, state }), [ctx, state]);
+  const toggleDemoData = React.useCallback(() => {
+    setDemoEnabled((current) => {
+      const next = !current;
+      if (next) localStorage.setItem(DEMO_DATA_STORAGE_KEY, "1");
+      else localStorage.removeItem(DEMO_DATA_STORAGE_KEY);
+      toast.success(next ? "Demo data added" : "Demo data removed");
+      return next;
+    });
+  }, []);
   const resetOverviewLayout = React.useCallback(() => {
     const next = resetLayouts();
     setOverviewLayouts(next);
@@ -388,7 +403,7 @@ function ConsoleShell({ ctx, theme, setTheme }: { ctx: ConsoleContext; theme: st
       <SidebarInset className="sgw-console-main min-w-0 bg-transparent">
         {nativeShell ? (
           <NativeWindowActions
-            ctx={ctx}
+            ctx={displayCtx}
             state={state}
             theme={theme}
             setTheme={setTheme}
@@ -396,10 +411,12 @@ function ConsoleShell({ ctx, theme, setTheme }: { ctx: ConsoleContext; theme: st
             view={view}
             onResetLayout={resetOverviewLayout}
             setCommandOpen={setCommandOpen}
+            demoEnabled={demoEnabled}
+            onToggleDemoData={toggleDemoData}
           />
         ) : (
           <ConsoleTopbar
-            ctx={ctx}
+            ctx={displayCtx}
             state={state}
             theme={theme}
             setTheme={setTheme}
@@ -434,7 +451,7 @@ function ConsoleShell({ ctx, theme, setTheme }: { ctx: ConsoleContext; theme: st
             </Alert>
           ) : null}
           <ViewContent
-            ctx={ctx}
+            ctx={displayCtx}
             view={view}
             setView={setView}
             setApproval={setApproval}
@@ -520,7 +537,9 @@ function NativeWindowActions({
   setView,
   view,
   onResetLayout,
-  setCommandOpen
+  setCommandOpen,
+  demoEnabled,
+  onToggleDemoData
 }: {
   ctx: ConsoleContext;
   state: ConsoleState | null;
@@ -530,6 +549,8 @@ function NativeWindowActions({
   view: ViewId;
   onResetLayout: () => void;
   setCommandOpen: (open: boolean) => void;
+  demoEnabled: boolean;
+  onToggleDemoData: () => void;
 }) {
   const pendingCount = state?.metrics.pendingApprovals || 0;
   const nextTheme = theme === "light" ? "dark" : "light";
@@ -558,7 +579,7 @@ function NativeWindowActions({
       </Button>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
-          <Button variant="outline" size="icon" className="sgw-native-action-button">
+          <Button variant="outline" size="icon" className="sgw-native-action-button" data-native-more-actions>
             <MoreVertical className="h-4 w-4" />
             <span className="sr-only">More actions</span>
           </Button>
@@ -566,6 +587,9 @@ function NativeWindowActions({
         <DropdownMenuContent align="end">
           <DropdownMenuLabel>s-gw</DropdownMenuLabel>
           <DropdownMenuItem onSelect={() => setView("settings")}>Settings</DropdownMenuItem>
+          <DropdownMenuItem onSelect={onToggleDemoData} data-demo-data-toggle>
+            {demoEnabled ? "Remove demo data" : "Demo data"}
+          </DropdownMenuItem>
           <DropdownMenuItem onSelect={() => setTheme(nextTheme)}>
             Use {nextTheme} theme
           </DropdownMenuItem>
@@ -979,7 +1003,12 @@ function CredentialHandlesPanel({
         <TableBody>
           {state.credentials.slice(0, 5).map((item) => (
             <TableRow key={item.provider} className="cursor-pointer" onClick={() => setView("credentials")}>
-              <TableCell className="font-medium"><ProviderIdentity provider={item.provider} /></TableCell>
+              <TableCell className="font-medium">
+                <span className="flex items-center gap-2">
+                  {item.demo ? item.label : <ProviderIdentity provider={item.provider} />}
+                  {item.demo ? <DemoBadge /> : null}
+                </span>
+              </TableCell>
               <TableCell className="text-right">{item.secrets}</TableCell>
               <TableCell><SeverityBadge severity={item.severity} /></TableCell>
             </TableRow>
@@ -1122,6 +1151,7 @@ function RecentActivityPanel({ state, setView }: { state: ConsoleState; setView:
                 <span className="sgw-event-source-cell">
                   <AgentIcon name={flow.sourceLabel} className="h-6 w-6" />
                   <span>{flow.sourceLabel}</span>
+                  {event.demo ? <DemoBadge /> : null}
                 </span>
                 <span className="sgw-event-type-pill">{recentEventKind(event.type)}</span>
                 <EventStatusLabel tone={flow.tone} status={flow.status} />
@@ -1165,6 +1195,7 @@ function ApprovalsView({ state, setApproval, search }: { state: ConsoleState; se
                   <span className="flex items-center gap-2">
                     <AgentIcon name={request.agentName} className="h-7 w-7" />
                     <span>{request.agentName || "Agent"}</span>
+                    {request.demo ? <DemoBadge /> : null}
                   </span>
                 </TableCell>
                 <TableCell>{commandName(request)}</TableCell>
@@ -1283,7 +1314,12 @@ function CredentialsView({
                   data-credential-row
                   onClick={() => setCredential(handle)}
                 >
-                  <TableCell className="truncate font-medium" data-credential-column="name" data-credential-name title={handle.name}>{handle.name}</TableCell>
+                  <TableCell className="font-medium" data-credential-column="name" data-credential-name title={handle.name}>
+                    <span className="flex min-w-0 items-center gap-2">
+                      <span className="truncate">{handle.name}</span>
+                      {handle.demo ? <DemoBadge /> : null}
+                    </span>
+                  </TableCell>
                   <TableCell data-credential-column="provider"><ProviderIdentity provider={handle.provider} backend={handle.backend} /></TableCell>
                   <TableCell className="text-xs sm:text-sm" data-credential-column="backend">{credentialBackendLabel(handle.backend)}</TableCell>
                   <TableCell className="truncate font-mono text-xs" data-credential-column="handle" title={handle.handle}>{shortHandle(handle.handle)}</TableCell>
@@ -1467,6 +1503,7 @@ function PoliciesView({ state, onDone, search }: { state: ConsoleState; onDone: 
                 <TableCell className="font-medium">
                   <div className="flex min-w-0 items-center gap-2">
                     <span className="truncate">{rule.name}</span>
+                    {rule.demo ? <DemoBadge /> : null}
                     {shadowedBy.get(rule.id) ? (
                       <Badge variant="secondary" className="shrink-0 text-amber-700 dark:text-amber-300" title={`Covered by ${shadowedBy.get(rule.id)?.name}`}>
                         Shadowed
@@ -1482,6 +1519,7 @@ function PoliciesView({ state, onDone, search }: { state: ConsoleState; onDone: 
                     size="icon-sm"
                     aria-label={`Edit ${rule.name}`}
                     onClick={() => setEditing(rule)}
+                    disabled={rule.demo}
                     data-policy-edit={rule.id}
                   >
                     <Pencil className="h-4 w-4" />
@@ -1491,6 +1529,7 @@ function PoliciesView({ state, onDone, search }: { state: ConsoleState; onDone: 
                     size="icon-sm"
                     aria-label={`Delete ${rule.name}`}
                     onClick={() => setDeleting(rule)}
+                    disabled={rule.demo}
                   >
                     <Trash2 className="h-4 w-4" />
                   </Button>
@@ -1540,7 +1579,7 @@ function PolicyStatusControl({
   const enabled = rule.enabled;
 
   async function togglePolicy() {
-    if (busy) return;
+    if (busy || rule.demo) return;
     const nextEnabled = !enabled;
     setBusy(true);
     try {
@@ -1560,12 +1599,12 @@ function PolicyStatusControl({
       role="switch"
       aria-checked={enabled}
       aria-label={`${enabled ? "Disable" : "Enable"} ${rule.name}`}
-      disabled={busy}
+      disabled={busy || rule.demo}
       onClick={() => void togglePolicy()}
       data-policy-status
       className={cn(
         "inline-flex min-w-[92px] items-center gap-2 rounded-md px-2 py-1.5 text-xs font-medium outline-none transition-colors",
-        "hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring/60 disabled:cursor-wait disabled:opacity-65",
+        "hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring/60 disabled:cursor-default disabled:opacity-65",
         enabled ? "text-emerald-700 dark:text-emerald-300" : "text-muted-foreground hover:text-foreground"
       )}
     >
@@ -2239,7 +2278,12 @@ function renderEventColumn(row: EventLogRow, column: EventColumnId, mode: "activ
       </span>
     );
   }
-  if (column === "eventType") return <span className="sgw-event-type-pill">{row.flow.eventType}</span>;
+  if (column === "eventType") return (
+    <span className="flex items-center gap-1.5">
+      <span className="sgw-event-type-pill">{row.flow.eventType}</span>
+      {row.event.demo ? <DemoBadge /> : null}
+    </span>
+  );
   if (column === "status") return <EventStatusLabel tone={row.flow.tone} status={row.flow.status} />;
   return eventColumnValue(row, column);
 }
@@ -2751,6 +2795,10 @@ function MiniMetric({ label, value }: { label: string; value: number }) {
   );
 }
 
+function DemoBadge() {
+  return <Badge variant="outline" className="h-4 px-1 text-[9px] font-medium uppercase tracking-wide">Demo</Badge>;
+}
+
 function ApprovalSheet({
   request,
   state,
@@ -2826,6 +2874,7 @@ function ApprovalSheet({
           <SheetTitle className="flex items-center gap-2">
             <AgentIcon name={request?.agentName} className="h-9 w-9" />
             Approval needed
+            {request?.demo ? <DemoBadge /> : null}
           </SheetTitle>
           <SheetDescription>{request?.agentName || "Agent"} wants to use a local credential handle.</SheetDescription>
         </SheetHeader>
@@ -2851,7 +2900,12 @@ function ApprovalSheet({
             <Textarea placeholder="Optional note for this decision..." />
           </div>
         ) : null}
-        <SheetFooter>
+        {request?.demo ? (
+          <div className="mx-4 rounded-md border border-primary/25 bg-primary/5 p-3 text-sm text-muted-foreground">
+            Demo requests are read-only and cannot be approved, denied, or executed.
+          </div>
+        ) : null}
+        {!request?.demo ? <SheetFooter>
           <Button disabled={busy} onClick={() => approve({ mode: "per-transaction", agentScope: "same-agent" })} data-approve={request?.id}>
             {busy ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
             Approve once
@@ -2876,7 +2930,7 @@ function ApprovalSheet({
             </PopoverContent>
           </Popover>
           <Button disabled={busy} variant="destructive" onClick={deny}>Deny</Button>
-        </SheetFooter>
+        </SheetFooter> : null}
       </SheetContent>
     </Sheet>
   );
@@ -2897,7 +2951,10 @@ function CredentialSheet({
       <Sheet open={Boolean(credential)} onOpenChange={onOpenChange}>
         <SheetContent className="w-[min(560px,calc(100vw-24px))] sm:max-w-none">
           <SheetHeader>
-            <SheetTitle>{credential?.name || "Credential"}</SheetTitle>
+            <SheetTitle className="flex items-center gap-2">
+              {credential?.name || "Credential"}
+              {credential?.demo ? <DemoBadge /> : null}
+            </SheetTitle>
             <SheetDescription>{credential ? shortHandle(credential.handle) : ""}</SheetDescription>
           </SheetHeader>
           {credential ? (
@@ -2913,10 +2970,14 @@ function CredentialSheet({
                   ["Updated", relativeTime(credential.updatedAt)]
                 ]}
               />
-              <Button variant="destructive" onClick={() => setConfirm(true)}>
+              {credential.demo ? (
+                <div className="rounded-md border border-primary/25 bg-primary/5 p-3 text-sm text-muted-foreground">
+                  Demo credentials are display-only and cannot be used or deleted.
+                </div>
+              ) : <Button variant="destructive" onClick={() => setConfirm(true)}>
                 <Trash2 className="mr-2 h-4 w-4" />
                 Delete credential
-              </Button>
+              </Button>}
             </div>
           ) : null}
         </SheetContent>
@@ -3475,7 +3536,9 @@ function FlowRowsTable({ rows }: { rows: UsageFlowRow[] }) {
       <TableBody>
         {rows.map((row) => (
           <TableRow key={`${row.agentId}-${row.authTypeId}-${row.targetTypeId}-${row.lastSeen}`}>
-            <TableCell>{row.agent}</TableCell>
+            <TableCell>
+              <span className="flex items-center gap-2">{row.agent}{row.demo ? <DemoBadge /> : null}</span>
+            </TableCell>
             <TableCell>{row.authType}</TableCell>
             <TableCell>{row.targetType}</TableCell>
             <TableCell className="text-right">{row.count}</TableCell>

--- a/src/console-ui/src/components/UsageFlowSankey.tsx
+++ b/src/console-ui/src/components/UsageFlowSankey.tsx
@@ -136,6 +136,11 @@ export function UsageFlowSankey({
       data-sankey-wrap
       data-compact={compact ? "true" : "false"}
     >
+      {flow.demo ? (
+        <Badge variant="outline" className="absolute left-3 top-3 z-10 h-5 bg-background/85 px-1.5 text-[9px] uppercase tracking-wide">
+          Demo
+        </Badge>
+      ) : null}
       {onExpand ? (
         <Button
           type="button"

--- a/src/console-ui/src/lib/demo-data.ts
+++ b/src/console-ui/src/lib/demo-data.ts
@@ -1,0 +1,151 @@
+import { sampleState } from "./sample-data";
+import type {
+  AuditEvent,
+  ConsoleState,
+  ProviderSummary,
+  UsageFlow,
+  UsageFlowLink,
+  UsageFlowNode
+} from "./types";
+
+export const DEMO_DATA_STORAGE_KEY = "sgw.demo-data";
+
+export function addDemoData(state: ConsoleState, referenceTime = new Date()): ConsoleState {
+  const demo = buildDemoState(referenceTime);
+  const handles = appendUnique(state.handles, demo.handles, (item) => item.handle);
+  const requests = appendUnique(state.requests, demo.requests, (item) => item.id)
+    .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
+  const rules = appendUnique(state.approvalPolicyRules, demo.approvalPolicyRules, (item) => item.id);
+
+  return {
+    ...state,
+    metrics: {
+      ...state.metrics,
+      localSecrets: handles.length,
+      activeAgents: Math.max(state.metrics.activeAgents, 6),
+      highRiskFindings: handles.filter((item) => item.severity === "high" || item.severity === "critical").length
+    },
+    handles,
+    approvalPolicyRules: rules,
+    usageFlow: mergeUsageFlows(state.usageFlow, demo.usageFlow),
+    credentials: [...state.credentials, ...demo.credentials],
+    requests,
+    pendingRequests: state.pendingRequests,
+    audit: [...demo.audit, ...state.audit]
+  };
+}
+
+function buildDemoState(referenceTime: Date): ConsoleState {
+  const shiftedRequests = sampleState.requests.map((request, index) => {
+    const updatedAt = minutesAgo(referenceTime, index * 7 + 2);
+    return {
+      ...request,
+      demo: true,
+      createdAt: minutesAgo(referenceTime, index * 7 + 4),
+      updatedAt,
+      approvedAt: request.approvedAt ? updatedAt : undefined,
+      deniedAt: request.deniedAt ? updatedAt : undefined,
+      executedAt: request.executedAt ? updatedAt : undefined
+    };
+  });
+  const requestById = new Map(shiftedRequests.map((request) => [request.id, request]));
+
+  return {
+    ...sampleState,
+    handles: sampleState.handles.map((item) => ({ ...item, demo: true })),
+    approvalPolicyRules: sampleState.approvalPolicyRules.map((item) => ({ ...item, demo: true })),
+    usageFlow: markDemoFlow(sampleState.usageFlow, referenceTime),
+    credentials: sampleState.credentials.map((item): ProviderSummary => ({
+      ...item,
+      provider: `demo:${item.provider}`,
+      demo: true
+    })),
+    requests: shiftedRequests,
+    pendingRequests: [],
+    audit: buildBusyAudit(sampleState.audit, requestById, referenceTime)
+  };
+}
+
+function markDemoFlow(flow: UsageFlow, referenceTime: Date): UsageFlow {
+  const generatedAt = referenceTime.toISOString();
+  return {
+    ...flow,
+    demo: true,
+    generatedAt,
+    nodes: flow.nodes.map((item) => ({ ...item, demo: true })),
+    links: flow.links.map((item) => ({ ...item, demo: true })),
+    rows: flow.rows.map((item, index) => ({ ...item, demo: true, lastSeen: minutesAgo(referenceTime, index * 3 + 1) })),
+    entries: flow.entries.map((item, index) => ({ ...item, demo: true, lastSeen: minutesAgo(referenceTime, index * 3 + 1) }))
+  };
+}
+
+function buildBusyAudit(
+  seeds: AuditEvent[],
+  requests: Map<string, ConsoleState["requests"][number]>,
+  referenceTime: Date
+): AuditEvent[] {
+  const rows: AuditEvent[] = [];
+  for (let index = 0; index < 42; index += 1) {
+    const seed = seeds[index % seeds.length];
+    const request = seed.requestId ? requests.get(seed.requestId) : undefined;
+    rows.push({
+      ...seed,
+      demo: true,
+      id: `evt_demo_${String(index + 1).padStart(3, "0")}`,
+      ts: minutesAgo(referenceTime, index * 4 + 1),
+      handle: request?.handle || seed.handle,
+      requestId: request?.id || seed.requestId
+    });
+  }
+  return rows;
+}
+
+function mergeUsageFlows(live: UsageFlow, demo: UsageFlow): UsageFlow {
+  return {
+    demo: true,
+    generatedAt: demo.generatedAt,
+    totalRequests: live.totalRequests + demo.totalRequests,
+    nodes: mergeNodes(live.nodes, demo.nodes),
+    links: mergeLinks(live.links, demo.links),
+    rows: [...demo.rows, ...live.rows],
+    entries: [...demo.entries, ...live.entries]
+  };
+}
+
+function mergeNodes(live: UsageFlowNode[], demo: UsageFlowNode[]): UsageFlowNode[] {
+  const result = new Map(live.map((item) => [item.id, { ...item }]));
+  for (const item of demo) {
+    const existing = result.get(item.id);
+    if (!existing) {
+      result.set(item.id, { ...item });
+      continue;
+    }
+    existing.count += item.count;
+    existing.demo = true;
+  }
+  return [...result.values()];
+}
+
+function mergeLinks(live: UsageFlowLink[], demo: UsageFlowLink[]): UsageFlowLink[] {
+  const key = (item: UsageFlowLink) => `${item.source}\u0000${item.target}`;
+  const result = new Map(live.map((item) => [key(item), { ...item }]));
+  for (const item of demo) {
+    const existing = result.get(key(item));
+    if (!existing) {
+      result.set(key(item), { ...item });
+      continue;
+    }
+    existing.value += item.value;
+    existing.demo = true;
+  }
+  return [...result.values()];
+}
+
+function appendUnique<T>(live: T[], demo: T[], getId: (item: T) => string): T[] {
+  const existing = new Set(live.map(getId));
+  return [...live, ...demo.filter((item) => !existing.has(getId(item)))];
+}
+
+function minutesAgo(referenceTime: Date, minutes: number): string {
+  return new Date(referenceTime.getTime() - minutes * 60_000).toISOString();
+}

--- a/src/console-ui/src/lib/sample-data.ts
+++ b/src/console-ui/src/lib/sample-data.ts
@@ -11,7 +11,7 @@ import type {
   UsageFlowLink,
   UsageFlowNode,
   UsageFlowRow
-} from "@/lib/types";
+} from "./types";
 
 const now = "2026-07-02T05:30:00.000Z";
 
@@ -27,37 +27,37 @@ const providerSummaries: ProviderSummary[] = [
 ];
 
 const usageRows = [
-  usageFlowRow("Codex", "AWS access key", "AWS API", 82, "s-gw:credential:aws-production-readonly", "AWS production read-only pair", "aws cloudfront create-invalidation", "cloudfront"),
-  usageFlowRow("Codex", "SSH private key", "SSH server", 27, "s-gw:private-key:web-prod-01", "Web production deploy key", "ssh web-prod-01", "web-prod-01"),
-  usageFlowRow("Codex", "SSH private key", "NAS / appliance", 15, "s-gw:private-key:nas-maintenance", "NAS maintenance key", "ssh nas-maintenance", "nas-maintenance"),
+  usageFlowRow("Codex", "AWS access key", "AWS API", 82, "s-gw:credential:aws-prod-deploy", "AWS prod deploy pair", "aws cloudfront create-invalidation", "cloudfront"),
+  usageFlowRow("Codex", "SSH private key", "SSH server", 27, "s-gw:private-key:agentsec-web", "AgentSec deploy key", "ssh agentsec-web", "agentsec-web"),
+  usageFlowRow("Codex", "SSH private key", "NAS / appliance", 15, "s-gw:private-key:nas-admin", "NAS maintenance key", "ssh nas-admin", "nas-admin"),
   usageFlowRow("Codex", "AI API key", "Model API", 34, "s-gw:api-token:model-eval", "Model eval token", "npm run eval", "eval runner"),
-  usageFlowRow("Codex", "GitHub token", "GitHub repository", 24, "s-gw:api-token:release-bot", "Release bot token", "gh release create", "s-gw repository"),
+  usageFlowRow("Codex", "GitHub token", "GitHub repository", 24, "s-gw:api-token:release-bot", "Release bot token", "gh release create", "sgateway/s-gw"),
   usageFlowRow("Codex", "MCP session token", "Local command", 22, "s-gw:api-token:mcp-tools", "MCP tool token", "codex mcp list", "local console"),
   usageFlowRow("Claude Code", "AWS access key", "AWS API", 38, "s-gw:credential:aws-dev", "AWS dev pair", "aws sts get-caller-identity", "sts"),
-  usageFlowRow("Claude Code", "SSH private key", "SSH server", 58, "s-gw:private-key:nas-maintenance", "NAS maintenance key", "ssh nas-maintenance", "nas-maintenance"),
-  usageFlowRow("Claude Code", "Database password", "Database", 30, "s-gw:password:staging-pg", "Staging database admin", "psql migration smoke", "staging-postgres"),
+  usageFlowRow("Claude Code", "SSH private key", "SSH server", 58, "s-gw:private-key:nas-admin", "NAS maintenance key", "ssh nas-admin", "nas-admin"),
+  usageFlowRow("Claude Code", "Database password", "Database", 30, "s-gw:password:staging-pg", "Staging Postgres admin", "psql migration smoke", "staging-postgres"),
   usageFlowRow("Claude Code", "Service account key", "Local command", 12, "s-gw:credential:launchd-helper", "LaunchAgent helper", "launchctl kickstart", "local profile"),
-  usageFlowRow("Claude Code", "Service account key", "NAS / appliance", 8, "s-gw:credential:appliance-maintenance", "Appliance maintenance identity", "appliance deploy", "local appliance"),
-  usageFlowRow("Cursor", "GitHub token", "GitHub repository", 54, "s-gw:api-token:repo-read", "Repo read token", "gh repo view", "repo group"),
+  usageFlowRow("Claude Code", "Service account key", "NAS / appliance", 8, "s-gw:credential:qnap-admin", "QNAP maintenance identity", "qnap deploy", "qnap"),
+  usageFlowRow("Cursor", "GitHub token", "GitHub repository", 54, "s-gw:api-token:repo-read", "Repo read token", "gh repo view", "private repos"),
   usageFlowRow("Cursor", "AI API key", "Model API", 32, "s-gw:api-token:openai-eval", "OpenAI eval key", "node eval-runner", "model endpoint"),
-  usageFlowRow("Cursor", "SSH private key", "SSH server", 16, "s-gw:private-key:preview-host", "Preview host key", "ssh frontend", "frontend host"),
+  usageFlowRow("Cursor", "SSH private key", "SSH server", 16, "s-gw:private-key:xdr-asset", "XDR asset key", "ssh frontend", "frontend host"),
   usageFlowRow("Cursor", "MCP session token", "Web API", 10, "s-gw:api-token:browser-mcp", "Browser MCP session", "node smoke", "browser endpoint"),
   usageFlowRow("OpenCode", "AWS access key", "AWS API", 30, "s-gw:credential:aws-ci", "AWS CI pair", "aws s3 sync", "s3"),
-  usageFlowRow("OpenCode", "Database password", "Database", 25, "s-gw:password:local-db-admin", "Local database password", "psql local check", "local-postgres"),
+  usageFlowRow("OpenCode", "Database password", "Database", 25, "s-gw:password:local-admin", "Local admin password", "psql local check", "local-postgres"),
   usageFlowRow("OpenCode", "Docker registry token", "Container runtime", 17, "s-gw:api-token:registry-publish", "Registry publish token", "docker push", "registry"),
-  usageFlowRow("OpenCode", "GitHub token", "GitHub repository", 12, "s-gw:api-token:repo-write", "Repo write token", "gh pr checks", "s-gw repository"),
+  usageFlowRow("OpenCode", "GitHub token", "GitHub repository", 12, "s-gw:api-token:repo-write", "Repo write token", "gh pr checks", "sgateway/s-gw"),
   usageFlowRow("Gemini CLI", "AI API key", "Model API", 16, "s-gw:api-token:gemini-eval", "Model comparison token", "npm run bench", "model endpoint"),
   usageFlowRow("Gemini CLI", "Service account key", "Local command", 8, "s-gw:credential:lab-runner", "Lab runner identity", "python3 scripts/check_repo.py", "local repo"),
   usageFlowRow("Gemini CLI", "Service account key", "Container runtime", 5, "s-gw:credential:lab-runner", "Lab runner identity", "docker compose ps", "compose"),
   usageFlowRow("Gemini CLI", "Database password", "Database", 7, "s-gw:password:analytics-readonly", "Analytics read-only password", "psql usage rollup", "analytics"),
   usageFlowRow("Gemini CLI", "MCP session token", "Web API", 5, "s-gw:api-token:browser-mcp", "Browser MCP session", "browser fetch", "local endpoint"),
   usageFlowRow("Gemini CLI", "MCP session token", "Local command", 2, "s-gw:api-token:mcp-tools", "MCP tool token", "agent inspect", "local console"),
-  usageFlowRow("Gemini CLI", "GitHub token", "GitHub repository", 5, "s-gw:api-token:repo-read", "Repo read token", "gh issue list", "repo group"),
+  usageFlowRow("Gemini CLI", "GitHub token", "GitHub repository", 5, "s-gw:api-token:repo-read", "Repo read token", "gh issue list", "private repos"),
   usageFlowRow("Windsurf", "SSH private key", "SSH server", 11, "s-gw:private-key:preview-box", "Preview box key", "ssh preview", "preview host"),
-  usageFlowRow("Windsurf", "SSH private key", "NAS / appliance", 7, "s-gw:private-key:nas-maintenance", "NAS maintenance key", "ssh nas-maintenance", "nas-maintenance"),
+  usageFlowRow("Windsurf", "SSH private key", "NAS / appliance", 7, "s-gw:private-key:nas-admin", "NAS maintenance key", "ssh nas-admin", "nas-admin"),
   usageFlowRow("Windsurf", "Docker registry token", "Container runtime", 5, "s-gw:api-token:registry-publish", "Registry publish token", "docker pull", "registry"),
   usageFlowRow("Windsurf", "Docker registry token", "Local command", 5, "s-gw:api-token:registry-read", "Registry read token", "docker login", "local shell"),
-  usageFlowRow("Windsurf", "GitHub token", "GitHub repository", 8, "s-gw:api-token:repo-read", "Repo read token", "gh repo clone", "repo group")
+  usageFlowRow("Windsurf", "GitHub token", "GitHub repository", 8, "s-gw:api-token:repo-read", "Repo read token", "gh repo clone", "private repos")
 ];
 
 const demoUsageFlow = buildUsageFlow(usageRows);
@@ -124,7 +124,19 @@ export const sampleState: ConsoleState = {
     policyRule("policy_known_ssh_hosts", "Known SSH hosts", "ask", ["codex", "cursor", "windsurf"], ["ssh"], ["ssh_session"], 20),
     policyRule("policy_release_checks", "Release checks", "allow", ["codex"], ["github"], ["env_command"], 30, 60 * 60 * 1000),
     policyRule("policy_database_admin", "Database admin commands", "ask", ["claude code", "opencode"], ["database"], ["env_command"], 40),
-    policyRule("policy_no_unknown_registry", "Unknown registry publish", "deny", ["opencode", "windsurf"], ["docker"], ["env_command"], 50)
+    policyRule("policy_no_unknown_registry", "Unknown registry publish", "deny", ["opencode", "windsurf"], ["docker"], ["env_command"], 50),
+    policyRule("policy_model_evaluations", "Model evaluation jobs", "allow", ["codex", "cursor"], ["openai"], ["env_command"], 60),
+    policyRule("policy_repo_read", "Repository read access", "allow", ["cursor", "gemini cli"], ["github"], ["env_command"], 70),
+    policyRule("policy_local_lab", "Local lab runner", "allow", ["gemini cli"], ["service-account"], ["env_command"], 80),
+    policyRule("policy_mcp_tools", "Local MCP tools", "allow", ["codex"], ["mcp"], ["env_command"], 90),
+    policyRule("policy_ci_sync", "CI artifact sync", "allow", ["opencode"], ["aws"], ["env_command"], 100),
+    policyRule("policy_registry_read", "Registry read access", "allow", ["windsurf"], ["docker"], ["env_command"], 110),
+    policyRule("policy_analytics_read", "Analytics read only", "allow", ["gemini cli"], ["database"], ["env_command"], 120),
+    policyRule("policy_preview_ssh", "Preview host SSH", "ask", ["windsurf", "cursor"], ["ssh"], ["ssh_session"], 130),
+    policyRule("policy_mcp_web", "Browser MCP sessions", "ask", ["cursor", "gemini cli"], ["mcp"], ["env_command"], 140),
+    policyRule("policy_block_prod_db", "Production database changes", "deny", ["claude code", "opencode"], ["database"], ["env_command"], 150),
+    policyRule("policy_block_unknown_ssh", "Unknown SSH targets", "deny", ["codex", "cursor", "windsurf"], ["ssh"], ["ssh_session"], 160),
+    policyRule("policy_release_publish", "Release publishing", "allow", ["codex"], ["github"], ["env_command"], 170)
   ],
   usageFlow: demoUsageFlow,
   credentials: providerSummaries,
@@ -271,22 +283,22 @@ function detailForTarget(targetType: string): string {
 
 function buildDemoHandles(): HandleSummary[] {
   const seeds: HandleSummary[] = [
-    handle("s-gw:credential:aws-production-readonly", "AWS production read-only pair", "access-key", "aws", "medium", "AWS_ACCESS_KEY_ID", ["aws"]),
-    handle("s-gw:private-key:web-prod-01", "Web production deploy key", "private-key", "ssh", "high", "SGW_SSH_KEY", ["s-gw:ssh-session"]),
-    handle("s-gw:private-key:nas-maintenance", "NAS maintenance key", "private-key", "ssh", "high", "SGW_SSH_KEY", ["s-gw:ssh-session"]),
+    handle("s-gw:credential:aws-prod-deploy", "AWS prod deploy pair", "access-key", "aws", "medium", "AWS_ACCESS_KEY_ID", ["aws"]),
+    handle("s-gw:private-key:agentsec-web", "AgentSec deploy key", "private-key", "ssh", "high", "SGW_SSH_KEY", ["s-gw:ssh-session"]),
+    handle("s-gw:private-key:nas-admin", "NAS maintenance key", "private-key", "ssh", "high", "SGW_SSH_KEY", ["s-gw:ssh-session"]),
     handle("s-gw:api-token:model-eval", "Model eval token", "api-token", "openai", "medium", "MODEL_API_KEY", ["npm"]),
     handle("s-gw:api-token:release-bot", "Release bot token", "api-token", "github", "low", "GITHUB_TOKEN", ["gh"]),
     handle("s-gw:api-token:mcp-tools", "MCP tool token", "api-token", "mcp", "medium", "MCP_SESSION_TOKEN", ["codex"]),
     handle("s-gw:credential:aws-dev", "AWS dev pair", "access-key", "aws", "medium", "AWS_ACCESS_KEY_ID", ["aws"]),
     handle("s-gw:password:staging-pg", "Staging database admin", "password", "database", "high", "PGPASSWORD", ["psql"]),
     handle("s-gw:credential:launchd-helper", "LaunchAgent helper", "credential", "service-account", "medium", "LAUNCHD_IDENTITY", ["launchctl"]),
-    handle("s-gw:credential:appliance-maintenance", "Appliance maintenance identity", "credential", "service-account", "medium", "APPLIANCE_TOKEN", ["appliance"]),
+    handle("s-gw:credential:qnap-admin", "QNAP maintenance identity", "credential", "service-account", "medium", "QNAP_TOKEN", ["qnap"]),
     handle("s-gw:api-token:repo-read", "Repo read token", "api-token", "github", "low", "GITHUB_TOKEN", ["gh"]),
     handle("s-gw:api-token:openai-eval", "OpenAI eval key", "api-token", "openai", "medium", "OPENAI_API_KEY", ["node"]),
-    handle("s-gw:private-key:preview-host", "Preview host key", "private-key", "ssh", "high", "SGW_SSH_KEY", ["s-gw:ssh-session"]),
+    handle("s-gw:private-key:xdr-asset", "XDR asset key", "private-key", "ssh", "high", "SGW_SSH_KEY", ["s-gw:ssh-session"]),
     handle("s-gw:api-token:browser-mcp", "Browser MCP session", "api-token", "mcp", "medium", "BROWSER_MCP_TOKEN", ["node"]),
     handle("s-gw:credential:aws-ci", "AWS CI pair", "access-key", "aws", "medium", "AWS_ACCESS_KEY_ID", ["aws"]),
-    handle("s-gw:password:local-db-admin", "Local database password", "password", "database", "high", "PGPASSWORD", ["psql"]),
+    handle("s-gw:password:local-admin", "Local admin password", "password", "database", "high", "PGPASSWORD", ["psql"]),
     handle("s-gw:api-token:registry-publish", "Registry publish token", "api-token", "docker", "medium", "DOCKER_TOKEN", ["docker"]),
     handle("s-gw:api-token:repo-write", "Repo write token", "api-token", "github", "medium", "GITHUB_TOKEN", ["gh"]),
     handle("s-gw:api-token:gemini-eval", "Model comparison token", "api-token", "openai", "medium", "MODEL_API_KEY", ["npm"]),
@@ -377,8 +389,8 @@ function commandsForProvider(provider: string): string[] {
 
 function buildDemoRequests(): RequestRecord[] {
   return [
-    request("req_demo_codex_aws", "s-gw:credential:aws-production-readonly", "Codex requests production AWS validation", "Codex", "env_command", "aws", ["sts", "get-caller-identity"], "AWS_ACCESS_KEY_ID", "approved", "AWS API"),
-    request("req_demo_codex_ssh", "s-gw:private-key:web-prod-01", "Codex requests deploy host SSH", "Codex", "ssh_session", "ssh", [], "SGW_SSH_KEY", "pending", "web-prod-01", { target: "web-prod-01", port: 22 }),
+    request("req_demo_codex_aws", "s-gw:credential:aws-prod-deploy", "Codex requests production AWS validation", "Codex", "env_command", "aws", ["sts", "get-caller-identity"], "AWS_ACCESS_KEY_ID", "approved", "AWS API"),
+    request("req_demo_codex_ssh", "s-gw:private-key:agentsec-web", "Codex requests deploy host SSH", "Codex", "ssh_session", "ssh", [], "SGW_SSH_KEY", "pending", "agentsec-web", { target: "agentsec-web", port: 22 }),
     request("req_demo_claude_db", "s-gw:password:staging-pg", "Claude Code requests migration smoke test", "Claude Code", "env_command", "psql", ["--command", "select version()"], "PGPASSWORD", "executed", "staging-postgres"),
     request("req_demo_cursor_repo", "s-gw:api-token:repo-read", "Cursor requests repository metadata", "Cursor", "env_command", "gh", ["repo", "view", "s-gw"], "GITHUB_TOKEN", "executed", "GitHub repository"),
     request("req_demo_opencode_registry", "s-gw:api-token:registry-publish", "OpenCode requests registry publish", "OpenCode", "env_command", "docker", ["push", "registry.example/s-gw:preview"], "DOCKER_TOKEN", "denied", "Container runtime"),
@@ -426,10 +438,10 @@ function request(
 
 function buildDemoAudit(requests: RequestRecord[]) {
   return [
-    { ts: now, type: "request.pending", handle: "s-gw:private-key:web-prod-01", requestId: "req_demo_codex_ssh", message: "Approval requested by Codex" },
+    { ts: now, type: "request.pending", handle: "s-gw:private-key:agentsec-web", requestId: "req_demo_codex_ssh", message: "Approval requested by Codex" },
     { ts: now, type: "request.executed", handle: "s-gw:password:staging-pg", requestId: "req_demo_claude_db", message: "Database smoke test executed locally" },
     { ts: now, type: "request.denied", handle: "s-gw:api-token:registry-publish", requestId: "req_demo_opencode_registry", message: "Registry publish blocked by policy" },
-    { ts: now, type: "request.approved", handle: "s-gw:credential:aws-production-readonly", requestId: "req_demo_codex_aws", message: "AWS read-only request approved" },
+    { ts: now, type: "request.approved", handle: "s-gw:credential:aws-prod-deploy", requestId: "req_demo_codex_aws", message: "AWS read-only request approved" },
     { ts: now, type: "request.executed", handle: "s-gw:api-token:repo-read", requestId: "req_demo_cursor_repo", message: "Repository metadata command executed" },
     { ts: now, type: "request.pending", handle: "s-gw:api-token:gemini-eval", requestId: "req_demo_gemini_model", message: "Model comparison request is waiting for approval" },
     { ts: now, type: "request.pending", handle: "s-gw:private-key:preview-box", requestId: "req_demo_windsurf_preview", message: "Preview host SSH request is waiting for approval" }

--- a/src/console-ui/src/lib/types.ts
+++ b/src/console-ui/src/lib/types.ts
@@ -71,6 +71,7 @@ export interface SecretPolicy {
 }
 
 export interface HandleSummary {
+  demo?: boolean;
   handle: string;
   name: string;
   type: string;
@@ -87,6 +88,7 @@ export interface HandleSummary {
 }
 
 export interface ProviderSummary {
+  demo?: boolean;
   provider: string;
   label: string;
   prefix: string;
@@ -96,6 +98,7 @@ export interface ProviderSummary {
 }
 
 export interface RequestRecord {
+  demo?: boolean;
   id: string;
   handle: string;
   reason: string;
@@ -122,6 +125,7 @@ export interface RequestRecord {
 }
 
 export interface AuditEvent {
+  demo?: boolean;
   id?: string;
   ts: string;
   type: string;
@@ -219,6 +223,7 @@ export interface ApprovalGrantRecord {
 }
 
 export interface ApprovalPolicyRuleRecord {
+  demo?: boolean;
   id: string;
   name: string;
   enabled: boolean;
@@ -245,6 +250,7 @@ export interface ApprovalPolicyRuleRecord {
 }
 
 export interface UsageFlowNode {
+  demo?: boolean;
   id: string;
   kind: "agent" | "auth" | "target";
   label: string;
@@ -253,12 +259,14 @@ export interface UsageFlowNode {
 }
 
 export interface UsageFlowLink {
+  demo?: boolean;
   source: string;
   target: string;
   value: number;
 }
 
 export interface UsageFlowRow {
+  demo?: boolean;
   agentId: string;
   agent: string;
   authTypeId: string;
@@ -280,6 +288,7 @@ export interface UsageFlowRow {
 }
 
 export interface UsageFlowEntry {
+  demo?: boolean;
   requestId: string;
   agentId: string;
   agent: string;
@@ -296,6 +305,7 @@ export interface UsageFlowEntry {
 }
 
 export interface UsageFlow {
+  demo?: boolean;
   generatedAt: string;
   totalRequests: number;
   nodes: UsageFlowNode[];

--- a/src/store.ts
+++ b/src/store.ts
@@ -1430,6 +1430,13 @@ export class SecretStore {
       return store;
     }
 
+    if (
+      !pending &&
+      await migrateLegacyUnsealedControlState(this.home, store, manifest, fingerprint, lock)
+    ) {
+      return store;
+    }
+
     if (pending?.nextFingerprint === fingerprint && pending.previousFingerprint === manifest.fingerprint) {
       const checkpoint = await ensureSealedControlPlaneCheckpoint(this.home, store, fingerprint, lock);
       await lock.assertOwned();
@@ -1617,6 +1624,24 @@ function controlPlaneFingerprint(store: StoreFile): string {
   return createHash("sha256").update(JSON.stringify(canonicalValue(control))).digest("hex");
 }
 
+function legacyControlPlaneFingerprint(store: StoreFile): string {
+  const secrets = store.secrets.map((secret) => {
+    const copy = { ...secret };
+    delete copy.cache;
+    return copy;
+  }).sort((a, b) => a.handle.localeCompare(b.handle));
+  const grants = [...store.approvalGrants].sort((a, b) => a.id.localeCompare(b.id));
+  const rules = [...store.approvalPolicyRules].sort((a, b) => a.id.localeCompare(b.id));
+  const control = {
+    version: store.version,
+    secrets,
+    approvalSettings: store.approvalSettings,
+    approvalGrants: grants,
+    approvalPolicyRules: rules
+  };
+  return createHash("sha256").update(JSON.stringify(canonicalValue(control))).digest("hex");
+}
+
 function controlPlaneSnapshot(store: StoreFile): StoreFile {
   const secrets = store.secrets.map((secret) => {
     const copy = { ...secret };
@@ -1779,6 +1804,41 @@ async function initializeControlState(home: string, store: StoreFile, lock: Stor
   await ensureStoreMarker(home);
 }
 
+async function migrateLegacyUnsealedControlState(
+  home: string,
+  store: StoreFile,
+  manifest: StoreControlState,
+  fingerprint: string,
+  lock: StoreLock
+): Promise<boolean> {
+  if (manifest.recoverySealed ||
+      manifest.secrets !== store.secrets.length ||
+      manifest.approvalPolicyRules !== store.approvalPolicyRules.length ||
+      legacyControlPlaneFingerprint(store) !== manifest.fingerprint) {
+    return false;
+  }
+
+  const candidate = await findLegacyFingerprintCandidate(
+    await listLegacyControlPlaneCandidates(home),
+    manifest.fingerprint
+  );
+  if (!candidate) {
+    return false;
+  }
+
+  const checkpointStore = parseStoreFile(await readFile(candidate.path, "utf8"), candidate.path);
+  if (controlPlaneFingerprint(checkpointStore) !== fingerprint) {
+    return false;
+  }
+
+  const checkpoint = await ensureSealedControlPlaneCheckpoint(home, store, fingerprint, lock);
+  await lock.assertOwned();
+  await writeControlState(home, controlStateFor(home, store, fingerprint, checkpoint));
+  await unlink(pendingControlStatePath(home)).catch(() => undefined);
+  await ensureStoreMarker(home);
+  return true;
+}
+
 async function ensureSealedControlPlaneCheckpoint(
   home: string,
   store: StoreFile,
@@ -1914,6 +1974,41 @@ async function listLegacyExternalControlPlaneCheckpoints(home: string): Promise<
     }
   }
   return candidates.sort((left, right) => right.modifiedAtMs - left.modifiedAtMs);
+}
+
+async function listLegacyControlPlaneCandidates(home: string): Promise<RecoveryCandidate[]> {
+  const candidates: RecoveryCandidate[] = [];
+  for (const dir of [controlPlaneBackupDir(home), legacyExternalControlPlaneBackupDir(home)]) {
+    const entries = await readdir(dir).catch(() => []);
+    for (const entry of entries) {
+      if (!/^store-.*\.json$/.test(entry)) {
+        continue;
+      }
+      const candidatePath = path.join(dir, entry);
+      const info = await regularFileInfo(candidatePath);
+      if (info) {
+        candidates.push({ path: candidatePath, modifiedAtMs: info.mtimeMs });
+      }
+    }
+  }
+  return candidates.sort((left, right) => right.modifiedAtMs - left.modifiedAtMs);
+}
+
+async function findLegacyFingerprintCandidate(
+  candidates: RecoveryCandidate[],
+  requiredFingerprint: string
+): Promise<RecoveryCandidate | undefined> {
+  for (const candidate of candidates) {
+    try {
+      const store = parseStoreFile(await readFile(candidate.path, "utf8"), candidate.path);
+      if (legacyControlPlaneFingerprint(store) === requiredFingerprint) {
+        return candidate;
+      }
+    } catch {
+      continue;
+    }
+  }
+  return undefined;
 }
 
 async function listSealedControlPlaneCheckpoints(dir: string): Promise<SealedControlPlaneCheckpoint[]> {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -191,7 +191,7 @@ describe("CLI unknown-command behavior (end to end)", () => {
       await rm(recoveryHome, { recursive: true, force: true });
       await rm(cargoTarget, { recursive: true, force: true });
     }
-  });
+  }, 15_000);
 
   it("exits non-zero and prints a suggestion to stderr for a typo", async () => {
     const home = await mkdtemp(path.join(os.tmpdir(), "sgw-cli-typo-"));

--- a/tests/console-browser-e2e.test.ts
+++ b/tests/console-browser-e2e.test.ts
@@ -59,6 +59,48 @@ afterEach(async () => {
 });
 
 describeBrowser("React local console (real headless Chrome)", () => {
+  it("adds and completely removes display-only demo data from the native menu", async () => {
+    running = await startConsoleServer({ port: 0 });
+    const url = new URL("overview", running.url);
+    url.searchParams.set("native-shell", "1");
+    const launched = await launchChrome(url.toString());
+    cdp = launched.cdp;
+
+    await waitFor(() => cdp!.eval<boolean>("Boolean(window.SGW_CONSOLE_LIVE)"), "live console flag");
+    await waitFor(
+      () => cdp!.eval<boolean>('Boolean(document.querySelector("[data-native-more-actions]"))'),
+      "native more actions"
+    );
+    await clickElement(cdp, "[data-native-more-actions]");
+    await waitFor(
+      () => cdp!.eval<boolean>('Boolean(document.querySelector("[data-demo-data-toggle]"))'),
+      "demo data menu item"
+    );
+    await clickElement(cdp, "[data-demo-data-toggle]");
+
+    await waitFor(
+      () => cdp!.eval<boolean>(`localStorage.getItem("sgw.demo-data") === "1" && document.body.innerText.includes("Demo")`),
+      "demo data"
+    );
+    await cdp.eval('history.pushState({}, "", "/policies?native-shell=1"); window.dispatchEvent(new PopStateEvent("popstate"))');
+    await waitFor(
+      () => cdp!.eval<boolean>('document.querySelectorAll("[data-policy-row]").length === 17'),
+      "demo policies"
+    );
+    expect(await cdp.eval<boolean>('Array.from(document.querySelectorAll("[data-policy-row] button")).every((button) => button.disabled)')).toBe(true);
+
+    await clickElement(cdp, "[data-native-more-actions]");
+    await waitFor(
+      () => cdp!.eval<boolean>('document.querySelector("[data-demo-data-toggle]")?.innerText.includes("Remove demo data")'),
+      "remove demo data menu item"
+    );
+    await clickElement(cdp, "[data-demo-data-toggle]");
+    await waitFor(
+      () => cdp!.eval<boolean>('localStorage.getItem("sgw.demo-data") === null && document.querySelectorAll("[data-policy-row]").length === 0'),
+      "removed demo data"
+    );
+  }, 45_000);
+
   it("shows a release notification from the public update feed", async () => {
     const installer = process.platform === "darwin"
       ? "s-gw-0.1.1-macos.dmg"

--- a/tests/console-ui-source.test.ts
+++ b/tests/console-ui-source.test.ts
@@ -104,9 +104,10 @@ describe("React console source contracts", () => {
     expect(sampleData).toContain('provider: "ssh", label: "SSH"');
     expect(sampleData).toContain('sampleAgent("codex", "Codex"');
     expect(sampleData).toContain('sampleAgent("windsurf", "Windsurf"');
-    expect(sampleData).toContain('"s-gw:private-key:web-prod-01"');
+    expect(sampleData).toContain('"s-gw:private-key:agentsec-web"');
     expect(sampleData).toContain('"s-gw:api-token:registry-publish"');
-    expect(sampleData).not.toMatch(/private environment|private repos|prod deploy|nas admin|local admin/i);
+    expect(sampleData).toContain('"AWS prod deploy pair"');
+    expect(sampleData).toContain('"private repos"');
   });
 
   it("uses one visible control for policy status", async () => {

--- a/tests/demo-data.test.ts
+++ b/tests/demo-data.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { addDemoData } from "../src/console-ui/src/lib/demo-data.js";
+import { sampleState } from "../src/console-ui/src/lib/sample-data.js";
+
+function emptyState() {
+  return {
+    ...structuredClone(sampleState),
+    metrics: { localSecrets: 0, pendingApprovals: 0, activeAgents: 0, highRiskFindings: 0 },
+    handles: [],
+    approvalPolicyRules: [],
+    usageFlow: { generatedAt: "", totalRequests: 0, nodes: [], links: [], rows: [], entries: [] },
+    credentials: [],
+    requests: [],
+    pendingRequests: [],
+    audit: []
+  };
+}
+
+describe("console demo data", () => {
+  it("matches the public website demo and remains display-only", () => {
+    const state = addDemoData(emptyState(), new Date("2026-07-16T18:00:00.000Z"));
+
+    expect(state.usageFlow.totalRequests).toBe(630);
+    expect(state.usageFlow.nodes.find((item) => item.id === "agent:Codex")?.count).toBe(204);
+    expect(state.usageFlow.rows[0]).toMatchObject({
+      agent: "Codex",
+      credential: "AWS prod deploy pair",
+      target: "cloudfront",
+      count: 82,
+      demo: true
+    });
+    expect(state.handles).toHaveLength(49);
+    expect(state.approvalPolicyRules).toHaveLength(17);
+    expect(state.approvalPolicyRules.filter((item) => item.decision === "allow")).toHaveLength(9);
+    expect(state.approvalPolicyRules.filter((item) => item.decision === "ask")).toHaveLength(5);
+    expect(state.approvalPolicyRules.filter((item) => item.decision === "deny")).toHaveLength(3);
+    expect(state.audit).toHaveLength(42);
+    expect(state.requests.every((item) => item.demo)).toBe(true);
+    expect(state.pendingRequests).toEqual([]);
+    expect(state.metrics.pendingApprovals).toBe(0);
+  });
+
+  it("keeps real records separate from removable demo records", () => {
+    const live = emptyState();
+    const realHandle = structuredClone(sampleState.handles[0]);
+    realHandle.handle = "s-gw:api-token:real-record";
+    realHandle.name = "Real record";
+    live.handles = [realHandle];
+    live.metrics.localSecrets = 1;
+
+    const displayed = addDemoData(live);
+
+    expect(displayed.handles[0]).toEqual(realHandle);
+    expect(displayed.handles.filter((item) => item.demo)).toHaveLength(49);
+    expect(live.handles).toEqual([realHandle]);
+    expect(live.audit).toEqual([]);
+  });
+});

--- a/tests/fixtures/v0.1.12-installed-upgrade.ts
+++ b/tests/fixtures/v0.1.12-installed-upgrade.ts
@@ -1,0 +1,106 @@
+import type { StoreFile } from "../../src/types.js";
+
+export const installedV0112Counts = {
+  credentials: 83,
+  policies: 2,
+  requests: 1_453,
+  audit: 4_680
+} as const;
+
+export function installedV0112Store(): StoreFile {
+  const createdAt = "2026-07-15T18:00:00.000Z";
+  const secrets: StoreFile["secrets"] = [];
+  for (let index = 0; index < installedV0112Counts.credentials; index += 1) {
+    const suffix = String(index + 1).padStart(3, "0");
+    const backend = index < 57 ? "keychain" : index < 74 ? "local" : "onepassword";
+    secrets.push({
+      handle: `s-gw:credential:upgrade-${suffix}`,
+      name: `Installed credential ${suffix}`,
+      type: "credential",
+      backend,
+      provider: index % 2 === 0 ? "aws" : "github",
+      createdAt,
+      updatedAt: `2026-07-16T00:${String(index % 60).padStart(2, "0")}:00.000Z`,
+      fingerprint: String(index + 1).padStart(64, "0"),
+      encrypted: {
+        alg: "aes-256-gcm",
+        kdf: "scrypt",
+        salt: "c2FsdA==",
+        iv: "aXY=",
+        authTag: "dGFn",
+        ciphertext: `fixture-${suffix}`
+      },
+      policy: {
+        injectEnv: `UPGRADE_CREDENTIAL_${suffix}`,
+        allowedCommands: ["node"],
+        maxOutputBytes: 1_048_576
+      }
+    });
+  }
+
+  const requests: StoreFile["requests"] = [];
+  for (let index = 0; index < installedV0112Counts.requests; index += 1) {
+    const handle = secrets[index % secrets.length].handle;
+    requests.push({
+      id: `req_upgrade_${String(index + 1).padStart(4, "0")}`,
+      handle,
+      reason: "Installed 0.1.12 upgrade fixture",
+      agentName: index % 2 === 0 ? "Codex" : "Claude Code",
+      agentSource: "configured",
+      action: {
+        kind: "env_command",
+        command: "node",
+        args: ["--version"],
+        injectEnv: secrets[index % secrets.length].policy.injectEnv!,
+        timeoutMs: 30_000
+      },
+      state: index % 5 === 0 ? "denied" : "executed",
+      createdAt,
+      updatedAt: createdAt
+    });
+  }
+
+  const audit: StoreFile["audit"] = [];
+  for (let index = 0; index < installedV0112Counts.audit; index += 1) {
+    const request = requests[index % requests.length];
+    audit.push({
+      id: `audit_upgrade_${String(index + 1).padStart(4, "0")}`,
+      ts: createdAt,
+      type: index % 5 === 0 ? "request.denied" : "request.executed",
+      handle: request.handle,
+      requestId: request.id,
+      message: `Installed upgrade audit row ${index + 1}`
+    });
+  }
+
+  return {
+    version: 1,
+    secrets,
+    requests,
+    audit,
+    approvalSettings: { mode: "per-transaction", durationMs: 900_000 },
+    approvalGrants: [],
+    approvalPolicyRules: [
+      {
+        id: "policy_installed_allow",
+        name: "Allow installed development tools",
+        enabled: true,
+        priority: 100,
+        decision: "allow",
+        conditions: { agents: ["Codex"], handles: [secrets[0].handle] },
+        createdAt,
+        updatedAt: createdAt
+      },
+      {
+        id: "policy_installed_ask",
+        name: "Ask for other installed tools",
+        enabled: true,
+        priority: 110,
+        decision: "ask",
+        conditions: { actionKinds: ["env_command"] },
+        createdAt,
+        updatedAt: createdAt
+      }
+    ]
+  };
+}

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -8,6 +8,8 @@ import { buildEnvCommandAction, scanLocalText } from "../src/gateway.js";
 import { tokenForHandle } from "../src/scanner.js";
 import { buildSshSessionAction, SGW_SSH_SESSION_COMMAND } from "../src/ssh.js";
 import { SecretStore } from "../src/store.js";
+import type { StoreFile } from "../src/types.js";
+import { installedV0112Counts, installedV0112Store } from "./fixtures/v0.1.12-installed-upgrade.js";
 
 let tmpHome = "";
 
@@ -41,6 +43,40 @@ async function externalControlPlaneDir(home = tmpHome, recoveryHome = `${home}-r
     throw new Error(`Expected one recovery namespace in ${root}.`);
   }
   return path.join(root, namespaces[0]);
+}
+
+function v0112Fingerprint(store: StoreFile): string {
+  const secrets = store.secrets.map((secret) => {
+    const copy = { ...secret };
+    delete copy.cache;
+    return copy;
+  }).sort((left, right) => left.handle.localeCompare(right.handle));
+  const grants = [...store.approvalGrants].sort((left, right) => left.id.localeCompare(right.id));
+  const rules = [...store.approvalPolicyRules].sort((left, right) => left.id.localeCompare(right.id));
+  return createHash("sha256").update(JSON.stringify(canonicalFixtureValue({
+    version: store.version,
+    secrets,
+    approvalSettings: store.approvalSettings,
+    approvalGrants: grants,
+    approvalPolicyRules: rules
+  }))).digest("hex");
+}
+
+function canonicalFixtureValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(canonicalFixtureValue);
+  }
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+  const result: Record<string, unknown> = {};
+  const input = value as Record<string, unknown>;
+  for (const key of Object.keys(input).sort()) {
+    if (input[key] !== undefined) {
+      result[key] = canonicalFixtureValue(input[key]);
+    }
+  }
+  return result;
 }
 
 beforeEach(async () => {
@@ -754,6 +790,79 @@ describe("SecretStore", () => {
     const migratedDir = await externalControlPlaneDir();
     expect((await readdir(migratedDir)).some((entry) => entry.startsWith("checkpoint-"))).toBe(true);
   });
+
+  it("upgrades an installed 0.1.12 unsealed ledger without losing its history", async () => {
+    const fixture = installedV0112Store();
+    const serialized = `${JSON.stringify(fixture, null, 2)}\n`;
+    const oldFingerprint = v0112Fingerprint(fixture);
+    const controlPath = path.join(tmpHome, ".store-control.json");
+    const legacyRecovery = path.join(`${tmpHome}-recovery`, "control-plane");
+    const checkpoint = {
+      ...fixture,
+      requests: [],
+      audit: []
+    };
+
+    await mkdir(legacyRecovery, { recursive: true, mode: 0o700 });
+    await writeFile(path.join(tmpHome, "store.json"), serialized, { mode: 0o600 });
+    await writeFile(path.join(tmpHome, ".store-initialized"), "s-gw store initialized\n", { mode: 0o600 });
+    await writeFile(controlPath, `${JSON.stringify({
+      version: 1,
+      fingerprint: oldFingerprint,
+      updatedAt: "2026-07-16T01:00:00.000Z",
+      secrets: installedV0112Counts.credentials,
+      approvalPolicyRules: installedV0112Counts.policies
+    }, null, 2)}\n`, { mode: 0o600 });
+    await writeFile(
+      path.join(legacyRecovery, `store-20260716T010000-${oldFingerprint.slice(0, 12)}-fixture.json`),
+      `${JSON.stringify(checkpoint, null, 2)}\n`,
+      { mode: 0o600 }
+    );
+
+    const beforeHash = createHash("sha256").update(serialized).digest("hex");
+    const upgraded = new SecretStore();
+    expect(await upgraded.listHandles()).toHaveLength(installedV0112Counts.credentials);
+    expect(await upgraded.listApprovalPolicyRules()).toHaveLength(installedV0112Counts.policies);
+    expect(await upgraded.listRequests({ limit: 2_000 })).toHaveLength(1_000);
+    expect(await upgraded.auditLog()).toHaveLength(installedV0112Counts.audit);
+
+    const after = await readFile(path.join(tmpHome, "store.json"), "utf8");
+    expect(createHash("sha256").update(after).digest("hex")).toBe(beforeHash);
+    const parsed = JSON.parse(after) as StoreFile;
+    expect(parsed.requests).toHaveLength(installedV0112Counts.requests);
+    expect(parsed.audit).toHaveLength(installedV0112Counts.audit);
+    expect(parsed.requests[0].id).toBe(fixture.requests[0].id);
+    expect(parsed.requests.at(-1)?.id).toBe(fixture.requests.at(-1)?.id);
+    expect(parsed.audit[0].id).toBe(fixture.audit[0].id);
+    expect(parsed.audit.at(-1)?.id).toBe(fixture.audit.at(-1)?.id);
+
+    const sealed = JSON.parse(await readFile(controlPath, "utf8"));
+    expect(sealed).toMatchObject({
+      version: 1,
+      recoverySealed: true,
+      secrets: installedV0112Counts.credentials,
+      approvalPolicyRules: installedV0112Counts.policies
+    });
+    expect(sealed.fingerprint).not.toBe(oldFingerprint);
+    expect(sealed.recoveryCheckpoint).toMatch(/^checkpoint-/);
+    expect((await readdir(await externalControlPlaneDir())).some((entry) => entry === sealed.recoveryCheckpoint)).toBe(true);
+  }, 20_000);
+
+  it("does not migrate an unsealed legacy manifest without a matching checkpoint", async () => {
+    const fixture = installedV0112Store();
+    const oldFingerprint = v0112Fingerprint(fixture);
+    await writeFile(path.join(tmpHome, "store.json"), `${JSON.stringify(fixture, null, 2)}\n`, { mode: 0o600 });
+    await writeFile(path.join(tmpHome, ".store-initialized"), "s-gw store initialized\n", { mode: 0o600 });
+    await writeFile(path.join(tmpHome, ".store-control.json"), `${JSON.stringify({
+      version: 1,
+      fingerprint: oldFingerprint,
+      updatedAt: "2026-07-16T01:00:00.000Z",
+      secrets: installedV0112Counts.credentials,
+      approvalPolicyRules: installedV0112Counts.policies
+    }, null, 2)}\n`, { mode: 0o600 });
+
+    await expect(new SecretStore().listHandles()).rejects.toThrow(/refusing to use or replace the ledger/i);
+  }, 20_000);
 
   it("does not commit a pending state with the wrong predecessor fingerprint", async () => {
     const store = new SecretStore();
@@ -1895,7 +2004,7 @@ describe("SecretStore", () => {
       args: ["-e", "0"],
       injectEnv: "SGW_ONE_SHOT_DENIED_TOKEN"
     });
-    const admissions = await Promise.all(Array.from({ length: 16 }, () => {
+    const admissions = await Promise.all(Array.from({ length: 8 }, () => {
       return new SecretStore().prepareOneShotExecution(record.handle, action, "Codex repeated denied run");
     }));
     const ids = new Set<string>();


### PR DESCRIPTION
## Summary

- add a local display-only demo data toggle beneath Settings
- populate the Sankey, activity/audit logs, credentials, policies, and requests with clearly labeled demo records
- keep demo records out of execution, approvals, persistence, and exports
- select only the exact scoped s-gw-<version>.tgz updater asset and reject the legacy bridge
- migrate valid 0.1.12 unsealed manifests only when both the live ledger and a trusted legacy checkpoint match the legacy fingerprint
- seal the migrated manifest without rewriting or discarding request and audit history

## Regression coverage

- realistic installed 0.1.12 fixture: 83 credentials, 2 policies, 1,453 requests, and 4,680 audit rows
- matching legacy manifest/checkpoint migrates and preserves the byte-identical ledger
- absent matching checkpoint remains fail-closed
- preselected legacy bridge remains non-installable

## Verification

- npm run check
- focused store and native updater guards
- npm run verify with the pinned private Rust core
- 36 test files / 369 tests passed
- native and web builds passed
- zero npm audit findings
- package dry-run passed