### PR TITLE
Fix release publish repository context

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -249,12 +249,12 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          test "$(gh release view "$RELEASE_TAG" --json isDraft --jq '.isDraft')" = "true"
+          test "$(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json isDraft --jq '.isDraft')" = "true"
           expected_prerelease=false
           if [ "$MACOS_DISTRIBUTION" = "unsigned-preview" ]; then expected_prerelease=true; fi
-          test "$(gh release view "$RELEASE_TAG" --json isPrerelease --jq '.isPrerelease')" = "$expected_prerelease"
-          gh release edit "$RELEASE_TAG" --draft=false
-          test "$(gh release view "$RELEASE_TAG" --json isDraft --jq '.isDraft')" = "false"
+          test "$(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json isPrerelease --jq '.isPrerelease')" = "$expected_prerelease"
+          gh release edit "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --draft=false
+          test "$(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json isDraft --jq '.isDraft')" = "false"
 
   publish-npm:
     needs: publish-release

--- a/tests/installers.test.ts
+++ b/tests/installers.test.ts
@@ -240,7 +240,8 @@ describe("platform installers", () => {
     );
 
     expect(releaseJob).toContain("needs: release-assets");
-    expect(releaseJob).toContain("gh release edit \"$RELEASE_TAG\" --draft=false");
+    expect(releaseJob).toContain('gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY"');
+    expect(releaseJob).toContain("gh release edit \"$RELEASE_TAG\" --repo \"$GITHUB_REPOSITORY\" --draft=false");
     expect(npmJob).toContain("runs-on: macos-15");
     expect(npmJob).toContain("needs: publish-release");
     expect(npmJob).toContain("inputs.macos_distribution == 'notarized'");


### PR DESCRIPTION
## Summary

- Pass the explicit repository to every GitHub CLI call in the final publish job.
- Add a regression assertion for the checkout-free publish job.

## Root cause

The final job intentionally has no checkout. GitHub CLI therefore could not infer a repository and failed before publishing an already verified draft release.

## Validation

- `actionlint .github/workflows/publish.yml`
- `npm run check`
- `npx vitest run --testTimeout 60000` (36 files, 371 tests)

The validated `.3` draft release remains unpublished while this durable workflow repair goes through CI.