### PR TITLE
Verify draft release assets by ID

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "s-gw",
-  "version": "0.1.18-unsigned.2",
+  "version": "0.1.18-unsigned.3",
   "description": "Local s-gw plugin that lets coding agents use typed secret handles without receiving raw credentials.",
   "author": {
     "name": "Barry Yuan"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -222,10 +222,13 @@ jobs:
             gh release upload "$RELEASE_TAG" "$asset"
           done
 
-          first_tgz="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}" --jq '[.assets[] | select(.name | endswith(".tgz"))][0].name')"
+          release_id="$(gh release view "$RELEASE_TAG" --json databaseId --jq '.databaseId')"
+          test -n "$release_id"
+
+          first_tgz="$(gh api "repos/${GITHUB_REPOSITORY}/releases/${release_id}" --jq '[.assets[] | select(.name | endswith(".tgz"))][0].name')"
           test "$first_tgz" = "$(basename "$bridge")"
 
-          uploaded="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}" --jq '.assets[] | select(.state == "uploaded") | .name')"
+          uploaded="$(gh api "repos/${GITHUB_REPOSITORY}/releases/${release_id}" --jq '.assets[] | select(.state == "uploaded") | .name')"
           for asset in dist/installers/*; do
             name="$(basename "$asset")"
             printf '%s\n' "$uploaded" | grep -Fqx "$name"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Notable changes to s-gw are documented here. The project follows [Semantic Versioning](https://semver.org/) once public releases begin.
 
-## 0.1.18-unsigned.2 - 2026-07-17
+## 0.1.18-unsigned.3 - 2026-07-17
 
 ### Added
 
@@ -12,6 +12,7 @@ Notable changes to s-gw are documented here. The project follows [Semantic Versi
 ### Fixed
 
 - Concurrent credential clients now wait up to 30 seconds for a durable store write to finish, rather than failing while another verified control-plane update is still being committed.
+- The release workflow now verifies draft assets by release ID, so an unsigned preview remains private until every asset is confirmed rather than failing on GitHub's published-release-by-tag endpoint.
 - The macOS package updater now accepts only the exact scoped `s-gw-<version>.tgz` asset and rejects the legacy compatibility bridge before download or installation.
 - Native update banners and Settings now report the active installed CLI/runtime version instead of a stale development app bundle version.
 - Valid 0.1.12 unsealed control manifests migrate to the current sealed recovery format only when the live ledger and a trusted legacy checkpoint both match the legacy fingerprint. Credentials, policies, requests, and audit history remain intact, while unexplained mismatches continue to fail closed.

--- a/native/macos-app/Sources/SgwMac/Services/UpdateChecker.swift
+++ b/native/macos-app/Sources/SgwMac/Services/UpdateChecker.swift
@@ -73,7 +73,7 @@ actor UpdateChecker: UpdateChecking {
     private let cli = CLIRunner()
 
     static var currentVersion: String {
-        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.1.18-unsigned.2"
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.1.18-unsigned.3"
     }
 
     static var usesSelfContainedRuntime: Bool {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@s-gw/s-gw",
-  "version": "0.1.18-unsigned.2",
+  "version": "0.1.18-unsigned.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@s-gw/s-gw",
-      "version": "0.1.18-unsigned.2",
+      "version": "0.1.18-unsigned.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-gw/s-gw",
-  "version": "0.1.18-unsigned.2",
+  "version": "0.1.18-unsigned.3",
   "mcpName": "io.github.sgateway/s-gw",
   "description": "Local credential control for AI coding agents.",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -15,13 +15,13 @@
     "url": "https://github.com/sgateway/s-gw",
     "source": "github"
   },
-  "version": "0.1.18-unsigned.2",
+  "version": "0.1.18-unsigned.3",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@s-gw/s-gw",
-      "version": "0.1.18-unsigned.2",
+      "version": "0.1.18-unsigned.3",
       "runtimeHint": "npx",
       "runtimeArguments": [
         {

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const CURRENT_VERSION = "0.1.18-unsigned.2";
+export const CURRENT_VERSION = "0.1.18-unsigned.3";

--- a/tests/installers.test.ts
+++ b/tests/installers.test.ts
@@ -214,6 +214,9 @@ describe("platform installers", () => {
     expect(assetJob).toContain("gh release create \"$RELEASE_TAG\" --draft --verify-tag --generate-notes");
     expect(assetJob).toContain('select(.state == "uploaded")');
     expect(assetJob).toContain("first_tgz");
+    expect(assetJob).toContain('gh release view "$RELEASE_TAG" --json databaseId');
+    expect(assetJob).toContain("releases/${release_id}");
+    expect(assetJob).not.toContain("releases/tags/${RELEASE_TAG}");
     expect(assetJob).not.toContain("needs: publish");
     expect(builder).toContain("buildLegacyBridge");
     expect(builder).toContain("0-s-gw-legacy-${version}.tgz");


### PR DESCRIPTION
## Summary

- Verify draft-release assets through the release ID returned by GitHub CLI.
- Keep the draft-first release flow intact, then publish only after every expected asset is confirmed.
- Advance the unsigned macOS preview to 0.1.18-unsigned.3 because the failed .2 tag is immutable.

## Root cause

GitHub's release-by-tag REST endpoint only resolves published releases. The .2 workflow uploaded all assets, then received 404 while verifying its still-draft release by tag.

## Validation

- Confirmed the existing .2 draft resolves through `gh release view` to a numeric release ID and through the release-by-ID API with all 10 assets.
- `actionlint .github/workflows/publish.yml`
- `npx vitest run --testTimeout 60000`
- `npm run check` and `npm run check:rust`
- `npm audit --audit-level=high`
- matching-core package dry-run and package validation
- self-contained unsigned installer build and release-asset validation
- private core fmt, clippy, and tests

The matching private core tag `unsigned-macos-preview-v0.1.18-unsigned.3` is already available.