### PR TITLE
Add unsigned macOS preview release channel

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "s-gw",
-  "version": "0.1.17",
+  "version": "0.1.18-unsigned.1",
   "description": "Local s-gw plugin that lets coding agents use typed secret handles without receiving raw credentials.",
   "author": {
     "name": "Barry Yuan"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,14 @@ on:
         required: true
         default: true
         type: boolean
+      macos_distribution:
+        description: macOS release channel. Unsigned previews are manual-download only.
+        required: true
+        default: notarized
+        type: choice
+        options:
+          - notarized
+          - unsigned-preview
 
 concurrency:
   group: publish-${{ inputs.release_tag }}
@@ -28,6 +36,8 @@ jobs:
       contents: write
     env:
       RELEASE_TAG: ${{ inputs.release_tag }}
+      MACOS_DISTRIBUTION: ${{ inputs.macos_distribution }}
+      SGW_RELEASE_TAG: ${{ inputs.release_tag }}
       SGW_REQUIRE_RUST_CORE: "1"
       SGW_RUST_CORE_DIR: ${{ github.workspace }}/.private/sgw-core
     steps:
@@ -55,6 +65,7 @@ jobs:
       - run: npm ci --ignore-scripts
 
       - name: Configure macOS distribution signing
+        if: inputs.macos_distribution == 'notarized'
         env:
           APPLE_DEVELOPER_ID_P12_BASE64: ${{ secrets.APPLE_DEVELOPER_ID_P12_BASE64 }}
           APPLE_DEVELOPER_ID_P12_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_P12_PASSWORD }}
@@ -96,12 +107,22 @@ jobs:
             echo "SGW_MACOS_SIGN_IDENTITY=$identity"
             echo "SGW_NOTARY_PROFILE=s-gw-notary"
             echo "SGW_REQUIRE_NOTARIZATION=1"
+            echo "SGW_MACOS_DISTRIBUTION=notarized"
           } >> "$GITHUB_ENV"
+
+      - name: Configure unsigned macOS preview
+        if: inputs.macos_distribution == 'unsigned-preview'
+        run: echo "SGW_MACOS_DISTRIBUTION=unsigned-preview" >> "$GITHUB_ENV"
 
       - name: Verify release version
         run: |
           package_version="$(node -p "require('./package.json').version")"
-          test "v${package_version}" = "${RELEASE_TAG}"
+          if [ "$MACOS_DISTRIBUTION" = "unsigned-preview" ]; then
+            case "$package_version" in *-unsigned.[0-9]*) ;; *) exit 1 ;; esac
+            test "$RELEASE_TAG" = "unsigned-macos-preview-v${package_version}"
+          else
+            test "v${package_version}" = "$RELEASE_TAG"
+          fi
 
       - name: Verify release build
         run: |
@@ -114,10 +135,47 @@ jobs:
       - run: npm run validate:npm-package
       - run: npm run build:installers
 
-      - name: Assess stapled macOS installer
+      - name: Verify macOS installer distribution
         run: |
+          set -euo pipefail
           package_version="$(node -p "require('./package.json').version")"
-          spctl --assess --type open --context context:primary-signature "dist/installers/s-gw-${package_version}-macos.dmg"
+          distribution="$(node -p "require('./dist/installers/RELEASE.json').macosDistribution")"
+          notarized="$(node -p "require('./dist/installers/RELEASE.json').notarized")"
+          test "$distribution" = "$MACOS_DISTRIBUTION"
+          if [ "$MACOS_DISTRIBUTION" = "notarized" ]; then
+            test "$notarized" = "true"
+            spctl --assess --type open --context context:primary-signature "dist/installers/s-gw-${package_version}-macos.dmg"
+          else
+            test "$notarized" = "false"
+            test -f "dist/installers/s-gw-${package_version}-macos-unsigned-preview.dmg"
+          fi
+
+      - name: Prepare release notes
+        run: |
+          set -euo pipefail
+          package_version="$(node -p "require('./package.json').version")"
+          notes="$RUNNER_TEMP/release-notes.md"
+          if [ "$MACOS_DISTRIBUTION" = "unsigned-preview" ]; then
+            cat > "$notes" <<EOF
+          ## Unsigned macOS preview
+
+          The Apple Silicon DMG in this release is an unsigned preview. It is not Developer ID signed or notarized, so macOS will require an explicit Gatekeeper override to open it. It is deliberately not used by s-gw's automatic macOS update channel.
+
+          If you prefer not to override Gatekeeper, install this exact release through npm instead (Node.js 20+):
+
+          \`\`\`bash
+          npm install -g https://github.com/${GITHUB_REPOSITORY}/releases/download/${RELEASE_TAG}/s-gw-${package_version}.tgz
+          s-gw setup
+          \`\`\`
+          EOF
+          else
+            cat > "$notes" <<EOF
+          ## macOS installation
+
+          Drag \`s-gw.app\` from the Apple Silicon DMG to Applications, then open it to complete setup.
+          EOF
+          fi
+          echo "SGW_RELEASE_NOTES=$notes" >> "$GITHUB_ENV"
 
       - name: Create or verify a draft release
         env:
@@ -126,9 +184,20 @@ jobs:
           set -euo pipefail
           if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
             test "$(gh release view "$RELEASE_TAG" --json isDraft --jq '.isDraft')" = "true"
+            expected_prerelease=false
+            if [ "$MACOS_DISTRIBUTION" = "unsigned-preview" ]; then expected_prerelease=true; fi
+            test "$(gh release view "$RELEASE_TAG" --json isPrerelease --jq '.isPrerelease')" = "$expected_prerelease"
             exit 0
           fi
-          gh release create "$RELEASE_TAG" --draft --verify-tag --generate-notes
+          if [ "$MACOS_DISTRIBUTION" = "unsigned-preview" ]; then
+            package_version="$(node -p "require('./package.json').version")"
+            gh release create "$RELEASE_TAG" --draft --prerelease --latest=false --verify-tag \
+              --title "s-gw ${package_version} unsigned macOS preview" \
+              --notes-file "$SGW_RELEASE_NOTES"
+          else
+            gh release create "$RELEASE_TAG" --draft --verify-tag --generate-notes \
+              --notes "$(cat "$SGW_RELEASE_NOTES")"
+          fi
 
       - name: Upload verified release assets
         env:
@@ -170,6 +239,7 @@ jobs:
       contents: write
     env:
       RELEASE_TAG: ${{ inputs.release_tag }}
+      MACOS_DISTRIBUTION: ${{ inputs.macos_distribution }}
     steps:
       - name: Publish the verified draft release
         env:
@@ -177,12 +247,15 @@ jobs:
         run: |
           set -euo pipefail
           test "$(gh release view "$RELEASE_TAG" --json isDraft --jq '.isDraft')" = "true"
+          expected_prerelease=false
+          if [ "$MACOS_DISTRIBUTION" = "unsigned-preview" ]; then expected_prerelease=true; fi
+          test "$(gh release view "$RELEASE_TAG" --json isPrerelease --jq '.isPrerelease')" = "$expected_prerelease"
           gh release edit "$RELEASE_TAG" --draft=false
           test "$(gh release view "$RELEASE_TAG" --json isDraft --jq '.isDraft')" = "false"
 
   publish-npm:
     needs: publish-release
-    if: github.repository == 'sgateway/s-gw' && needs.publish-release.result == 'success'
+    if: github.repository == 'sgateway/s-gw' && needs.publish-release.result == 'success' && inputs.macos_distribution == 'notarized'
     runs-on: macos-15
     environment: npm
     permissions:
@@ -268,7 +341,7 @@ jobs:
 
   publish-registry:
     needs: publish-npm
-    if: always() && github.repository == 'sgateway/s-gw' && needs.publish-npm.result == 'success'
+    if: always() && github.repository == 'sgateway/s-gw' && inputs.macos_distribution == 'notarized' && needs.publish-npm.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 Notable changes to s-gw are documented here. The project follows [Semantic Versioning](https://semver.org/) once public releases begin.
 
+## 0.1.18-unsigned.1 - 2026-07-16
+
+### Added
+
+- An explicit unsigned macOS preview channel for the self-contained app. Its distinctly named DMG includes installation guidance and an npm alternative for users who prefer not to override Gatekeeper.
+
+### Changed
+
+- Unsigned macOS previews are GitHub prereleases under non-version tags: they do not publish npm or the MCP Registry and are excluded from automatic update notices, including in older clients.
+- Automatic update checks select only stable releases with the normal installer and checksum, preventing incomplete or unsigned-preview assets from causing repeated retry checks.
+
 ## 0.1.17 - 2026-07-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -96,7 +96,16 @@ The agent never needs the unlock passphrase or raw credential. Approval is scope
 
 ## Quick Start
 
-On an Apple Silicon Mac, download the signed `s-gw-VERSION-macos.dmg` from [GitHub Releases](https://github.com/sgateway/s-gw/releases), drag `s-gw.app` to **Applications**, then open it and complete setup. The app includes its own Node runtime, CLI, MCP server, native helpers, and menu-bar helper; it does not require Node.js or npm on the host. Setup is intentionally blocked until the app is in `/Applications` or `~/Applications`.
+On an Apple Silicon Mac, download the macOS DMG from [GitHub Releases](https://github.com/sgateway/s-gw/releases), drag `s-gw.app` to **Applications**, then open it and complete setup. The app includes its own Node runtime, CLI, MCP server, native helpers, and menu-bar helper; it does not require Node.js or npm on the host. Setup is intentionally blocked until the app is in `/Applications` or `~/Applications`.
+
+Normal macOS releases use `s-gw-VERSION-macos.dmg` and are Developer ID signed and notarized. An explicitly labelled `s-gw-VERSION-macos-unsigned-preview.dmg` is a manual-download preview: macOS will require a Gatekeeper override. It uses a non-version GitHub prerelease tag, so current and older s-gw clients cannot mistake it for an automatic update. If you prefer not to override Gatekeeper, install the matching release package with Node.js 20 or newer instead:
+
+```bash
+npm install -g https://github.com/sgateway/s-gw/releases/download/unsigned-macos-preview-vVERSION/s-gw-VERSION.tgz
+s-gw setup
+```
+
+Replace `VERSION` with the version in that preview's filename, or copy the exact command from the preview release notes or DMG README.
 
 For terminal-first, Linux, Windows, or source installs, use Node.js 20 or newer:
 
@@ -108,7 +117,7 @@ s-gw status
 
 The public source builds the TypeScript compatibility path. Building the native macOS surfaces also requires a Swift toolchain. Maintainer release builds additionally require access to the private Rust core checkout.
 
-The Apple Silicon Mac DMG is the preferred desktop path. Published macOS DMGs are Developer ID signed and notarized; local `npm run build:installers` output is ad-hoc signed for local verification only. The npm package remains the terminal-first path and includes the native app, menu helper, Keychain helper, metadata-only Keychain inspector, and Rust core for Apple Silicon Macs. Linux and Windows use the TypeScript execution path when a matching native core is not packaged. Intel Macs must build the native Keychain and desktop surfaces from source for now; packaged arm64-only helpers are rejected before launch.
+The Apple Silicon Mac DMG is the preferred desktop path. Normal published macOS DMGs are Developer ID signed and notarized. An unsigned preview has a distinct filename and non-version prerelease tag, so it is never offered through automatic updates. Local `npm run build:installers` output is ad-hoc signed for local verification. The npm package remains the terminal-first path and includes the native app, menu helper, Keychain helper, metadata-only Keychain inspector, and Rust core for Apple Silicon Macs. Linux and Windows use the TypeScript execution path when a matching native core is not packaged. Intel Macs must build the native Keychain and desktop surfaces from source for now; packaged arm64-only helpers are rejected before launch.
 
 ```bash
 git clone https://github.com/sgateway/s-gw.git
@@ -215,7 +224,7 @@ The model can complete the task without receiving the raw access key.
 | Windows 10/11 | Preview | Credential Manager | PowerShell client, tray helper, local web console |
 | Linux | Experimental CLI | Environment-provided unlock material | Local web console |
 
-Published Apple Silicon macOS DMGs are self-contained, Developer ID signed, and notarized. The Windows package remains unsigned preview software. Build locally with `npm run build:installers`; local DMGs are ad-hoc signed and deliberately not publishable.
+Published Apple Silicon macOS DMGs are self-contained. Normal releases are Developer ID signed and notarized; an explicitly labelled unsigned preview is manual-download only, uses a non-version prerelease tag, and requires a macOS override. The Windows package remains unsigned preview software. Build locally with `npm run build:installers`; local DMGs are ad-hoc signed and are only publishable through the explicit unsigned-preview channel.
 
 ## Security Model
 
@@ -229,7 +238,7 @@ Read the [threat model](docs/threat-model.md) before relying on s-gw for sensiti
 - macOS is the primary development and test platform.
 - Windows Credential Manager support is present but still needs broader native QA.
 - Linux currently depends on environment-provided unlock material.
-- The Windows desktop package remains an unsigned preview. Published macOS DMGs must pass Developer ID signing and notarization.
+- The Windows desktop package remains an unsigned preview. The default macOS release path requires Developer ID signing and notarization; unsigned previews are separately named, use non-version prerelease tags, and never participate in automatic updates.
 - The repository is prepared for open-source collaboration, but security-sensitive changes should come with focused tests and threat-model updates when behavior changes.
 
 ## Documentation

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -37,7 +37,7 @@ Exercise the [quick-start trust loop](docs/quickstart.md) with a disposable stor
 
 `npm run build:installers` writes versioned files and SHA-256 checksums under `dist/installers`.
 
-The macOS DMG is a self-contained `s-gw.app` plus an Applications shortcut. Public releases require Developer ID signing, hardened runtime, Apple notarization, stapling, and Gatekeeper assessment. The `release-assets` workflow fails closed unless these repository secrets are present:
+The macOS DMG is a self-contained `s-gw.app` plus an Applications shortcut. The default `notarized` release mode requires Developer ID signing, hardened runtime, Apple notarization, stapling, and Gatekeeper assessment. The `release-assets` workflow fails closed unless these repository secrets are present:
 
 - `APPLE_DEVELOPER_ID_P12_BASE64`
 - `APPLE_DEVELOPER_ID_P12_PASSWORD`
@@ -45,17 +45,17 @@ The macOS DMG is a self-contained `s-gw.app` plus an Applications shortcut. Publ
 - `APPLE_NOTARY_KEY_ID`
 - `APPLE_NOTARY_ISSUER_ID`
 
-Local builds use ad-hoc signatures only and must not be uploaded as releases. Do not describe the Windows package as a production download until it is signed and validated on supported Windows versions.
+`unsigned-preview` is the only exception: it produces `s-gw-VERSION-macos-unsigned-preview.dmg`, marks the GitHub release as a prerelease under the non-version tag `unsigned-macos-preview-vVERSION`, omits npm and MCP Registry publication, and keeps it out of automatic updates in both current and older clients. Its release notes include the exact `.tgz` npm command for users who prefer not to override Gatekeeper. Local builds use ad-hoc signatures only. Do not describe the Windows package as a production download until it is signed and validated on supported Windows versions.
 
 ## Publish
 
-1. Create an annotated `vX.Y.Z` tag from a green `main` commit.
-2. Ensure private `barryqy/s-gw-rust-core` has the matching immutable tag.
-3. Run **Publish release** with `release_tag=vX.Y.Z` and `publish_release=true`.
-4. The workflow verifies the tag/version pair, builds, signs, notarizes, staples, and Gatekeeper-assesses the DMG before it creates or updates a **draft** GitHub release.
-5. It uploads every installer and checksum, confirms their GitHub asset state is `uploaded`, then publishes the draft. Only after that succeeds does it publish npm and the MCP Registry.
+1. Create an annotated `vX.Y.Z` tag from a green `main` commit, or `unsigned-macos-preview-vX.Y.Z-unsigned.N` for the explicit unsigned preview channel.
+2. Ensure private `barryqy/s-gw-rust-core` has the same immutable tag.
+3. Run **Publish release** with `release_tag=vX.Y.Z`, `publish_release=true`, and `macos_distribution=notarized` for a normal release. For an unsigned preview, use the matching non-version preview tag and `macos_distribution=unsigned-preview`.
+4. The normal workflow verifies the tag/version pair, builds, signs, notarizes, staples, and Gatekeeper-assesses the DMG before it creates or updates a **draft** GitHub release.
+5. It uploads every installer and checksum, confirms their GitHub asset state is `uploaded`, then publishes the draft. Only after a normal release succeeds does it publish npm and the MCP Registry.
 6. To inspect assets without notifying users, run the workflow with `publish_release=false`; the release remains a draft. Re-run with `true` only after review.
 7. Verify checksums from a clean download and install the release on clean macOS and Windows test accounts.
 8. Confirm the update checker sees the release and opens the correct notes.
 
-Do not publish a macOS DMG when signing or notarization is unavailable. The Windows package may still be labeled as a preview artifact with its limitations stated in the release notes.
+When signing is unavailable, run the explicit `unsigned-preview` mode only. It creates a prerelease under a non-version tag, so current and older clients ignore it rather than treating it as an automatic update. It intentionally does not publish to npm or the MCP Registry. The Windows package may still be labeled as a preview artifact with its limitations stated in the release notes.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -69,11 +69,20 @@ npm run build
 npm link
 ```
 
-### Signed macOS Installer
+### macOS Installer
 
-The macOS DMG contains only `s-gw.app` and an `Applications` shortcut. The app includes the runtime and all macOS components, so users drag one bundle into Applications instead of double-clicking a shell installer. Release CI signs every executable with a Developer ID Application certificate, enables the hardened runtime, applies the Node JIT entitlement required by V8, submits the DMG to Apple notarization, staples the result, and assesses it with Gatekeeper before upload.
+The macOS DMG contains `s-gw.app`, an `Applications` shortcut, and a short README with the npm installation alternative. The app includes the runtime and all macOS components, so users drag one bundle into Applications instead of double-clicking a shell installer. The default release mode signs every executable with a Developer ID Application certificate, enables the hardened runtime, applies the Node JIT entitlement required by V8, submits the DMG to Apple notarization, staples the result, and assesses it with Gatekeeper before upload.
 
-Local builds use ad-hoc signing only; they are useful for package verification but are not publishable. The installer never pre-seeds passphrases, credentials, `SGW_HOME`, or policy templates.
+When Developer ID signing is unavailable, the explicit `unsigned-preview` mode produces `s-gw-VERSION-macos-unsigned-preview.dmg` under the non-version GitHub prerelease tag `unsigned-macos-preview-vVERSION`. It is not notarized, requires a Gatekeeper override, is ignored by current and older automatic updaters, and does not publish npm or the MCP Registry. Users who prefer not to override Gatekeeper can install the matching `.tgz` release asset with Node.js 20 or newer:
+
+```bash
+npm install -g https://github.com/sgateway/s-gw/releases/download/unsigned-macos-preview-vVERSION/s-gw-VERSION.tgz
+s-gw setup
+```
+
+Replace `VERSION` with the version in that preview's filename, or copy the exact command from the preview release notes or DMG README.
+
+The installer never pre-seeds passphrases, credentials, `SGW_HOME`, or policy templates.
 
 ### Homebrew
 
@@ -382,7 +391,7 @@ Supported means s-gw has a documented standard MCP stdio path. Profiled means `s
 
 ## Upgrade
 
-The CLI and local console cache ordinary successful responses from the public `sgateway/s-gw` GitHub Releases feed for six hours. A newer release whose expected installer or checksum is still uploading is retried after five minutes instead. Drafts are ignored; preview releases are included while s-gw is in preview. If GitHub's unauthenticated Releases API is rate-limited, clients fall back to the repository's public Atom release feed; the macOS app then checks the deterministic package and checksum URLs before offering an upgrade. The CLI prints a notice in interactive terminals and supports `s-gw update check`, the local console shows an update banner, and the Windows tray helper shows a notification plus a release link. The login-started macOS menu helper checks immediately and every 15 minutes, while the main app performs one startup check and supports manual checks. Both otherwise reuse the six-hour release-feed cache, so the helper's poll does not force a GitHub request or create a new update record each time. A failed request does not advance that timestamp, so the helper retries on its next poll. The main app persists the available release and its banner across restarts in a locked, atomic state file shared with the helper. The menu helper is the only automatic macOS-alert sender: it first confirms that macOS alerts are enabled, reserves a queue attempt, and records an accepted request as a bounded attempt—not proof that macOS displayed it. It retries an unacknowledged update after one day and then one week, stopping after three accepted queue attempts. Dismissing the app banner or opening the notification acknowledges that version; **Notify Again** in the app's Updates settings deliberately starts a new bounded reminder sequence.
+The CLI and local console cache ordinary successful responses from the public `sgateway/s-gw` GitHub Releases feed for six hours. Drafts, prereleases, and incomplete asset uploads are ignored by the automatic update channel. If GitHub's unauthenticated Releases API is rate-limited, clients fall back to the repository's public Atom release feed; the macOS app then checks the deterministic package and checksum URLs before offering an upgrade. The CLI prints a notice in interactive terminals and supports `s-gw update check`, the local console shows an update banner, and the Windows tray helper shows a notification plus a release link. The login-started macOS menu helper checks immediately and every 15 minutes, while the main app performs one startup check and supports manual checks. Both otherwise reuse the six-hour release-feed cache, so the helper's poll does not force a GitHub request or create a new update record each time. A failed request does not advance that timestamp, so the helper retries on its next poll. The main app persists the available release and its banner across restarts in a locked, atomic state file shared with the helper. The menu helper is the only automatic macOS-alert sender: it first confirms that macOS alerts are enabled, reserves a queue attempt, and records an accepted request as a bounded attempt—not proof that macOS displayed it. It retries an unacknowledged update after one day and then one week, stopping after three accepted queue attempts. Dismissing the app banner or opening the notification acknowledges that version; **Notify Again** in the app's Updates settings deliberately starts a new bounded reminder sequence.
 
 The release workflow runs the full verification suite, then builds the scoped package, legacy bridge, platform installers, `SHA256SUMS.txt`, and per-file `.sha256` assets. It refuses to upload an update package whose identity or checksum cannot be verified, uploads only to a draft release, verifies every remote asset, and makes the release public afterward. A self-contained macOS app verifies that the release includes the matching DMG and checksum, then opens the release page. Download the DMG, quit s-gw, replace the copy in Applications, and reopen it. On first launch after the version or bundle location changes, the app restarts any running console and menu-bar LaunchAgents so they use the new bundled runtime. npm installs retain the verified tarball update flow. The original `0.1.0` app can take the legacy bridge on its next update check; once that fixed app is installed, later releases migrate it to the scoped package automatically. Other clients open the release page for the platform installer. Update checks fail quietly when GitHub is unavailable and never block local credential operations.
 
@@ -457,7 +466,7 @@ For macOS production packages, also verify:
 - `s-gw doctor` finds the installed CLI, MCP server, native Keychain helper, and menu-bar app bundle;
 - `s-gw service install --start` loads the console LaunchAgent;
 - `s-gw menubar open` launches the menu-bar helper and sees pending requests;
-- package or installer is signed and notarized;
+- normal macOS package or installer is signed and notarized, or an unsigned preview is explicitly labelled and manually installed;
 - install/uninstall leaves no raw secrets in logs or shell history.
 
 For Windows preview packages, also verify:

--- a/docs/keychain.md
+++ b/docs/keychain.md
@@ -24,7 +24,7 @@ The raw credential is written through the bundled helper on stdin. The encrypted
 
 Use `--service SERVICE` or `SGW_SECRET_KEYCHAIN_SERVICE` when you want a separate credential-store namespace for testing, work, or isolated profiles.
 
-On macOS, setup copies the first working Keychain helper to `~/.s-gw/native/darwin-arm64/s-gw-keychain-helper` with owner-only permissions. A Keychain ACL records the creating helper's path and code-signing requirement; macOS grants access only when the executing helper satisfies that requirement. npm updates preserve the existing helper before replacing a package, and later releases do not overwrite it silently. The self-contained app also copies its helper to that persistent path, but never modifies the signed app bundle itself.
+On macOS, setup copies the first working Keychain helper to `~/.s-gw/native/darwin-arm64/s-gw-keychain-helper` with owner-only permissions. A Keychain ACL records the creating helper's path and code-signing requirement; macOS grants access only when the executing helper satisfies that requirement. npm updates preserve the existing helper before replacing a package, and later releases do not overwrite it silently. The self-contained app also copies its helper to that persistent path, but never modifies the installed app bundle itself.
 
 After an upgrade, s-gw checks each item's trusted-application metadata before any credential read. An item tied to an older package path is copied through a verified temporary Keychain backup and recreated for the persistent helper. The original is not deleted until the recovery copy has been verified. Run the same repair explicitly at any time:
 

--- a/native/macos-app/Sources/SgwMac/App/AppState.swift
+++ b/native/macos-app/Sources/SgwMac/App/AppState.swift
@@ -748,13 +748,13 @@ final class AppState {
     }
 
     guard release.hasVerifiedAsset else {
-      operationMessage = "The signed installer for s-gw \(release.version) is still being uploaded. Try again shortly."
+      operationMessage = "The installer for s-gw \(release.version) is still being uploaded. Try again shortly."
       return
     }
 
     if release.isMacInstaller {
       openAvailableRelease()
-      operationMessage = "Download the signed s-gw installer, quit s-gw, replace the app in Applications, then reopen it."
+      operationMessage = "Download the s-gw installer, quit s-gw, replace the app in Applications, then reopen it."
       return
     }
 

--- a/native/macos-app/Sources/SgwMac/Services/UpdateChecker.swift
+++ b/native/macos-app/Sources/SgwMac/Services/UpdateChecker.swift
@@ -72,7 +72,7 @@ actor UpdateChecker: UpdateChecking {
     private let cli = CLIRunner()
 
     static var currentVersion: String {
-        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.1.17"
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.1.18-unsigned.1"
     }
 
     static var usesSelfContainedRuntime: Bool {
@@ -116,14 +116,17 @@ actor UpdateChecker: UpdateChecking {
                 throw UpdateError.releaseCheckFailed
             }
             let releases = try JSONDecoder().decode([GitHubRelease].self, from: data)
-            guard let release = releases
+            let candidates = releases
                 .filter({ !$0.draft })
+                .filter({ !$0.preRelease })
                 .filter({ Self.semanticVersion($0.tagName) != nil })
                 .sorted(by: { Self.isNewer($0.tagName, than: $1.tagName) })
-                .first else {
-                return nil
+            for release in candidates {
+                if let info = await releaseInfo(from: release), info.hasVerifiedAsset {
+                    return info
+                }
             }
-            return await releaseInfo(from: release)
+            return nil
         } catch {
             return try await latestReleaseFromAtom(repository: trimmed)
         }
@@ -170,7 +173,7 @@ actor UpdateChecker: UpdateChecking {
                 notes: parsed.notes
             )
         }
-        return Self.withoutInstallAssets(parsed)
+        return nil
     }
 
     private func assetExists(_ url: URL) async -> Bool {
@@ -630,6 +633,7 @@ private struct GitHubRelease: Decodable {
     let body: String?
     let assets: [GitHubAsset]
     let draft: Bool
+    let preRelease: Bool
 
     enum CodingKeys: String, CodingKey {
         case tagName = "tag_name"
@@ -637,6 +641,7 @@ private struct GitHubRelease: Decodable {
         case body
         case assets
         case draft
+        case preRelease = "prerelease"
     }
 }
 

--- a/native/macos-app/Sources/SgwMac/Views/MainWindow.swift
+++ b/native/macos-app/Sources/SgwMac/Views/MainWindow.swift
@@ -60,7 +60,7 @@ struct MainWindow: View {
           .font(.caption)
           .foregroundStyle(.secondary)
         Text(release.isMacInstaller
-          ? "Download the signed installer, quit s-gw, replace the app in Applications, then reopen it."
+          ? "Download the installer, quit s-gw, replace the app in Applications, then reopen it."
           : "This update stays available here until you dismiss it or install it.")
           .font(.caption)
           .foregroundStyle(.secondary)

--- a/native/macos-app/Sources/SgwMac/Views/SettingsView.swift
+++ b/native/macos-app/Sources/SgwMac/Views/SettingsView.swift
@@ -201,7 +201,7 @@ struct SettingsView: View {
 
         if let release = appState.availableUpdate {
           Text(release.isMacInstaller
-            ? "Available: \(release.version) · download the signed installer to update this app"
+            ? "Available: \(release.version) · download the installer to update this app"
             : "Available: \(release.version)\(release.canInstallPackage ? "" : " · checksum required for automatic install")")
             .font(.caption)
             .foregroundStyle(release.hasVerifiedAsset ? SGWTheme.teal : SGWTheme.orange)
@@ -225,7 +225,7 @@ struct SettingsView: View {
       Section("CLI") {
         if UpdateChecker.usesSelfContainedRuntime {
           LabeledContent("Runtime", value: "Bundled with this app")
-          Text("This signed app always uses its bundled CLI and Node runtime so background services and agent registrations stay on the same version.")
+          Text("This app always uses its bundled CLI and Node runtime so background services and agent registrations stay on the same version.")
             .font(.caption)
             .foregroundStyle(.secondary)
         } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@s-gw/s-gw",
-  "version": "0.1.17",
+  "version": "0.1.18-unsigned.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@s-gw/s-gw",
-      "version": "0.1.17",
+      "version": "0.1.18-unsigned.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-gw/s-gw",
-  "version": "0.1.17",
+  "version": "0.1.18-unsigned.1",
   "mcpName": "io.github.sgateway/s-gw",
   "description": "Local credential control for AI coding agents.",
   "type": "module",

--- a/scripts/build-installers.mjs
+++ b/scripts/build-installers.mjs
@@ -28,6 +28,8 @@ const version = packageInfo.version;
 const packedFile = `${packageInfo.name.replace(/^@/, "").replaceAll("/", "-")}-${version}.tgz`;
 const packageFile = `s-gw-${version}.tgz`;
 const legacyBridgeFile = `0-s-gw-legacy-${version}.tgz`;
+const macInstallerFile = `s-gw-${version}-macos.dmg`;
+const unsignedPreviewMacInstallerFile = `s-gw-${version}-macos-unsigned-preview.dmg`;
 const outputDir = resolve(root, "dist/installers");
 const workDir = mkdtempSync(resolve(tmpdir(), "s-gw-installers-"));
 
@@ -52,7 +54,7 @@ try {
   copyFileSync(packed, resolve(outputDir, packageFile));
   buildLegacyBridge(packed, resolve(outputDir, legacyBridgeFile), version);
 
-  const artifacts = [legacyBridgeFile, packageFile, basename(macArtifact), basename(windowsArtifact)];
+  const artifacts = [legacyBridgeFile, packageFile, basename(macArtifact.path), basename(windowsArtifact)];
   const checksumLines = artifacts.map((name) => `${sha256(resolve(outputDir, name))}  ${name}`);
   writeFileSync(resolve(outputDir, "SHA256SUMS.txt"), `${checksumLines.join("\n")}\n`);
 
@@ -64,6 +66,9 @@ try {
     name: packageInfo.name,
     version,
     generatedAt: new Date().toISOString(),
+    releaseTag: macArtifact.releaseTag,
+    macosDistribution: macArtifact.distribution,
+    notarized: macArtifact.notarized,
     artifacts
   }, null, 2)}\n`);
 
@@ -79,13 +84,66 @@ function buildMacInstaller(packed) {
   mkdirSync(stageRoot, { recursive: true });
   buildSelfContainedMacApp(packed, appRoot);
   symlinkSync("/Applications", resolve(stageRoot, "Applications"));
+  writeFileSync(resolve(stageRoot, "README.txt"), macInstallReadme(signing));
 
   signMacApp(appRoot, signing);
-  const target = resolve(outputDir, `s-gw-${version}-macos.dmg`);
+  const target = resolve(outputDir, macInstallerFileName(signing));
   run("hdiutil", ["create", "-volname", `s-gw ${version}`, "-srcfolder", stageRoot, "-ov", "-format", "UDZO", target], root);
   signMacDmg(target, signing);
   notarizeMacDmg(target, signing);
-  return target;
+  return {
+    path: target,
+    releaseTag: releaseTagFor(signing),
+    distribution: signing.distribution,
+    notarized: signing.requireNotarization
+  };
+}
+
+function macInstallerFileName(signing) {
+  return signing.distribution === "unsigned-preview" ? unsignedPreviewMacInstallerFile : macInstallerFile;
+}
+
+function macInstallReadme(signing) {
+  const releaseTag = releaseTagFor(signing);
+  const npmInstall = signing.distribution === "unsigned-preview"
+    ? `npm install -g https://github.com/sgateway/s-gw/releases/download/${releaseTag}/s-gw-${version}.tgz`
+    : "npm install -g @s-gw/s-gw";
+  const trustNotice = signing.distribution === "unsigned-preview"
+    ? [
+      "This is an unsigned macOS preview. It is not signed with an Apple Developer ID or notarized.",
+      "macOS will require an explicit Gatekeeper override before it opens."
+    ]
+    : signing.distribution === "notarized"
+      ? ["This installer is Developer ID signed and notarized by Apple."]
+      : ["This is a local ad-hoc build. It is not intended for public distribution."];
+
+  return `${[
+    `s-gw ${version} for Apple silicon`,
+    "",
+    "1. Drag s-gw.app to Applications.",
+    "2. Open s-gw from Applications and complete setup.",
+    "",
+    ...trustNotice,
+    "",
+    "Prefer not to use a macOS security override? Install the CLI package instead (Node.js 20+ required):",
+    npmInstall,
+    "s-gw setup",
+    ...(signing.distribution === "unsigned-preview" ? [] : [
+      "",
+      "For an unsigned preview that is not in npm yet, use the exact .tgz link in the GitHub release notes."
+    ])
+  ].join("\n")}\n`;
+}
+
+function releaseTagFor(signing) {
+  const expected = signing.distribution === "unsigned-preview"
+    ? `unsigned-macos-preview-v${version}`
+    : `v${version}`;
+  const configured = process.env.SGW_RELEASE_TAG?.trim();
+  if (configured && configured !== expected) {
+    throw new Error(`SGW_RELEASE_TAG must be ${expected} for this distribution.`);
+  }
+  return expected;
 }
 
 function buildSelfContainedMacApp(packed, appRoot) {
@@ -250,6 +308,20 @@ function signingConfiguration() {
   const identity = process.env.SGW_MACOS_SIGN_IDENTITY?.trim() || "-";
   const requireNotarization = process.env.SGW_REQUIRE_NOTARIZATION === "1";
   const notaryProfile = process.env.SGW_NOTARY_PROFILE?.trim();
+  const distribution = process.env.SGW_MACOS_DISTRIBUTION?.trim() || "local";
+
+  if (!["local", "notarized", "unsigned-preview"].includes(distribution)) {
+    throw new Error("SGW_MACOS_DISTRIBUTION must be local, notarized, or unsigned-preview.");
+  }
+  if (distribution === "notarized" && !requireNotarization) {
+    throw new Error("A notarized distribution requires SGW_REQUIRE_NOTARIZATION=1.");
+  }
+  if (distribution === "unsigned-preview" && (identity !== "-" || requireNotarization)) {
+    throw new Error("An unsigned preview must use the ad-hoc signing identity and no notarization.");
+  }
+  if (distribution === "unsigned-preview" && !/^\d+\.\d+\.\d+-unsigned\.\d+$/.test(version)) {
+    throw new Error("An unsigned preview requires a package version such as 0.1.18-unsigned.1.");
+  }
 
   if (requireNotarization && identity === "-") {
     throw new Error("SGW_REQUIRE_NOTARIZATION=1 requires SGW_MACOS_SIGN_IDENTITY.");
@@ -261,7 +333,7 @@ function signingConfiguration() {
     throw new Error("SGW_REQUIRE_NOTARIZATION=1 requires SGW_NOTARY_PROFILE.");
   }
 
-  return { identity, requireNotarization, notaryProfile };
+  return { identity, requireNotarization, notaryProfile, distribution };
 }
 
 function signCode(target, signing, options = {}) {

--- a/scripts/validate-release-assets.mjs
+++ b/scripts/validate-release-assets.mjs
@@ -9,6 +9,14 @@ const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const packageInfo = JSON.parse(await readFile(path.join(root, "package.json"), "utf8"));
 const directory = path.resolve(process.argv[2] || path.join(root, "dist", "installers"));
 const selected = await validateReleaseDirectory(directory, packageInfo.version);
+const releaseMetadata = JSON.parse(await readFile(path.join(directory, "RELEASE.json"), "utf8"));
+const distributions = new Set(["local", "notarized", "unsigned-preview"]);
+if (!distributions.has(releaseMetadata.macosDistribution) || typeof releaseMetadata.notarized !== "boolean" || typeof releaseMetadata.releaseTag !== "string") {
+  throw new Error("RELEASE.json must declare the macOS distribution and notarization state.");
+}
+if (releaseMetadata.macosDistribution === "unsigned-preview" && releaseMetadata.notarized) {
+  throw new Error("An unsigned macOS preview cannot claim notarization.");
+}
 const legacyBridgeName = `0-s-gw-legacy-${packageInfo.version}.tgz`;
 const legacyBridgePath = path.join(directory, legacyBridgeName);
 const bridgeMetadata = inspectPackage(legacyBridgePath);
@@ -27,7 +35,28 @@ await verifyReleasePackageChecksum(
   "per-file"
 );
 
-const macDmg = path.join(directory, `s-gw-${packageInfo.version}-macos.dmg`);
+const macSuffix = releaseMetadata.macosDistribution === "unsigned-preview" ? "-unsigned-preview" : "";
+const macDmgName = `s-gw-${packageInfo.version}-macos${macSuffix}.dmg`;
+const expectedReleaseTag = releaseMetadata.macosDistribution === "unsigned-preview"
+  ? `unsigned-macos-preview-v${packageInfo.version}`
+  : `v${packageInfo.version}`;
+if (releaseMetadata.releaseTag !== expectedReleaseTag) {
+  throw new Error(`RELEASE.json must use ${expectedReleaseTag} for this distribution.`);
+}
+if (!Array.isArray(releaseMetadata.artifacts) || !releaseMetadata.artifacts.includes(macDmgName)) {
+  throw new Error(`RELEASE.json does not list ${macDmgName}.`);
+}
+const macDmg = path.join(directory, macDmgName);
+await verifyReleasePackageChecksum(
+  macDmg,
+  await readFile(path.join(directory, "SHA256SUMS.txt"), "utf8"),
+  "sha256sums"
+);
+await verifyReleasePackageChecksum(
+  macDmg,
+  await readFile(path.join(directory, `${macDmgName}.sha256`), "utf8"),
+  "per-file"
+);
 if (process.platform === "darwin" && existsSync(macDmg)) {
   const verification = spawnSync(process.execPath, [path.join(root, "scripts/verify-macos-dmg.mjs"), macDmg], {
     encoding: "utf8",

--- a/scripts/verify-macos-dmg.mjs
+++ b/scripts/verify-macos-dmg.mjs
@@ -1,4 +1,4 @@
-import { existsSync, lstatSync, mkdtempSync, readlinkSync, rmSync } from "node:fs";
+import { existsSync, lstatSync, mkdtempSync, readFileSync, readlinkSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
@@ -24,6 +24,7 @@ try {
 
   const appPath = path.join(mountPoint, "s-gw.app");
   const applicationsLink = path.join(mountPoint, "Applications");
+  const readmePath = path.join(mountPoint, "README.txt");
   const runtimeRoot = path.join(appPath, "Contents", "Resources", "s-gw-runtime");
   const packageRoot = path.join(runtimeRoot, "package");
   const expected = [
@@ -51,6 +52,17 @@ try {
   }
   if (existsSync(path.join(mountPoint, "Install s-gw.command"))) {
     throw new Error("The DMG must not include a clickable shell installer.");
+  }
+  if (!existsSync(readmePath)) {
+    throw new Error("The DMG must include installation guidance.");
+  }
+  const readme = readFileSync(readmePath, "utf8");
+  const packageVersion = JSON.parse(readFileSync(path.join(packageRoot, "package.json"), "utf8")).version;
+  const npmInstall = packageVersion.includes("-unsigned.")
+    ? `npm install -g https://github.com/sgateway/s-gw/releases/download/unsigned-macos-preview-v${packageVersion}/s-gw-${packageVersion}.tgz`
+    : "npm install -g @s-gw/s-gw";
+  if (!readme.includes(npmInstall) || !readme.includes("s-gw setup")) {
+    throw new Error("The DMG installation guidance must include the matching npm alternative.");
   }
 
   run("codesign", ["--verify", "--deep", "--strict", "--verbose=2", appPath]);

--- a/server.json
+++ b/server.json
@@ -15,13 +15,13 @@
     "url": "https://github.com/sgateway/s-gw",
     "source": "github"
   },
-  "version": "0.1.17",
+  "version": "0.1.18-unsigned.1",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@s-gw/s-gw",
-      "version": "0.1.17",
+      "version": "0.1.18-unsigned.1",
       "runtimeHint": "npx",
       "runtimeArguments": [
         {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -108,7 +108,7 @@ async function main(): Promise<void> {
     if (process.platform === "darwin") {
       const layout = getPackageLayout();
       if (layout.isSelfContainedMacApp) {
-        throw new Error("This self-contained s-gw.app updates through the signed macOS installer. Download the current DMG from the release page, quit s-gw, replace the app in Applications, then reopen it.");
+        throw new Error("This self-contained s-gw.app updates through the macOS installer. Download the current DMG from the release page, quit s-gw, replace the app in Applications, then reopen it.");
       }
       if (layout.standaloneMacAppInstalled) {
         throw new Error("A self-contained s-gw.app is already installed. Open that app to update it instead of using the npm package updater.");

--- a/src/update-check.ts
+++ b/src/update-check.ts
@@ -5,7 +5,6 @@ import { CURRENT_VERSION } from "./version.js";
 
 export const UPDATE_REPOSITORY = "sgateway/s-gw";
 export const UPDATE_CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000;
-export const UPDATE_ASSET_RETRY_INTERVAL_MS = 5 * 60 * 1000;
 
 export interface UpdateCheckResult {
   checked: boolean;
@@ -165,7 +164,10 @@ export class ReleaseChecker {
           signal: AbortSignal.timeout(5_000)
         });
         if (!response.ok) throw new Error(`GitHub release feed returned HTTP ${response.status}.`);
-        return releaseFromAtom(await response.text());
+        const release = releaseFromAtom(await response.text());
+        if (!release) return null;
+        const assets = await atomReleaseAssets(release, this.fetcher);
+        return assets ? { ...release, assets } : null;
       } catch (feedError) {
         const apiMessage = apiError instanceof Error ? apiError.message : String(apiError);
         const feedMessage = feedError instanceof Error ? feedError.message : String(feedError);
@@ -200,14 +202,18 @@ export class ReleaseChecker {
 export const releaseChecker = new ReleaseChecker();
 
 function newestRelease(releases: GitHubRelease[]): GitHubRelease | null {
-  let newest: GitHubRelease | null = null;
-  for (const release of releases) {
-    if (release.draft || !parseSemanticVersion(release.tag_name)) continue;
-    if (!newest || isNewerVersion(release.tag_name, newest.tag_name)) {
-      newest = release;
-    }
+  const candidates = releases
+    .filter((release) => !release.draft && !release.prerelease && Boolean(parseSemanticVersion(release.tag_name)))
+    .sort((left, right) => {
+      if (isNewerVersion(left.tag_name, right.tag_name)) return -1;
+      if (isNewerVersion(right.tag_name, left.tag_name)) return 1;
+      return 0;
+    });
+
+  for (const release of candidates) {
+    if (releaseHasVerifiedInstaller(release)) return release;
   }
-  return newest;
+  return null;
 }
 
 function releaseFromAtom(xml: string): GitHubRelease | null {
@@ -229,6 +235,46 @@ function releaseFromAtom(xml: string): GitHubRelease | null {
     prerelease: parsed.prerelease.length > 0,
     published_at: entry.match(/<updated>([^<]+)<\/updated>/i)?.[1] || null
   };
+}
+
+async function atomReleaseAssets(
+  release: GitHubRelease,
+  fetcher: typeof fetch
+): Promise<GitHubReleaseAsset[] | null> {
+  const version = cleanVersion(release.tag_name);
+  const installer = expectedInstallerName(version);
+  const prefix = `https://github.com/${UPDATE_REPOSITORY}/releases/download/${release.tag_name}`;
+  const installerUrl = `${prefix}/${installer}`;
+  const checksumUrl = `${installerUrl}.sha256`;
+  const manifestUrl = `${prefix}/SHA256SUMS.txt`;
+
+  const installerResponse = await fetcher(installerUrl, {
+    method: "HEAD",
+    headers: { "User-Agent": "s-gw-updater" },
+    signal: AbortSignal.timeout(5_000)
+  });
+  if (!installerResponse.ok) return null;
+
+  const checksumResponse = await fetcher(checksumUrl, {
+    method: "HEAD",
+    headers: { "User-Agent": "s-gw-updater" },
+    signal: AbortSignal.timeout(5_000)
+  });
+  if (checksumResponse.ok) {
+    return [
+      { name: installer, state: "uploaded" },
+      { name: `${installer}.sha256`, state: "uploaded" }
+    ];
+  }
+
+  const manifestResponse = await fetcher(manifestUrl, {
+    method: "HEAD",
+    headers: { "User-Agent": "s-gw-updater" },
+    signal: AbortSignal.timeout(5_000)
+  });
+  return manifestResponse.ok
+    ? [{ name: installer, state: "uploaded" }, { name: "SHA256SUMS.txt", state: "uploaded" }]
+    : null;
 }
 
 function decodeXml(value: string): string {
@@ -319,11 +365,7 @@ function cacheIsFresh(result: UpdateCheckResult, now: number): boolean {
   const checkedAt = Date.parse(result.checkedAt);
   if (!Number.isFinite(checkedAt)) return false;
 
-  const waitingForInstaller = Boolean(result.latestVersion) &&
-    isNewerVersion(result.latestVersion!, result.currentVersion) &&
-    !result.installerReady;
-  const interval = waitingForInstaller ? UPDATE_ASSET_RETRY_INTERVAL_MS : UPDATE_CHECK_INTERVAL_MS;
-  return now - checkedAt < interval;
+  return now - checkedAt < UPDATE_CHECK_INTERVAL_MS;
 }
 
 function validResult(value: unknown): value is UpdateCheckResult {

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const CURRENT_VERSION = "0.1.17";
+export const CURRENT_VERSION = "0.1.18-unsigned.1";

--- a/tests/console-browser-e2e.test.ts
+++ b/tests/console-browser-e2e.test.ts
@@ -71,7 +71,7 @@ describeBrowser("React local console (real headless Chrome)", () => {
         tag_name: "v0.1.1",
         html_url: "https://github.com/sgateway/s-gw/releases/tag/v0.1.1",
         draft: false,
-        prerelease: true,
+        prerelease: false,
         published_at: "2026-07-04T00:00:00.000Z",
         assets: [
           { name: installer, state: "uploaded" },

--- a/tests/console-server.test.ts
+++ b/tests/console-server.test.ts
@@ -154,7 +154,7 @@ describe("local console server", () => {
         tag_name: "v0.1.1",
         html_url: "https://github.com/sgateway/s-gw/releases/tag/v0.1.1",
         draft: false,
-        prerelease: true,
+        prerelease: false,
         published_at: "2026-07-04T00:00:00.000Z",
         assets: [
           { name: installer, state: "uploaded" },
@@ -171,7 +171,7 @@ describe("local console server", () => {
       latestVersion: "0.1.1",
       available: true,
       installerReady: true,
-      prerelease: true
+      prerelease: false
     });
   });
 

--- a/tests/installers.test.ts
+++ b/tests/installers.test.ts
@@ -33,6 +33,7 @@ describe("platform installers", () => {
     expect(pkg.files).not.toContain("native/menu-bar-helper/Sources");
     expect(builder).toContain("hdiutil");
     expect(builder).toContain("s-gw-${version}-macos.dmg");
+    expect(builder).toContain("s-gw-${version}-macos-unsigned-preview.dmg");
     expect(builder).toContain("s-gw-${version}-windows.zip");
     expect(builder).toContain('const packageFile = `s-gw-${version}.tgz`');
     expect(builder).toContain("SHA256SUMS.txt");
@@ -101,6 +102,11 @@ describe("platform installers", () => {
     expect(builder).toContain('writeLauncher(resolve(binDir, "s-gw")');
     expect(builder).toContain('writeLauncher(resolve(binDir, "s-gw-mcp")');
     expect(builder).toContain("SGW_REQUIRE_NOTARIZATION");
+    expect(builder).toContain("SGW_MACOS_DISTRIBUTION");
+    expect(builder).toContain("unsigned-preview");
+    expect(builder).toContain("README.txt");
+    expect(builder).toContain("npm install -g https://github.com/sgateway/s-gw/releases/download");
+    expect(builder).toContain("Prefer not to use a macOS security override?");
     expect(builder).toContain("notarytool");
     expect(builder).toContain("NodeRuntime.entitlements");
     expect(builder).toContain("com.apple.security.cs.allow-jit");
@@ -111,6 +117,8 @@ describe("platform installers", () => {
     expect(verifier).toContain('path.join(runtimeRoot, "bin", "s-gw")');
     expect(verifier).toContain("runMcpSmoke");
     expect(verifier).toContain("SGW_TEST_HOME_ROOT");
+    expect(verifier).toContain("const npmInstall = packageVersion.includes");
+    expect(verifier).toContain("readme.includes(npmInstall)");
     expect(runtime.node.version).toMatch(/^24\./);
     expect(runtime.node.url).toContain(`v${runtime.node.version}/node-v${runtime.node.version}-darwin-arm64.tar.gz`);
     expect(runtime.node.sha256).toMatch(/^[a-f0-9]{64}$/);
@@ -175,6 +183,8 @@ describe("platform installers", () => {
     expect(workflow).not.toContain("  release:");
     expect(workflow).toContain("release_tag:");
     expect(workflow).toContain("publish_release:");
+    expect(workflow).toContain("macos_distribution:");
+    expect(workflow).toContain("unsigned-preview");
     expect(assetJob).toContain("ref: ${{ inputs.release_tag }}");
     expect(assetJob).toContain('SGW_REQUIRE_RUST_CORE: "1"');
     expect(assetJob).toContain("SGW_RUST_CORE_DIR: ${{ github.workspace }}/.private/sgw-core");
@@ -192,7 +202,14 @@ describe("platform installers", () => {
     expect(assetJob).toContain("APPLE_NOTARY_KEY_P8_BASE64");
     expect(assetJob).toContain("SGW_MACOS_SIGN_IDENTITY=$identity");
     expect(assetJob).toContain("SGW_REQUIRE_NOTARIZATION=1");
+    expect(assetJob).toContain("SGW_MACOS_DISTRIBUTION=notarized");
+    expect(assetJob).toContain("SGW_MACOS_DISTRIBUTION=unsigned-preview");
     expect(assetJob).toContain("spctl --assess");
+    expect(assetJob).toContain("s-gw-${package_version}-macos-unsigned-preview.dmg");
+    expect(assetJob).toContain("--prerelease --latest=false");
+    expect(assetJob).toContain("unsigned-macos-preview-v${package_version}");
+    expect(assetJob).toContain("npm install -g https://github.com/${GITHUB_REPOSITORY}");
+    expect(assetJob).toContain("If you prefer not to override Gatekeeper");
     expect(assetJob).toContain("Create or verify a draft release");
     expect(assetJob).toContain("gh release create \"$RELEASE_TAG\" --draft --verify-tag --generate-notes");
     expect(assetJob).toContain('select(.state == "uploaded")');
@@ -201,6 +218,7 @@ describe("platform installers", () => {
     expect(builder).toContain("buildLegacyBridge");
     expect(builder).toContain("0-s-gw-legacy-${version}.tgz");
     expect(validator).toContain('bridgeMetadata.name !== "s-gw"');
+    expect(validator).toContain("macosDistribution");
   });
 
   it("publishes the native npm package on Apple Silicon and keeps Registry publishing on Linux", async () => {
@@ -222,6 +240,7 @@ describe("platform installers", () => {
     expect(releaseJob).toContain("gh release edit \"$RELEASE_TAG\" --draft=false");
     expect(npmJob).toContain("runs-on: macos-15");
     expect(npmJob).toContain("needs: publish-release");
+    expect(npmJob).toContain("inputs.macos_distribution == 'notarized'");
     expect(npmJob).toContain('SGW_REQUIRE_RUST_CORE: "1"');
     expect(npmJob).toContain("repository: barryqy/s-gw-rust-core");
     expect(npmJob).toContain("ref: ${{ inputs.release_tag }}");
@@ -234,6 +253,7 @@ describe("platform installers", () => {
     expect(npmJob).toContain('s-gw-core" --version');
     expect(npmJob).toContain('test ! -e "$package_root/dist/native/s-gw-core"');
     expect(registryJob).toContain("needs: publish-npm");
+    expect(registryJob).toContain("inputs.macos_distribution == 'notarized'");
     expect(registryJob).toContain("runs-on: ubuntu-latest");
     expect(registryJob).toContain("mcp-publisher_linux_amd64.tar.gz");
     expect(registryJob).not.toContain("npm publish --access public");

--- a/tests/native-update.test.ts
+++ b/tests/native-update.test.ts
@@ -73,6 +73,9 @@ describe("native macOS update lifecycle", () => {
     expect(checker).toContain('return "s-gw-\\(cleanVersion)-macos.dmg"');
     expect(checker).toContain("static var usesSelfContainedRuntime");
     expect(checker).toContain('$0.state?.lowercased() == "uploaded"');
+    expect(checker).toContain("for release in candidates");
+    expect(checker).toContain(".filter({ !$0.preRelease })");
+    expect(checker).toContain("if let info = await releaseInfo(from: release), info.hasVerifiedAsset");
     expect(checker).toContain("await assetExists(assetURL)");
     expect(checker).toContain("await assetExists(checksumURL)");
     expect(checker).toContain('"update", "install", "--package", downloadURL.path');
@@ -103,7 +106,8 @@ describe("native macOS update lifecycle", () => {
     expect(state).not.toContain("guard let previousVersion");
     expect(checker).toContain("var isMacInstaller");
     expect(checker).toContain("static var bundledAppPath");
-    expect(checker).toContain("return await releaseInfo(from: release)");
+    expect(checker).toContain("for release in candidates");
+    expect(checker).toContain("return nil");
     expect(window).toContain(".disabled(!release.hasVerifiedAsset || appState.updateState.isBusy)");
     expect(settings).toContain(".disabled(!release.hasVerifiedAsset || appState.updateState.isBusy)");
     expect(window).toContain("release.isMacInstaller ? \"Download\" : \"Upgrade\"");

--- a/tests/update-check.test.ts
+++ b/tests/update-check.test.ts
@@ -5,7 +5,6 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   isNewerVersion,
   ReleaseChecker,
-  UPDATE_ASSET_RETRY_INTERVAL_MS,
   UPDATE_CHECK_INTERVAL_MS
 } from "../src/update-check.js";
 import { CURRENT_VERSION } from "../src/version.js";
@@ -18,7 +17,7 @@ afterEach(async () => {
 });
 
 describe("release update checks", () => {
-  it("includes preview releases, ignores drafts, and refreshes after the cache interval", async () => {
+  it("ignores drafts and prereleases, then refreshes stable releases after the cache interval", async () => {
     tmpDir = await mkdtemp(path.join(os.tmpdir(), "sgw-update-check-"));
     let calls = 0;
     let now = Date.parse("2026-07-03T12:00:00.000Z");
@@ -26,9 +25,9 @@ describe("release update checks", () => {
       [
         release("v9.0.0", { draft: true }),
         release("v0.2.0", { prerelease: true }),
-        release("v0.1.0")
+        release("v0.1.1")
       ],
-      [release("v0.3.0", { prerelease: true })]
+      [release("v0.3.0", { prerelease: true }), release("v0.1.2")]
     ];
     const checker = new ReleaseChecker({
       cachePath: path.join(tmpDir, "update.json"),
@@ -39,20 +38,20 @@ describe("release update checks", () => {
     });
 
     const first = await checker.check();
-    expect(first).toMatchObject({ checked: true, available: true, installerReady: true, latestVersion: "0.2.0", prerelease: true });
+    expect(first).toMatchObject({ checked: true, available: true, installerReady: true, latestVersion: "0.1.1", prerelease: false });
     expect(calls).toBe(1);
 
     const cached = await checker.check();
-    expect(cached.latestVersion).toBe("0.2.0");
+    expect(cached.latestVersion).toBe("0.1.1");
     expect(calls).toBe(1);
 
     now += UPDATE_CHECK_INTERVAL_MS + 1;
     const refreshed = await checker.check();
-    expect(refreshed.latestVersion).toBe("0.3.0");
+    expect(refreshed.latestVersion).toBe("0.1.2");
     expect(calls).toBe(2);
 
     const cache = await readFile(path.join(tmpDir, "update.json"), "utf8");
-    expect(cache).toContain('"latestVersion": "0.3.0"');
+    expect(cache).toContain('"latestVersion": "0.1.2"');
   });
 
   it("fails quietly when the public release feed is unavailable", async () => {
@@ -106,12 +105,18 @@ describe("release update checks", () => {
       checked: true,
       currentVersion: "0.1.0",
       latestVersion: "0.1.2",
-      available: false,
-      installerReady: false,
+      available: true,
+      installerReady: true,
       releaseUrl: "https://github.com/sgateway/s-gw/releases/tag/v0.1.2",
       publishedAt: "2026-07-11T12:00:00Z"
     });
-    expect(calls).toEqual([api, atom]);
+    const asset = installerName("v0.1.2");
+    expect(calls).toEqual([
+      api,
+      atom,
+      `https://github.com/sgateway/s-gw/releases/download/v0.1.2/${asset}`,
+      `https://github.com/sgateway/s-gw/releases/download/v0.1.2/${asset}.sha256`
+    ]);
   });
 
   it("compares tagged release versions numerically", () => {
@@ -150,7 +155,7 @@ describe("release update checks", () => {
     });
   });
 
-  it("waits for an uploaded installer and checksum before announcing a release", async () => {
+  it("ignores incomplete installer uploads instead of repeatedly retrying them", async () => {
     tmpDir = await mkdtemp(path.join(os.tmpdir(), "sgw-update-installer-ready-"));
     const tag = "v0.2.0";
     const expected = installerName(tag);
@@ -164,7 +169,7 @@ describe("release update checks", () => {
     });
 
     await expect(checker.check(true)).resolves.toMatchObject({
-      latestVersion: "0.2.0",
+      latestVersion: null,
       installerReady: false,
       available: false
     });
@@ -186,7 +191,7 @@ describe("release update checks", () => {
     await expect(ready.check(true)).resolves.toMatchObject({ installerReady: true, available: true });
   });
 
-  it("retries an unready release soon after its installer assets finish uploading", async () => {
+  it("checks again on the normal interval after an incomplete release", async () => {
     tmpDir = await mkdtemp(path.join(os.tmpdir(), "sgw-update-pending-assets-"));
     let now = Date.parse("2026-07-16T20:00:00.000Z");
     let calls = 0;
@@ -213,9 +218,36 @@ describe("release update checks", () => {
     await expect(checker.check()).resolves.toMatchObject({ installerReady: false, available: false });
     expect(calls).toBe(1);
 
-    now += UPDATE_ASSET_RETRY_INTERVAL_MS + 1;
+    now += UPDATE_CHECK_INTERVAL_MS + 1;
     await expect(checker.check()).resolves.toMatchObject({ installerReady: true, available: true });
     expect(calls).toBe(2);
+  });
+
+  it("skips a prerelease even when it has regular installer assets", async () => {
+    tmpDir = await mkdtemp(path.join(os.tmpdir(), "sgw-update-preview-"));
+    const previewAsset = installerName("v0.2.0");
+    const checker = new ReleaseChecker({
+      cachePath: path.join(tmpDir, "update.json"),
+      currentVersion: "0.1.0",
+      enabled: true,
+      fetcher: async () => new Response(JSON.stringify([
+        release("v0.2.0", {
+          prerelease: true,
+          assets: [
+            { name: previewAsset, state: "uploaded" },
+            { name: `${previewAsset}.sha256`, state: "uploaded" }
+          ]
+        }),
+        release("unsigned-macos-preview-v0.2.0-unsigned.1", { prerelease: true }),
+        release("v0.1.1")
+      ]), { status: 200 })
+    });
+
+    await expect(checker.check(true)).resolves.toMatchObject({
+      latestVersion: "0.1.1",
+      available: true,
+      installerReady: true
+    });
   });
 
   it("keeps the updater version aligned with the package", async () => {


### PR DESCRIPTION
## Summary
- Add the Apple-ID-free unsigned macOS preview channel with a self-contained DMG.
- Keep the preview out of automatic updates and npm/MCP Registry publication.
- Offer the exact direct .tgz npm fallback for users who decline a Gatekeeper override.

## Verification
- Full isolated Vitest suite
- TypeScript check
- npm package and release-asset validation
- Rebuilt and verified self-contained unsigned macOS DMG