### PR TITLE
Report the installed runtime version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Notable changes to s-gw are documented here. The project follows [Semantic Versi
 ### Fixed
 
 - The macOS package updater now accepts only the exact scoped `s-gw-<version>.tgz` asset and rejects the legacy compatibility bridge before download or installation.
+- Native update banners and Settings now report the active installed CLI/runtime version instead of a stale development app bundle version.
 - Valid 0.1.12 unsealed control manifests migrate to the current sealed recovery format only when the live ledger and a trusted legacy checkpoint both match the legacy fingerprint. Credentials, policies, requests, and audit history remain intact, while unexplained mismatches continue to fail closed.
 
 ## 0.1.17 - 2026-07-16

--- a/native/macos-app/Sources/SgwMac/App/AppState.swift
+++ b/native/macos-app/Sources/SgwMac/App/AppState.swift
@@ -92,6 +92,10 @@ final class AppState {
     status?.readiness?.summary
   }
 
+  var installedVersion: String {
+    status?.version ?? UpdateChecker.currentVersion
+  }
+
   var highRiskCount: Int {
     handles.filter { $0.severityValue >= .high }.count
   }
@@ -187,6 +191,7 @@ final class AppState {
       async let auditList = store.auditEvents(storePath: newStatus.storePath)
 
       status = newStatus
+      restoreAvailableUpdate()
       handles = try await handleList.sorted { $0.updatedAt > $1.updatedAt }
       requests = try await requestList.sorted { requestSortKey($0) > requestSortKey($1) }
       agents = (try? await agentList.sorted { $0.name < $1.name }) ?? []
@@ -678,10 +683,11 @@ final class AppState {
       return
     }
 
-    if UpdateChecker.isNewer(release.version, than: UpdateChecker.currentVersion) {
+    let currentVersion = installedVersion
+    if UpdateChecker.isNewer(release.version, than: currentVersion) {
       if let snapshot = updateNotice.observe(
         noticeRelease(from: release),
-        installedVersion: UpdateChecker.currentVersion
+        installedVersion: currentVersion
       ) {
         availableUpdate = releaseInfo(from: snapshot.release)
         updateBannerDismissed = snapshot.acknowledgedAt != nil
@@ -828,7 +834,7 @@ final class AppState {
   }
 
   private func restoreAvailableUpdate() {
-    guard let snapshot = updateNotice.available(installedVersion: UpdateChecker.currentVersion) else {
+    guard let snapshot = updateNotice.available(installedVersion: installedVersion) else {
       availableUpdate = nil
       updateBannerDismissed = false
       return

--- a/native/macos-app/Sources/SgwMac/Models/Models.swift
+++ b/native/macos-app/Sources/SgwMac/Models/Models.swift
@@ -333,6 +333,7 @@ struct Readiness: Decodable, Hashable {
 }
 
 struct StatusPayload: Decodable, Hashable {
+  var version: String?
   var packageRoot: String
   // `ready`/`readiness` were added to the CLI health payload later; keep them optional so a
   // freshly built app still decodes status from an older `s-gw` on PATH instead of erroring.

--- a/native/macos-app/Sources/SgwMac/Views/MainWindow.swift
+++ b/native/macos-app/Sources/SgwMac/Views/MainWindow.swift
@@ -56,7 +56,7 @@ struct MainWindow: View {
       VStack(alignment: .leading, spacing: 2) {
         Text("s-gw \(release.version) is available")
           .font(.callout.weight(.semibold))
-        Text("Installed \(UpdateChecker.currentVersion)")
+        Text("Installed \(appState.installedVersion)")
           .font(.caption)
           .foregroundStyle(.secondary)
         Text(release.isMacInstaller
@@ -122,7 +122,7 @@ private struct UpdateReleaseSheet: View {
         VStack(alignment: .leading, spacing: 4) {
           Text("s-gw \(release.version)")
             .font(.title2.weight(.semibold))
-          Text("Installed \(UpdateChecker.currentVersion)")
+          Text("Installed \(appState.installedVersion)")
             .foregroundStyle(.secondary)
         }
       }

--- a/native/macos-app/Sources/SgwMac/Views/SettingsView.swift
+++ b/native/macos-app/Sources/SgwMac/Views/SettingsView.swift
@@ -166,7 +166,7 @@ struct SettingsView: View {
   private var updatesTab: some View {
     Form {
       Section("Application Update") {
-        LabeledContent("Installed version", value: UpdateChecker.currentVersion)
+        LabeledContent("Installed version", value: appState.installedVersion)
         TextField(
           "GitHub repository",
           text: Binding(

--- a/native/macos-app/Tests/AppStateGuardTests.swift
+++ b/native/macos-app/Tests/AppStateGuardTests.swift
@@ -226,6 +226,7 @@ struct AppStateGuardTests {
     await runInFlightGuardTest(scratch)
     await runGuardReleaseTest(scratch)
     await runReadinessDerivationTest()
+    await runInstalledVersionTest()
     await runCommandOutputCaptureTest()
     await runUpdateRetryTest()
     await runIncompleteReleaseRetryTest()
@@ -376,6 +377,35 @@ struct AppStateGuardTests {
           "the retry should publish the newly available release")
     check(defaults.double(forKey: UpdateChecker.lastCheckDefaultsKey) == now.timeIntervalSince1970,
           "the successful retry should persist its timestamp")
+  }
+
+  @MainActor
+  static func runInstalledVersionTest() async {
+    let defaults = isolatedDefaults("installed-version")
+    let notice = UpdateNoticeStore(defaults: defaults)
+    notice.clear()
+    defer { notice.clear() }
+    let app = AppState(
+      updater: FakeUpdateChecker([.release(makeRelease("9.4.0"))]),
+      defaults: defaults
+    )
+
+    check(app.installedVersion == UpdateChecker.currentVersion,
+          "the app bundle version should remain the fallback before CLI status loads")
+    app.status = statusPayload(
+      ready: true,
+      summary: "Ready",
+      blockers: [],
+      activeSource: "environment",
+      consoleLoaded: true,
+      version: "9.5.0"
+    )
+    check(app.installedVersion == "9.5.0",
+          "the installed CLI runtime version must override a stale app bundle version")
+
+    await app.checkForUpdates(force: true)
+    check(app.availableUpdate == nil,
+          "a release older than the installed CLI runtime must not be offered as an update")
   }
 
   @MainActor
@@ -671,10 +701,13 @@ struct AppStateGuardTests {
   }
 
   static func statusPayload(ready: Bool, summary: String, blockers: [String],
-                            activeSource: String, consoleLoaded: Bool) -> StatusPayload {
+                            activeSource: String, consoleLoaded: Bool,
+                            version: String? = nil) -> StatusPayload {
     let blockerJson = blockers.map { "\"\($0)\"" }.joined(separator: ",")
+    let versionJson = version.map { "\"version\":\"\($0)\"," } ?? ""
     let json = """
     {
+      \(versionJson)
       "packageRoot": "/tmp/sgw",
       "ready": \(ready),
       "readiness": {"ok": \(ready), "summary": "\(summary)", "blockers": [\(blockerJson)]},

--- a/src/install.ts
+++ b/src/install.ts
@@ -20,6 +20,7 @@ import {
   resolveSelfContainedMacRuntime
 } from "./self-contained-runtime.js";
 import { unlockStatus } from "./unlock.js";
+import { CURRENT_VERSION } from "./version.js";
 
 export const consoleLabel = "com.s-gw.sgw.console";
 export const menuBarLabel = "com.s-gw.sgw.menubar";
@@ -184,6 +185,7 @@ export function packageHealth(port = 8718) {
   const ready = unlockConfigured && cli.exists && mcp.exists;
 
   return {
+    version: CURRENT_VERSION,
     packageRoot: layout.packageRoot,
     selfContainedMacApp: layout.isSelfContainedMacApp,
     nodePath: pathStatus(layout.nodePath),

--- a/tests/console-ui-source.test.ts
+++ b/tests/console-ui-source.test.ts
@@ -69,6 +69,18 @@ describe("React console source contracts", () => {
     expect(types).toContain("update: UpdateCheckResult | null");
   });
 
+  it("uses the installed runtime version in native update surfaces", async () => {
+    const [state, mainWindow, settings] = await Promise.all([
+      readFile(path.join(repoRoot, "native/macos-app/Sources/SgwMac/App/AppState.swift"), "utf8"),
+      readFile(path.join(repoRoot, "native/macos-app/Sources/SgwMac/Views/MainWindow.swift"), "utf8"),
+      readFile(path.join(repoRoot, "native/macos-app/Sources/SgwMac/Views/SettingsView.swift"), "utf8")
+    ]);
+
+    expect(state).toContain("status?.version ?? UpdateChecker.currentVersion");
+    expect(mainWindow).toContain("Installed \\(appState.installedVersion)");
+    expect(settings).toContain('LabeledContent("Installed version", value: appState.installedVersion)');
+  });
+
   it("uses provider logos and normalized secure-storage names", async () => {
     const [app, providerIdentity, presentation] = await Promise.all([
       readFile(path.join(repoRoot, "src/console-ui/src/App.tsx"), "utf8"),

--- a/tests/install.test.ts
+++ b/tests/install.test.ts
@@ -12,6 +12,7 @@ import {
   menuBarLabel,
   packageHealth
 } from "../src/install.js";
+import { CURRENT_VERSION } from "../src/version.js";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(here, "..");
@@ -116,6 +117,7 @@ describe("customer package layout", () => {
       expect(health).toContain("s-gw-client.ps1");
       expect(health).toContain("s-gw-helper.ps1");
       expect(health).not.toContain("do not serialize this value");
+      expect(packageHealth().version).toBe(CURRENT_VERSION);
     } finally {
       if (oldValue === undefined) {
         delete process.env.SGW_MASTER_PASSPHRASE;


### PR DESCRIPTION
## Summary

- report the active CLI/runtime version from `s-gw status`
- use that runtime version in native update banners, settings, and release details
- retain the app bundle version as a backward-compatible fallback

## Verification

- `npm run verify`
- 36 test files, 370 tests passed
- native and web builds passed
- package dry-run and audit passed