### PR TITLE
Fix queued store writes for unsigned preview

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "s-gw",
-  "version": "0.1.18-unsigned.1",
+  "version": "0.1.18-unsigned.2",
   "description": "Local s-gw plugin that lets coding agents use typed secret handles without receiving raw credentials.",
   "author": {
     "name": "Barry Yuan"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Notable changes to s-gw are documented here. The project follows [Semantic Versioning](https://semver.org/) once public releases begin.
 
-## 0.1.18-unsigned.1 - 2026-07-16
+## 0.1.18-unsigned.2 - 2026-07-17
 
 ### Added
 
@@ -11,6 +11,7 @@ Notable changes to s-gw are documented here. The project follows [Semantic Versi
 
 ### Fixed
 
+- Concurrent credential clients now wait up to 30 seconds for a durable store write to finish, rather than failing while another verified control-plane update is still being committed.
 - The macOS package updater now accepts only the exact scoped `s-gw-<version>.tgz` asset and rejects the legacy compatibility bridge before download or installation.
 - Native update banners and Settings now report the active installed CLI/runtime version instead of a stale development app bundle version.
 - Valid 0.1.12 unsealed control manifests migrate to the current sealed recovery format only when the live ledger and a trusted legacy checkpoint both match the legacy fingerprint. Credentials, policies, requests, and audit history remain intact, while unexplained mismatches continue to fail closed.

--- a/native/macos-app/Sources/SgwMac/Services/UpdateChecker.swift
+++ b/native/macos-app/Sources/SgwMac/Services/UpdateChecker.swift
@@ -73,7 +73,7 @@ actor UpdateChecker: UpdateChecking {
     private let cli = CLIRunner()
 
     static var currentVersion: String {
-        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.1.18-unsigned.1"
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.1.18-unsigned.2"
     }
 
     static var usesSelfContainedRuntime: Bool {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@s-gw/s-gw",
-  "version": "0.1.18-unsigned.1",
+  "version": "0.1.18-unsigned.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@s-gw/s-gw",
-      "version": "0.1.18-unsigned.1",
+      "version": "0.1.18-unsigned.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-gw/s-gw",
-  "version": "0.1.18-unsigned.1",
+  "version": "0.1.18-unsigned.2",
   "mcpName": "io.github.sgateway/s-gw",
   "description": "Local credential control for AI coding agents.",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -15,13 +15,13 @@
     "url": "https://github.com/sgateway/s-gw",
     "source": "github"
   },
-  "version": "0.1.18-unsigned.1",
+  "version": "0.1.18-unsigned.2",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@s-gw/s-gw",
-      "version": "0.1.18-unsigned.1",
+      "version": "0.1.18-unsigned.2",
       "runtimeHint": "npx",
       "runtimeArguments": [
         {

--- a/src/store.ts
+++ b/src/store.ts
@@ -48,7 +48,8 @@ const defaultApprovalSettings: ApprovalSettings = {
 };
 
 const maxApprovalDurationMs = 30 * 24 * 60 * 60 * 1000;
-const lockTimeoutMs = 5_000;
+// Concurrent clients may need to serialize a durable control-plane write on a slow disk.
+const lockTimeoutMs = 30_000;
 
 // A request gets claimed into "executing" right before its secret is revealed. If the
 // runner is killed, sleeps, or crashes before markExecuted/markFailed, that request is

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const CURRENT_VERSION = "0.1.18-unsigned.1";
+export const CURRENT_VERSION = "0.1.18-unsigned.2";

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -1981,7 +1981,7 @@ describe("SecretStore", () => {
 
     expect(ids.size).toBe(1);
     expect((await store.listRequests("pending")).filter((request) => request.handle === record.handle)).toHaveLength(1);
-  }, 15_000);
+  }, 60_000);
 
   it("coalesces repeated policy denials into one durable record", async () => {
     const store = new SecretStore();


### PR DESCRIPTION
## Summary

- Raise the bounded durable store-lock wait from 5 to 30 seconds while keeping serialization and recovery safeguards intact.
- Give the 16-client coalescing regression a 60-second test budget.
- Advance the unsigned macOS preview to 0.1.18-unsigned.2 because the failed .1 tag is immutable.

## Why

The prior unsigned-preview release run failed in CI when queued one-shot requests outwaited the 5-second lock budget. It created no release or assets.

## Validation

- `npx vitest run --testTimeout 60000`
- `npm run check`
- `npm audit --audit-level=high`
- `npm run validate:npm-package`
- `npm run build:installers` with the matching private core and unsigned-preview mode
- private core fmt, clippy, and tests

The matching private-core branch and `unsigned-macos-preview-v0.1.18-unsigned.2` tag are already available for the release workflow.