### PR TITLE
Publish standard 0.1.18 release

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "s-gw",
-  "version": "0.1.18-unsigned.3",
+  "version": "0.1.18",
   "description": "Local s-gw plugin that lets coding agents use typed secret handles without receiving raw credentials.",
   "author": {
     "name": "Barry Yuan"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,13 +13,13 @@ on:
         default: true
         type: boolean
       macos_distribution:
-        description: macOS release channel. Unsigned previews are manual-download only.
+        description: macOS distribution. Unsigned releases remain discoverable but require a Gatekeeper override.
         required: true
-        default: notarized
+        default: unsigned
         type: choice
         options:
           - notarized
-          - unsigned-preview
+          - unsigned
 
 concurrency:
   group: publish-${{ inputs.release_tag }}
@@ -110,19 +110,14 @@ jobs:
             echo "SGW_MACOS_DISTRIBUTION=notarized"
           } >> "$GITHUB_ENV"
 
-      - name: Configure unsigned macOS preview
-        if: inputs.macos_distribution == 'unsigned-preview'
-        run: echo "SGW_MACOS_DISTRIBUTION=unsigned-preview" >> "$GITHUB_ENV"
+      - name: Configure unsigned macOS distribution
+        if: inputs.macos_distribution == 'unsigned'
+        run: echo "SGW_MACOS_DISTRIBUTION=unsigned" >> "$GITHUB_ENV"
 
       - name: Verify release version
         run: |
           package_version="$(node -p "require('./package.json').version")"
-          if [ "$MACOS_DISTRIBUTION" = "unsigned-preview" ]; then
-            case "$package_version" in *-unsigned.[0-9]*) ;; *) exit 1 ;; esac
-            test "$RELEASE_TAG" = "unsigned-macos-preview-v${package_version}"
-          else
-            test "v${package_version}" = "$RELEASE_TAG"
-          fi
+          test "v${package_version}" = "$RELEASE_TAG"
 
       - name: Verify release build
         run: |
@@ -144,22 +139,23 @@ jobs:
           test "$distribution" = "$MACOS_DISTRIBUTION"
           if [ "$MACOS_DISTRIBUTION" = "notarized" ]; then
             test "$notarized" = "true"
-            spctl --assess --type open --context context:primary-signature "dist/installers/s-gw-${package_version}-macos.dmg"
+            spctl --assess --type open --context context:primary-signature "dist/installers/s-gw.dmg"
           else
             test "$notarized" = "false"
-            test -f "dist/installers/s-gw-${package_version}-macos-unsigned-preview.dmg"
+            test -f "dist/installers/s-gw.dmg"
           fi
+          test -f "dist/installers/s-gw-${package_version}-macos.dmg"
 
       - name: Prepare release notes
         run: |
           set -euo pipefail
           package_version="$(node -p "require('./package.json').version")"
           notes="$RUNNER_TEMP/release-notes.md"
-          if [ "$MACOS_DISTRIBUTION" = "unsigned-preview" ]; then
+          if [ "$MACOS_DISTRIBUTION" = "unsigned" ]; then
             cat > "$notes" <<EOF
-          ## Unsigned macOS preview
+          ## macOS installation
 
-          The Apple Silicon DMG in this release is an unsigned preview. It is not Developer ID signed or notarized, so macOS will require an explicit Gatekeeper override to open it. It is deliberately not used by s-gw's automatic macOS update channel.
+          The Apple Silicon DMG in this release is not Developer ID signed or notarized, so macOS will require an explicit Gatekeeper override to open it. Drag \`s-gw.app\` from \`s-gw.dmg\` to Applications, then open it to complete setup.
 
           If you prefer not to override Gatekeeper, install this exact release through npm instead (Node.js 20+):
 
@@ -184,20 +180,13 @@ jobs:
           set -euo pipefail
           if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
             test "$(gh release view "$RELEASE_TAG" --json isDraft --jq '.isDraft')" = "true"
-            expected_prerelease=false
-            if [ "$MACOS_DISTRIBUTION" = "unsigned-preview" ]; then expected_prerelease=true; fi
-            test "$(gh release view "$RELEASE_TAG" --json isPrerelease --jq '.isPrerelease')" = "$expected_prerelease"
+            test "$(gh release view "$RELEASE_TAG" --json isPrerelease --jq '.isPrerelease')" = "false"
             exit 0
           fi
-          if [ "$MACOS_DISTRIBUTION" = "unsigned-preview" ]; then
-            package_version="$(node -p "require('./package.json').version")"
-            gh release create "$RELEASE_TAG" --draft --prerelease --latest=false --verify-tag \
-              --title "s-gw ${package_version} unsigned macOS preview" \
-              --notes-file "$SGW_RELEASE_NOTES"
-          else
-            gh release create "$RELEASE_TAG" --draft --verify-tag --generate-notes \
-              --notes "$(cat "$SGW_RELEASE_NOTES")"
-          fi
+          package_version="$(node -p "require('./package.json').version")"
+          gh release create "$RELEASE_TAG" --draft --verify-tag --generate-notes \
+            --title "s-gw ${package_version}" \
+            --notes "$(cat "$SGW_RELEASE_NOTES")"
 
       - name: Upload verified release assets
         env:
@@ -250,9 +239,7 @@ jobs:
         run: |
           set -euo pipefail
           test "$(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json isDraft --jq '.isDraft')" = "true"
-          expected_prerelease=false
-          if [ "$MACOS_DISTRIBUTION" = "unsigned-preview" ]; then expected_prerelease=true; fi
-          test "$(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json isPrerelease --jq '.isPrerelease')" = "$expected_prerelease"
+          test "$(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json isPrerelease --jq '.isPrerelease')" = "false"
           gh release edit "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --draft=false
           test "$(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json isDraft --jq '.isDraft')" = "false"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,25 +2,26 @@
 
 Notable changes to s-gw are documented here. The project follows [Semantic Versioning](https://semver.org/) once public releases begin.
 
-## 0.1.18-unsigned.3 - 2026-07-17
+## 0.1.18 - 2026-07-17
 
 ### Added
 
 - A local **Demo data** toggle fills the Sankey, activity and audit logs, credentials, policies, and requests with clearly labeled display-only records that can be removed in one click.
-- An explicit unsigned macOS preview channel for the self-contained app. Its distinctly named DMG includes installation guidance and an npm alternative for users who prefer not to override Gatekeeper.
+- A self-contained Apple Silicon macOS DMG named `s-gw.dmg`, with a versioned compatibility copy so existing clients can discover the update.
+- An expandable policy view that shows evaluation order, policy flow, complete matching conditions, and richer shadow explanations without changing policy evaluation or editing semantics.
 
 ### Fixed
 
 - Concurrent credential clients now wait up to 30 seconds for a durable store write to finish, rather than failing while another verified control-plane update is still being committed.
-- The release workflow now verifies draft assets by release ID, so an unsigned preview remains private until every asset is confirmed rather than failing on GitHub's published-release-by-tag endpoint.
+- The release workflow now verifies draft assets by release ID, so an unsigned release remains private until every asset is confirmed rather than failing on GitHub's published-release-by-tag endpoint.
 - The macOS package updater now accepts only the exact scoped `s-gw-<version>.tgz` asset and rejects the legacy compatibility bridge before download or installation.
 - Native update banners and Settings now report the active installed CLI/runtime version instead of a stale development app bundle version.
 - Valid 0.1.12 unsealed control manifests migrate to the current sealed recovery format only when the live ledger and a trusted legacy checkpoint both match the legacy fingerprint. Credentials, policies, requests, and audit history remain intact, while unexplained mismatches continue to fail closed.
 
 ### Changed
 
-- Unsigned macOS previews are GitHub prereleases under non-version tags: they do not publish npm or the MCP Registry and are excluded from automatic update notices, including in older clients.
-- Automatic update checks select only stable releases with the normal installer and checksum, preventing incomplete or unsigned-preview assets from causing repeated retry checks.
+- The unsigned macOS release uses the standard SemVer tag and remains discoverable by existing clients. It is not Developer ID signed or notarized, so macOS will require a Gatekeeper override. The exact release tarball remains the npm fallback for users who prefer not to override Gatekeeper.
+- Automatic update checks select only stable releases with a verified installer and checksum, preventing incomplete uploads from causing repeated retry checks.
 
 ## 0.1.17 - 2026-07-16
 

--- a/README.md
+++ b/README.md
@@ -98,14 +98,14 @@ The agent never needs the unlock passphrase or raw credential. Approval is scope
 
 On an Apple Silicon Mac, download the macOS DMG from [GitHub Releases](https://github.com/sgateway/s-gw/releases), drag `s-gw.app` to **Applications**, then open it and complete setup. The app includes its own Node runtime, CLI, MCP server, native helpers, and menu-bar helper; it does not require Node.js or npm on the host. Setup is intentionally blocked until the app is in `/Applications` or `~/Applications`.
 
-Normal macOS releases use `s-gw-VERSION-macos.dmg` and are Developer ID signed and notarized. An explicitly labelled `s-gw-VERSION-macos-unsigned-preview.dmg` is a manual-download preview: macOS will require a Gatekeeper override. It uses a non-version GitHub prerelease tag, so current and older s-gw clients cannot mistake it for an automatic update. If you prefer not to override Gatekeeper, install the matching release package with Node.js 20 or newer instead:
+macOS releases provide `s-gw.dmg` and a versioned compatibility copy for existing update clients. A release built without an Apple Developer ID is clearly documented as unsigned and requires a Gatekeeper override. If you prefer not to override Gatekeeper, install the matching release package with Node.js 20 or newer instead:
 
 ```bash
-npm install -g https://github.com/sgateway/s-gw/releases/download/unsigned-macos-preview-vVERSION/s-gw-VERSION.tgz
+npm install -g https://github.com/sgateway/s-gw/releases/download/vVERSION/s-gw-VERSION.tgz
 s-gw setup
 ```
 
-Replace `VERSION` with the version in that preview's filename, or copy the exact command from the preview release notes or DMG README.
+Replace `VERSION` with the release version, or copy the exact command from the release notes or DMG README.
 
 For terminal-first, Linux, Windows, or source installs, use Node.js 20 or newer:
 
@@ -117,7 +117,7 @@ s-gw status
 
 The public source builds the TypeScript compatibility path. Building the native macOS surfaces also requires a Swift toolchain. Maintainer release builds additionally require access to the private Rust core checkout.
 
-The Apple Silicon Mac DMG is the preferred desktop path. Normal published macOS DMGs are Developer ID signed and notarized. An unsigned preview has a distinct filename and non-version prerelease tag, so it is never offered through automatic updates. Local `npm run build:installers` output is ad-hoc signed for local verification. The npm package remains the terminal-first path and includes the native app, menu helper, Keychain helper, metadata-only Keychain inspector, and Rust core for Apple Silicon Macs. Linux and Windows use the TypeScript execution path when a matching native core is not packaged. Intel Macs must build the native Keychain and desktop surfaces from source for now; packaged arm64-only helpers are rejected before launch.
+The Apple Silicon Mac DMG is the preferred desktop path. Published macOS DMGs are either Developer ID signed and notarized or explicitly documented as unsigned; unsigned builds require a Gatekeeper override but retain the standard release tag and update path. Local `npm run build:installers` output is ad-hoc signed for local verification. The npm package remains the terminal-first path and includes the native app, menu helper, Keychain helper, metadata-only Keychain inspector, and Rust core for Apple Silicon Macs. Linux and Windows use the TypeScript execution path when a matching native core is not packaged. Intel Macs must build the native Keychain and desktop surfaces from source for now; packaged arm64-only helpers are rejected before launch.
 
 ```bash
 git clone https://github.com/sgateway/s-gw.git
@@ -224,7 +224,7 @@ The model can complete the task without receiving the raw access key.
 | Windows 10/11 | Preview | Credential Manager | PowerShell client, tray helper, local web console |
 | Linux | Experimental CLI | Environment-provided unlock material | Local web console |
 
-Published Apple Silicon macOS DMGs are self-contained. Normal releases are Developer ID signed and notarized; an explicitly labelled unsigned preview is manual-download only, uses a non-version prerelease tag, and requires a macOS override. The Windows package remains unsigned preview software. Build locally with `npm run build:installers`; local DMGs are ad-hoc signed and are only publishable through the explicit unsigned-preview channel.
+Published Apple Silicon macOS DMGs are self-contained. Releases are Developer ID signed and notarized when credentials are available; otherwise the release notes and DMG README state that a Gatekeeper override is required. The Windows package remains unsigned preview software. Build locally with `npm run build:installers`; local DMGs are ad-hoc signed.
 
 ## Security Model
 
@@ -238,7 +238,7 @@ Read the [threat model](docs/threat-model.md) before relying on s-gw for sensiti
 - macOS is the primary development and test platform.
 - Windows Credential Manager support is present but still needs broader native QA.
 - Linux currently depends on environment-provided unlock material.
-- The Windows desktop package remains an unsigned preview. The default macOS release path requires Developer ID signing and notarization; unsigned previews are separately named, use non-version prerelease tags, and never participate in automatic updates.
+- The Windows desktop package remains an unsigned preview. macOS releases without Developer ID signing are marked unsigned in their release notes and require a Gatekeeper override.
 - The repository is prepared for open-source collaboration, but security-sensitive changes should come with focused tests and threat-model updates when behavior changes.
 
 ## Documentation

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -35,7 +35,7 @@ Exercise the [quick-start trust loop](docs/quickstart.md) with a disposable stor
 
 ## Artifacts
 
-`npm run build:installers` writes versioned files and SHA-256 checksums under `dist/installers`.
+`npm run build:installers` writes release files and SHA-256 checksums under `dist/installers`.
 
 The macOS DMG is a self-contained `s-gw.app` plus an Applications shortcut. The default `notarized` release mode requires Developer ID signing, hardened runtime, Apple notarization, stapling, and Gatekeeper assessment. The `release-assets` workflow fails closed unless these repository secrets are present:
 
@@ -45,17 +45,17 @@ The macOS DMG is a self-contained `s-gw.app` plus an Applications shortcut. The 
 - `APPLE_NOTARY_KEY_ID`
 - `APPLE_NOTARY_ISSUER_ID`
 
-`unsigned-preview` is the only exception: it produces `s-gw-VERSION-macos-unsigned-preview.dmg`, marks the GitHub release as a prerelease under the non-version tag `unsigned-macos-preview-vVERSION`, omits npm and MCP Registry publication, and keeps it out of automatic updates in both current and older clients. Its release notes include the exact `.tgz` npm command for users who prefer not to override Gatekeeper. Local builds use ad-hoc signatures only. Do not describe the Windows package as a production download until it is signed and validated on supported Windows versions.
+`unsigned` is the Apple-ID-free macOS mode. It produces the primary `s-gw.dmg` plus a versioned compatibility copy, uses the ordinary `vVERSION` tag, omits npm and MCP Registry publication, and remains discoverable by current and older clients. Its release notes and DMG README explain the required Gatekeeper override and include the exact `.tgz` npm command for users who prefer not to override it. Local builds use ad-hoc signatures only. Do not describe the Windows package as a production download until it is signed and validated on supported Windows versions.
 
 ## Publish
 
-1. Create an annotated `vX.Y.Z` tag from a green `main` commit, or `unsigned-macos-preview-vX.Y.Z-unsigned.N` for the explicit unsigned preview channel.
+1. Create an annotated `vX.Y.Z` tag from a green `main` commit.
 2. Ensure private `barryqy/s-gw-rust-core` has the same immutable tag.
-3. Run **Publish release** with `release_tag=vX.Y.Z`, `publish_release=true`, and `macos_distribution=notarized` for a normal release. For an unsigned preview, use the matching non-version preview tag and `macos_distribution=unsigned-preview`.
+3. Run **Publish release** with `release_tag=vX.Y.Z`, `publish_release=true`, and `macos_distribution=notarized` for a signed release or `macos_distribution=unsigned` when an Apple Developer ID is unavailable.
 4. The normal workflow verifies the tag/version pair, builds, signs, notarizes, staples, and Gatekeeper-assesses the DMG before it creates or updates a **draft** GitHub release.
-5. It uploads every installer and checksum, confirms their GitHub asset state is `uploaded`, then publishes the draft. Only after a normal release succeeds does it publish npm and the MCP Registry.
+5. It uploads every installer and checksum, confirms their GitHub asset state is `uploaded`, then publishes the draft. Only a notarized release publishes npm and the MCP Registry.
 6. To inspect assets without notifying users, run the workflow with `publish_release=false`; the release remains a draft. Re-run with `true` only after review.
 7. Verify checksums from a clean download and install the release on clean macOS and Windows test accounts.
 8. Confirm the update checker sees the release and opens the correct notes.
 
-When signing is unavailable, run the explicit `unsigned-preview` mode only. It creates a prerelease under a non-version tag, so current and older clients ignore it rather than treating it as an automatic update. It intentionally does not publish to npm or the MCP Registry. The Windows package may still be labeled as a preview artifact with its limitations stated in the release notes.
+When signing is unavailable, use `unsigned`. It creates a normal SemVer release so installed clients can discover it, but it intentionally does not publish to npm or the MCP Registry. The release notes must state the Gatekeeper override and exact tarball alternative. The Windows package may still be labeled as a preview artifact with its limitations stated in the release notes.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -22,7 +22,7 @@ Raw credentials stay in the local encrypted ledger and are decrypted only inside
 
 The preferred Mac installation is the self-contained DMG from [GitHub Releases](https://github.com/sgateway/s-gw/releases):
 
-1. Open `s-gw-VERSION-macos.dmg`.
+1. Open `s-gw.dmg`.
 2. Drag `s-gw.app` onto the **Applications** shortcut.
 3. Open `s-gw.app` from `/Applications` or `~/Applications` and complete setup.
 
@@ -73,14 +73,14 @@ npm link
 
 The macOS DMG contains `s-gw.app`, an `Applications` shortcut, and a short README with the npm installation alternative. The app includes the runtime and all macOS components, so users drag one bundle into Applications instead of double-clicking a shell installer. The default release mode signs every executable with a Developer ID Application certificate, enables the hardened runtime, applies the Node JIT entitlement required by V8, submits the DMG to Apple notarization, staples the result, and assesses it with Gatekeeper before upload.
 
-When Developer ID signing is unavailable, the explicit `unsigned-preview` mode produces `s-gw-VERSION-macos-unsigned-preview.dmg` under the non-version GitHub prerelease tag `unsigned-macos-preview-vVERSION`. It is not notarized, requires a Gatekeeper override, is ignored by current and older automatic updaters, and does not publish npm or the MCP Registry. Users who prefer not to override Gatekeeper can install the matching `.tgz` release asset with Node.js 20 or newer:
+When Developer ID signing is unavailable, the `unsigned` mode produces the primary `s-gw.dmg` plus a versioned compatibility copy under the ordinary `vVERSION` release tag. It is not notarized, requires a Gatekeeper override, remains visible to automatic updaters, and does not publish npm or the MCP Registry. Users who prefer not to override Gatekeeper can install the matching `.tgz` release asset with Node.js 20 or newer:
 
 ```bash
-npm install -g https://github.com/sgateway/s-gw/releases/download/unsigned-macos-preview-vVERSION/s-gw-VERSION.tgz
+npm install -g https://github.com/sgateway/s-gw/releases/download/vVERSION/s-gw-VERSION.tgz
 s-gw setup
 ```
 
-Replace `VERSION` with the version in that preview's filename, or copy the exact command from the preview release notes or DMG README.
+Replace `VERSION` with the release version, or copy the exact command from the release notes or DMG README.
 
 The installer never pre-seeds passphrases, credentials, `SGW_HOME`, or policy templates.
 
@@ -265,7 +265,8 @@ npm run build:installers
 
 The command rebuilds the native clients and console, then writes these files under `dist/installers`:
 
-- `s-gw-VERSION-macos.dmg`, containing the self-contained `s-gw.app` and an `Applications` shortcut;
+- `s-gw.dmg`, containing the self-contained `s-gw.app` and an `Applications` shortcut;
+- `s-gw-VERSION-macos.dmg`, a versioned compatibility copy for existing update clients;
 - `s-gw-VERSION-windows.zip`, containing the local npm package plus PowerShell and CMD setup launchers;
 - `s-gw-VERSION.tgz`, used by both installers and the in-app updater;
 - `0-s-gw-legacy-VERSION.tgz`, a release-only unscoped bridge for the original `0.1.0` updater;
@@ -466,7 +467,7 @@ For macOS production packages, also verify:
 - `s-gw doctor` finds the installed CLI, MCP server, native Keychain helper, and menu-bar app bundle;
 - `s-gw service install --start` loads the console LaunchAgent;
 - `s-gw menubar open` launches the menu-bar helper and sees pending requests;
-- normal macOS package or installer is signed and notarized, or an unsigned preview is explicitly labelled and manually installed;
+- macOS installers are signed and notarized, or explicitly documented as unsigned with the required Gatekeeper override;
 - install/uninstall leaves no raw secrets in logs or shell history.
 
 For Windows preview packages, also verify:

--- a/native/macos-app/Sources/SgwMac/Services/UpdateChecker.swift
+++ b/native/macos-app/Sources/SgwMac/Services/UpdateChecker.swift
@@ -73,7 +73,7 @@ actor UpdateChecker: UpdateChecking {
     private let cli = CLIRunner()
 
     static var currentVersion: String {
-        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.1.18-unsigned.3"
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.1.18"
     }
 
     static var usesSelfContainedRuntime: Bool {
@@ -381,8 +381,7 @@ actor UpdateChecker: UpdateChecking {
     }
 
     static func releaseAssetName(for version: String) -> String {
-        let cleanVersion = parseVersion(version)
-        return "s-gw-\(cleanVersion)-macos.dmg"
+        return "s-gw.dmg"
     }
 
     static func verifyChecksum(

--- a/native/macos-app/Tests/AppStateGuardTests.swift
+++ b/native/macos-app/Tests/AppStateGuardTests.swift
@@ -695,8 +695,8 @@ struct AppStateGuardTests {
       fail("the GitHub Atom fallback should parse the newest release entry")
     }
     check(release.version == "9.3.1", "Atom fallback should parse the release version")
-    check(release.assetName == "s-gw-9.3.1-macos.dmg", "Atom fallback should bind the exact installer name")
-    check(release.checksumAssetName == "s-gw-9.3.1-macos.dmg.sha256",
+    check(release.assetName == "s-gw.dmg", "Atom fallback should bind the primary installer name")
+    check(release.checksumAssetName == "s-gw.dmg.sha256",
           "Atom fallback should prefer the exact per-file checksum")
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@s-gw/s-gw",
-  "version": "0.1.18-unsigned.3",
+  "version": "0.1.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@s-gw/s-gw",
-      "version": "0.1.18-unsigned.3",
+      "version": "0.1.18",
       "license": "Apache-2.0",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-gw/s-gw",
-  "version": "0.1.18-unsigned.3",
+  "version": "0.1.18",
   "mcpName": "io.github.sgateway/s-gw",
   "description": "Local credential control for AI coding agents.",
   "type": "module",

--- a/scripts/build-installers.mjs
+++ b/scripts/build-installers.mjs
@@ -28,8 +28,8 @@ const version = packageInfo.version;
 const packedFile = `${packageInfo.name.replace(/^@/, "").replaceAll("/", "-")}-${version}.tgz`;
 const packageFile = `s-gw-${version}.tgz`;
 const legacyBridgeFile = `0-s-gw-legacy-${version}.tgz`;
-const macInstallerFile = `s-gw-${version}-macos.dmg`;
-const unsignedPreviewMacInstallerFile = `s-gw-${version}-macos-unsigned-preview.dmg`;
+const macInstallerFile = "s-gw.dmg";
+const versionedMacInstallerFile = `s-gw-${version}-macos.dmg`;
 const outputDir = resolve(root, "dist/installers");
 const workDir = mkdtempSync(resolve(tmpdir(), "s-gw-installers-"));
 
@@ -54,7 +54,7 @@ try {
   copyFileSync(packed, resolve(outputDir, packageFile));
   buildLegacyBridge(packed, resolve(outputDir, legacyBridgeFile), version);
 
-  const artifacts = [legacyBridgeFile, packageFile, basename(macArtifact.path), basename(windowsArtifact)];
+  const artifacts = [legacyBridgeFile, packageFile, ...macArtifact.paths.map((file) => basename(file)), basename(windowsArtifact)];
   const checksumLines = artifacts.map((name) => `${sha256(resolve(outputDir, name))}  ${name}`);
   writeFileSync(resolve(outputDir, "SHA256SUMS.txt"), `${checksumLines.join("\n")}\n`);
 
@@ -87,30 +87,28 @@ function buildMacInstaller(packed) {
   writeFileSync(resolve(stageRoot, "README.txt"), macInstallReadme(signing));
 
   signMacApp(appRoot, signing);
-  const target = resolve(outputDir, macInstallerFileName(signing));
+  const target = resolve(outputDir, macInstallerFile);
   run("hdiutil", ["create", "-volname", `s-gw ${version}`, "-srcfolder", stageRoot, "-ov", "-format", "UDZO", target], root);
   signMacDmg(target, signing);
   notarizeMacDmg(target, signing);
+  const compatibilityTarget = resolve(outputDir, versionedMacInstallerFile);
+  copyFileSync(target, compatibilityTarget);
   return {
-    path: target,
+    paths: [target, compatibilityTarget],
     releaseTag: releaseTagFor(signing),
     distribution: signing.distribution,
     notarized: signing.requireNotarization
   };
 }
 
-function macInstallerFileName(signing) {
-  return signing.distribution === "unsigned-preview" ? unsignedPreviewMacInstallerFile : macInstallerFile;
-}
-
 function macInstallReadme(signing) {
   const releaseTag = releaseTagFor(signing);
-  const npmInstall = signing.distribution === "unsigned-preview"
+  const npmInstall = signing.distribution === "unsigned"
     ? `npm install -g https://github.com/sgateway/s-gw/releases/download/${releaseTag}/s-gw-${version}.tgz`
     : "npm install -g @s-gw/s-gw";
-  const trustNotice = signing.distribution === "unsigned-preview"
+  const trustNotice = signing.distribution === "unsigned"
     ? [
-      "This is an unsigned macOS preview. It is not signed with an Apple Developer ID or notarized.",
+      "This macOS release is not signed with an Apple Developer ID or notarized.",
       "macOS will require an explicit Gatekeeper override before it opens."
     ]
     : signing.distribution === "notarized"
@@ -127,18 +125,12 @@ function macInstallReadme(signing) {
     "",
     "Prefer not to use a macOS security override? Install the CLI package instead (Node.js 20+ required):",
     npmInstall,
-    "s-gw setup",
-    ...(signing.distribution === "unsigned-preview" ? [] : [
-      "",
-      "For an unsigned preview that is not in npm yet, use the exact .tgz link in the GitHub release notes."
-    ])
+    "s-gw setup"
   ].join("\n")}\n`;
 }
 
 function releaseTagFor(signing) {
-  const expected = signing.distribution === "unsigned-preview"
-    ? `unsigned-macos-preview-v${version}`
-    : `v${version}`;
+  const expected = `v${version}`;
   const configured = process.env.SGW_RELEASE_TAG?.trim();
   if (configured && configured !== expected) {
     throw new Error(`SGW_RELEASE_TAG must be ${expected} for this distribution.`);
@@ -310,17 +302,14 @@ function signingConfiguration() {
   const notaryProfile = process.env.SGW_NOTARY_PROFILE?.trim();
   const distribution = process.env.SGW_MACOS_DISTRIBUTION?.trim() || "local";
 
-  if (!["local", "notarized", "unsigned-preview"].includes(distribution)) {
-    throw new Error("SGW_MACOS_DISTRIBUTION must be local, notarized, or unsigned-preview.");
+  if (!["local", "notarized", "unsigned"].includes(distribution)) {
+    throw new Error("SGW_MACOS_DISTRIBUTION must be local, notarized, or unsigned.");
   }
   if (distribution === "notarized" && !requireNotarization) {
     throw new Error("A notarized distribution requires SGW_REQUIRE_NOTARIZATION=1.");
   }
-  if (distribution === "unsigned-preview" && (identity !== "-" || requireNotarization)) {
-    throw new Error("An unsigned preview must use the ad-hoc signing identity and no notarization.");
-  }
-  if (distribution === "unsigned-preview" && !/^\d+\.\d+\.\d+-unsigned\.\d+$/.test(version)) {
-    throw new Error("An unsigned preview requires a package version such as 0.1.18-unsigned.1.");
+  if (distribution === "unsigned" && (identity !== "-" || requireNotarization)) {
+    throw new Error("An unsigned distribution must use the ad-hoc signing identity and no notarization.");
   }
 
   if (requireNotarization && identity === "-") {

--- a/scripts/validate-release-assets.mjs
+++ b/scripts/validate-release-assets.mjs
@@ -10,12 +10,12 @@ const packageInfo = JSON.parse(await readFile(path.join(root, "package.json"), "
 const directory = path.resolve(process.argv[2] || path.join(root, "dist", "installers"));
 const selected = await validateReleaseDirectory(directory, packageInfo.version);
 const releaseMetadata = JSON.parse(await readFile(path.join(directory, "RELEASE.json"), "utf8"));
-const distributions = new Set(["local", "notarized", "unsigned-preview"]);
+const distributions = new Set(["local", "notarized", "unsigned"]);
 if (!distributions.has(releaseMetadata.macosDistribution) || typeof releaseMetadata.notarized !== "boolean" || typeof releaseMetadata.releaseTag !== "string") {
   throw new Error("RELEASE.json must declare the macOS distribution and notarization state.");
 }
-if (releaseMetadata.macosDistribution === "unsigned-preview" && releaseMetadata.notarized) {
-  throw new Error("An unsigned macOS preview cannot claim notarization.");
+if (releaseMetadata.macosDistribution === "unsigned" && releaseMetadata.notarized) {
+  throw new Error("An unsigned macOS distribution cannot claim notarization.");
 }
 const legacyBridgeName = `0-s-gw-legacy-${packageInfo.version}.tgz`;
 const legacyBridgePath = path.join(directory, legacyBridgeName);
@@ -35,16 +35,14 @@ await verifyReleasePackageChecksum(
   "per-file"
 );
 
-const macSuffix = releaseMetadata.macosDistribution === "unsigned-preview" ? "-unsigned-preview" : "";
-const macDmgName = `s-gw-${packageInfo.version}-macos${macSuffix}.dmg`;
-const expectedReleaseTag = releaseMetadata.macosDistribution === "unsigned-preview"
-  ? `unsigned-macos-preview-v${packageInfo.version}`
-  : `v${packageInfo.version}`;
+const macDmgName = "s-gw.dmg";
+const compatibilityDmgName = `s-gw-${packageInfo.version}-macos.dmg`;
+const expectedReleaseTag = `v${packageInfo.version}`;
 if (releaseMetadata.releaseTag !== expectedReleaseTag) {
   throw new Error(`RELEASE.json must use ${expectedReleaseTag} for this distribution.`);
 }
-if (!Array.isArray(releaseMetadata.artifacts) || !releaseMetadata.artifacts.includes(macDmgName)) {
-  throw new Error(`RELEASE.json does not list ${macDmgName}.`);
+if (!Array.isArray(releaseMetadata.artifacts) || !releaseMetadata.artifacts.includes(macDmgName) || !releaseMetadata.artifacts.includes(compatibilityDmgName)) {
+  throw new Error(`RELEASE.json must list ${macDmgName} and ${compatibilityDmgName}.`);
 }
 const macDmg = path.join(directory, macDmgName);
 await verifyReleasePackageChecksum(
@@ -55,6 +53,17 @@ await verifyReleasePackageChecksum(
 await verifyReleasePackageChecksum(
   macDmg,
   await readFile(path.join(directory, `${macDmgName}.sha256`), "utf8"),
+  "per-file"
+);
+const compatibilityDmg = path.join(directory, compatibilityDmgName);
+await verifyReleasePackageChecksum(
+  compatibilityDmg,
+  await readFile(path.join(directory, "SHA256SUMS.txt"), "utf8"),
+  "sha256sums"
+);
+await verifyReleasePackageChecksum(
+  compatibilityDmg,
+  await readFile(path.join(directory, `${compatibilityDmgName}.sha256`), "utf8"),
   "per-file"
 );
 if (process.platform === "darwin" && existsSync(macDmg)) {

--- a/scripts/verify-macos-dmg.mjs
+++ b/scripts/verify-macos-dmg.mjs
@@ -58,9 +58,8 @@ try {
   }
   const readme = readFileSync(readmePath, "utf8");
   const packageVersion = JSON.parse(readFileSync(path.join(packageRoot, "package.json"), "utf8")).version;
-  const npmInstall = packageVersion.includes("-unsigned.")
-    ? `npm install -g https://github.com/sgateway/s-gw/releases/download/unsigned-macos-preview-v${packageVersion}/s-gw-${packageVersion}.tgz`
-    : "npm install -g @s-gw/s-gw";
+  const releaseNpmInstall = `npm install -g https://github.com/sgateway/s-gw/releases/download/v${packageVersion}/s-gw-${packageVersion}.tgz`;
+  const npmInstall = readme.includes(releaseNpmInstall) ? releaseNpmInstall : "npm install -g @s-gw/s-gw";
   if (!readme.includes(npmInstall) || !readme.includes("s-gw setup")) {
     throw new Error("The DMG installation guidance must include the matching npm alternative.");
   }

--- a/server.json
+++ b/server.json
@@ -15,13 +15,13 @@
     "url": "https://github.com/sgateway/s-gw",
     "source": "github"
   },
-  "version": "0.1.18-unsigned.3",
+  "version": "0.1.18",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@s-gw/s-gw",
-      "version": "0.1.18-unsigned.3",
+      "version": "0.1.18",
       "runtimeHint": "npx",
       "runtimeArguments": [
         {

--- a/src/console-ui/src/App.tsx
+++ b/src/console-ui/src/App.tsx
@@ -8,11 +8,13 @@ import {
   Bell,
   CheckCircle2,
   ChevronDown,
+  ChevronRight,
   Circle,
   Clock3,
   Command as CommandIcon,
   Copy,
   Download,
+  EyeOff,
   ExternalLink,
   FileKey2,
   Gauge,
@@ -1411,10 +1413,56 @@ function UsageFlowView({ state }: { state: ConsoleState }) {
   );
 }
 
+function PolicyShadowBadge({
+  rule,
+  shadowedBy
+}: {
+  rule: ApprovalPolicyRuleRecord;
+  shadowedBy?: ApprovalPolicyRuleRecord;
+}) {
+  if (!shadowedBy) return null;
+  const unreachable = shadowedBy.decision !== rule.decision;
+  const label = unreachable ? "Never runs" : "Redundant";
+  const description = unreachable
+    ? `“${shadowedBy.name}” matches first with a different decision.`
+    : `“${shadowedBy.name}” already covers this rule with the same decision.`;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Badge variant={unreachable ? "destructive" : "secondary"} className="shrink-0 gap-1">
+          <EyeOff className="h-3 w-3" />
+          {label}
+        </Badge>
+      </TooltipTrigger>
+      <TooltipContent>{description}</TooltipContent>
+    </Tooltip>
+  );
+}
+
+function PolicyConditionsCell({ conditions }: { conditions: ApprovalPolicyRuleRecord["conditions"] }) {
+  const agents = conditions.agents || [];
+  const restSummary = policyConditionSummary({ ...conditions, agents: undefined });
+  const hasRest = restSummary !== "All matching credential requests" || agents.length === 0;
+
+  return (
+    <div className="flex flex-wrap items-center gap-1.5">
+      {agents.map((agent) => (
+        <span key={agent} className="inline-flex items-center gap-1 rounded-md bg-muted px-1.5 py-0.5 text-xs">
+          <AgentIcon name={agent} className="h-4 w-4" />
+          {titleCase(agent)}
+        </span>
+      ))}
+      {hasRest ? <span className="truncate text-sm text-muted-foreground">{restSummary}</span> : null}
+    </div>
+  );
+}
+
 function PoliciesView({ state, onDone, search }: { state: ConsoleState; onDone: () => void; search: string }) {
   const [editing, setEditing] = React.useState<ApprovalPolicyRuleRecord | null>(null);
   const [adding, setAdding] = React.useState(false);
   const [deleting, setDeleting] = React.useState<ApprovalPolicyRuleRecord | null>(null);
+  const [expandedId, setExpandedId] = React.useState<string | null>(null);
   const [arranging, setArranging] = React.useState(false);
   const rows = filterText(state.approvalPolicyRules, search, (rule) => `${rule.name} ${rule.decision} ${policyConditionSummary(rule.conditions)}`);
   const shadowedBy = React.useMemo(() => {
@@ -1454,11 +1502,15 @@ function PoliciesView({ state, onDone, search }: { state: ConsoleState; onDone: 
     }
   }
 
+  function toggleDetails(id: string) {
+    setExpandedId((current) => current === id ? null : id);
+  }
+
   return (
     <PageFrame title="Policies" description="Define when agents may use credentials without interrupting you, and when s-gw should always ask or deny.">
       <div className="flex flex-wrap items-center justify-between gap-3">
         <p className="max-w-3xl text-sm text-muted-foreground">
-          Rules run in priority order. Auto-arrange moves narrower rules ahead of broader ask and allow rules; deny rules stay ahead as guardrails.
+          Rules run in the order shown. Auto-arrange moves narrower rules ahead of broader ask and allow rules; deny rules stay ahead as guardrails.
         </p>
         <div className="flex gap-2">
           <Button variant="outline" disabled={arranging} onClick={() => void arrange()} data-policy-arrange>
@@ -1495,47 +1547,84 @@ function PoliciesView({ state, onDone, search }: { state: ConsoleState; onDone: 
                 </TableCell>
               </TableRow>
             ) : null}
-            {rows.map((rule) => (
-              <TableRow key={rule.id} data-policy-row={rule.id} className={cn(shadowedBy.has(rule.id) && "bg-amber-500/5")}>
-                <TableCell>
-                  <PolicyStatusControl rule={rule} onDone={onDone} />
-                </TableCell>
-                <TableCell className="font-medium">
-                  <div className="flex min-w-0 items-center gap-2">
-                    <span className="truncate">{rule.name}</span>
-                    {rule.demo ? <DemoBadge /> : null}
-                    {shadowedBy.get(rule.id) ? (
-                      <Badge variant="secondary" className="shrink-0 text-amber-700 dark:text-amber-300" title={`Covered by ${shadowedBy.get(rule.id)?.name}`}>
-                        Shadowed
-                      </Badge>
-                    ) : null}
-                  </div>
-                </TableCell>
-                <TableCell><DecisionBadge decision={rule.decision} /></TableCell>
-                <TableCell className="max-w-[560px] truncate">{policyConditionSummary(rule.conditions)}</TableCell>
-                <TableCell className="text-right whitespace-nowrap">
-                  <Button
-                    variant="ghost"
-                    size="icon-sm"
-                    aria-label={`Edit ${rule.name}`}
-                    onClick={() => setEditing(rule)}
-                    disabled={rule.demo}
-                    data-policy-edit={rule.id}
+            {rows.map((rule) => {
+              const coveringRule = shadowedBy.get(rule.id);
+              const expanded = expandedId === rule.id;
+              return (
+                <React.Fragment key={rule.id}>
+                  <TableRow
+                    data-policy-row={rule.id}
+                    aria-expanded={expanded}
+                    tabIndex={0}
+                    onClick={() => toggleDetails(rule.id)}
+                    onKeyDown={(event) => {
+                      if (event.target !== event.currentTarget) return;
+                      if (event.key !== "Enter" && event.key !== " ") return;
+                      event.preventDefault();
+                      toggleDetails(rule.id);
+                    }}
+                    className={cn("cursor-pointer", coveringRule && "bg-amber-500/5", expanded && "bg-muted/40")}
                   >
-                    <Pencil className="h-4 w-4" />
-                  </Button>
-                  <Button
-                    variant="ghost"
-                    size="icon-sm"
-                    aria-label={`Delete ${rule.name}`}
-                    onClick={() => setDeleting(rule)}
-                    disabled={rule.demo}
-                  >
-                    <Trash2 className="h-4 w-4" />
-                  </Button>
-                </TableCell>
-              </TableRow>
-            ))}
+                    <TableCell onClick={(event) => event.stopPropagation()}>
+                      <PolicyStatusControl rule={rule} onDone={onDone} />
+                    </TableCell>
+                    <TableCell className="font-medium">
+                      <div className="flex min-w-0 items-center gap-2">
+                        <span className="truncate">{rule.name}</span>
+                        {rule.demo ? <DemoBadge /> : null}
+                        <PolicyShadowBadge rule={rule} shadowedBy={coveringRule} />
+                      </div>
+                    </TableCell>
+                    <TableCell><DecisionBadge decision={rule.decision} /></TableCell>
+                    <TableCell className="max-w-[560px]"><PolicyConditionsCell conditions={rule.conditions} /></TableCell>
+                    <TableCell className="text-right whitespace-nowrap" onClick={(event) => event.stopPropagation()}>
+                      <Button
+                        variant="ghost"
+                        size="icon-sm"
+                        aria-label={expanded ? `Hide details for ${rule.name}` : `Show details for ${rule.name}`}
+                        onClick={() => toggleDetails(rule.id)}
+                        disabled={rule.demo}
+                        data-policy-expand={rule.id}
+                      >
+                        <ChevronRight className={cn("h-4 w-4 transition-transform", expanded && "rotate-90")} />
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="icon-sm"
+                        aria-label={`Edit ${rule.name}`}
+                        onClick={() => setEditing(rule)}
+                        disabled={rule.demo}
+                        data-policy-edit={rule.id}
+                      >
+                        <Pencil className="h-4 w-4" />
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="icon-sm"
+                        aria-label={`Delete ${rule.name}`}
+                        onClick={() => setDeleting(rule)}
+                        disabled={rule.demo}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                  {expanded ? (
+                    <TableRow className="bg-muted/20 hover:bg-muted/20">
+                      <TableCell colSpan={5} className="p-0">
+                        <PolicyDetailPanel
+                          rule={rule}
+                          state={state}
+                          shadowedBy={coveringRule}
+                          onEdit={() => setEditing(rule)}
+                          onDelete={() => setDeleting(rule)}
+                        />
+                      </TableCell>
+                    </TableRow>
+                  ) : null}
+                </React.Fragment>
+              );
+            })}
           </TableBody>
         </Table>
       </DataCard>
@@ -1566,6 +1655,78 @@ function PoliciesView({ state, onDone, search }: { state: ConsoleState; onDone: 
       </AlertDialog>
     </PageFrame>
   );
+}
+
+function PolicyDetailPanel({
+  rule,
+  state,
+  shadowedBy,
+  onEdit,
+  onDelete
+}: {
+  rule: ApprovalPolicyRuleRecord;
+  state: ConsoleState;
+  shadowedBy?: ApprovalPolicyRuleRecord;
+  onEdit: () => void;
+  onDelete: () => void;
+}) {
+  const conditions = rule.conditions;
+  const bindings = (conditions.envBindings || []).map((binding) => {
+    const handle = state.handles.find((item) => item.handle === binding.handle);
+    return `${binding.injectEnv} → ${handle?.name || shortHandle(binding.handle)}`;
+  });
+  const coveredBySameDecision = shadowedBy?.decision === rule.decision;
+
+  return (
+    <div className="space-y-5 px-4 py-5 lg:px-6" data-policy-detail={rule.id}>
+      <PolicyFlowPreview form={policyFormFromRule(rule)} state={state} />
+      {shadowedBy ? (
+        <Alert variant={coveredBySameDecision ? "default" : "destructive"}>
+          <EyeOff className="h-4 w-4" />
+          <AlertTitle>{coveredBySameDecision ? "Redundant rule" : "Rule never runs"}</AlertTitle>
+          <AlertDescription>
+            {coveredBySameDecision
+              ? `“${shadowedBy.name}” already covers the same requests with the same decision.`
+              : `“${shadowedBy.name}” runs first with a different decision, so this rule cannot take effect.`}
+          </AlertDescription>
+        </Alert>
+      ) : null}
+      {rule.demo ? (
+        <Alert>
+          <AlertTitle>Demo policy</AlertTitle>
+          <AlertDescription>Demo policies are read-only and never evaluated.</AlertDescription>
+        </Alert>
+      ) : null}
+      <DetailGrid
+        rows={[
+          ["Evaluation order", `Priority ${rule.priority} · ${rule.enabled ? "Enabled" : "Disabled"}`],
+          ["Decision", titleCase(rule.decision)],
+          ["Agents", policyDetailValue(conditions.agents)],
+          ["Credentials", bindings.length > 0 ? bindings.join(", ") : policyDetailValue(conditions.handles, (handle) => state.handles.find((item) => item.handle === handle)?.name || shortHandle(handle))],
+          ["Action", policyDetailValue([...(conditions.actionKinds || []), ...(conditions.commands || [])])],
+          ["Scope", policyDetailValue([...(conditions.providers || []), ...(conditions.secretTypes || []), conditions.minSeverity ? `${conditions.minSeverity} and above` : ""])],
+          ["Environment", policyDetailValue([...(conditions.injectEnvs || []), ...(conditions.workingDirs || [])])],
+          ["SSH", policyDetailValue([...(conditions.sshTargets || []), ...(conditions.sshPorts || []).map(String)])],
+          ["Expires", rule.expiresAt ? new Date(rule.expiresAt).toLocaleString() : "Never"],
+          ["Updated", relativeTime(rule.updatedAt)]
+        ]}
+      />
+      <div className="flex flex-wrap items-center justify-end gap-2 border-t pt-4">
+        <Button variant="outline" onClick={onEdit} disabled={rule.demo}>
+          <Pencil className="mr-2 h-4 w-4" />Edit rule
+        </Button>
+        <Button variant="outline" className="text-destructive hover:text-destructive" onClick={onDelete} disabled={rule.demo}>
+          <Trash2 className="mr-2 h-4 w-4" />Delete rule
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function policyDetailValue(values: Array<string | number> | undefined, label?: (value: string) => string): string {
+  if (!values || values.length === 0) return "Any";
+  const labels = values.map((value) => label ? label(String(value)) : String(value)).filter(Boolean);
+  return labels.length > 0 ? labels.join(", ") : "Any";
 }
 
 function PolicyStatusControl({

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const CURRENT_VERSION = "0.1.18-unsigned.3";
+export const CURRENT_VERSION = "0.1.18";

--- a/tests/console-browser-e2e.test.ts
+++ b/tests/console-browser-e2e.test.ts
@@ -101,6 +101,44 @@ describeBrowser("React local console (real headless Chrome)", () => {
     );
   }, 45_000);
 
+  it("expands a policy without changing its hardened edit path", async () => {
+    process.env.SGW_MASTER_PASSPHRASE = "policy-detail-browser-passphrase";
+    running = await startConsoleServer({ port: 0 });
+    const policy = await api<{ id: string }>("api/approval/policies", {
+      name: "Detailed SSH policy",
+      decision: "ask",
+      priority: 7,
+      agents: ["Codex"],
+      actionKinds: ["ssh_session"],
+      commands: ["ssh"],
+      sshTargets: ["git@github.com"],
+      sshPorts: [2222]
+    });
+    const launched = await launchChrome(new URL("policies", running.url).toString());
+    cdp = launched.cdp;
+
+    await waitFor(
+      () => cdp!.eval<boolean>(`Boolean(document.querySelector('[data-policy-expand="${policy.id}"]'))`),
+      "policy detail control"
+    );
+    await clickElement(cdp, `[data-policy-expand="${policy.id}"]`);
+    await waitFor(
+      () => cdp!.eval<boolean>(`Boolean(document.querySelector('[data-policy-detail="${policy.id}"]'))`),
+      "expanded policy detail"
+    );
+    const detail = await cdp.eval<string>(`document.querySelector('[data-policy-detail="${policy.id}"]').innerText`);
+    expect(detail).toContain("Evaluation order");
+    expect(detail).toContain("git@github.com");
+    expect(detail).toContain("2222");
+
+    await clickElement(cdp, `[data-policy-edit="${policy.id}"]`);
+    await waitFor(
+      () => cdp!.eval<boolean>("Boolean(document.querySelector('[role=dialog]'))"),
+      "policy editor"
+    );
+    expect(await cdp.eval<boolean>(`Boolean(document.querySelector('[data-policy-detail="${policy.id}"]'))`)).toBe(true);
+  }, 45_000);
+
   it("shows a release notification from the public update feed", async () => {
     const installer = process.platform === "darwin"
       ? "s-gw-0.1.1-macos.dmg"

--- a/tests/console-ui-source.test.ts
+++ b/tests/console-ui-source.test.ts
@@ -181,6 +181,24 @@ describe("React console source contracts", () => {
     expect(store).toContain("exactBindingsWouldConflict");
   });
 
+  it("shows policy details without replacing hardened policy evaluation", async () => {
+    const [app, policyOrder] = await Promise.all([
+      readFile(path.join(repoRoot, "src/console-ui/src/App.tsx"), "utf8"),
+      readFile(path.join(repoRoot, "src/policy-order.ts"), "utf8")
+    ]);
+
+    expect(app).toContain("function PolicyDetailPanel");
+    expect(app).toContain("data-policy-detail={rule.id}");
+    expect(app).toContain("data-policy-expand={rule.id}");
+    expect(app).toContain("function PolicyShadowBadge");
+    expect(app).toContain("findShadowingPolicyRule(state.approvalPolicyRules, rule)");
+    expect(app).toContain("conditions.envBindings");
+    expect(app).toContain("conditions.sshPorts");
+    expect(app).toContain("<PolicyEditorDialog");
+    expect(policyOrder).toContain("bindingSetCovers");
+    expect(policyOrder).toContain("compareApprovalPolicyRules");
+  });
+
   it("keeps settings sections compact and approval durations readable", async () => {
     const [app, tabs] = await Promise.all([
       readFile(path.join(repoRoot, "src/console-ui/src/App.tsx"), "utf8"),

--- a/tests/installers.test.ts
+++ b/tests/installers.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it } from "vitest";
 const root = process.cwd();
 
 describe("platform installers", () => {
-  it("builds versioned Mac and Windows artifacts from the package tarball", async () => {
+  it("builds a primary Mac DMG, a compatibility copy, and Windows artifacts from the package tarball", async () => {
     const [pkgRaw, builder, inspectorSource] = await Promise.all([
       readFile(path.join(root, "package.json"), "utf8"),
       readFile(path.join(root, "scripts/build-installers.mjs"), "utf8"),
@@ -32,8 +32,8 @@ describe("platform installers", () => {
     expect(pkg.files).not.toContain("native/macos-app/Sources");
     expect(pkg.files).not.toContain("native/menu-bar-helper/Sources");
     expect(builder).toContain("hdiutil");
+    expect(builder).toContain('const macInstallerFile = "s-gw.dmg"');
     expect(builder).toContain("s-gw-${version}-macos.dmg");
-    expect(builder).toContain("s-gw-${version}-macos-unsigned-preview.dmg");
     expect(builder).toContain("s-gw-${version}-windows.zip");
     expect(builder).toContain('const packageFile = `s-gw-${version}.tgz`');
     expect(builder).toContain("SHA256SUMS.txt");
@@ -103,7 +103,7 @@ describe("platform installers", () => {
     expect(builder).toContain('writeLauncher(resolve(binDir, "s-gw-mcp")');
     expect(builder).toContain("SGW_REQUIRE_NOTARIZATION");
     expect(builder).toContain("SGW_MACOS_DISTRIBUTION");
-    expect(builder).toContain("unsigned-preview");
+    expect(builder).toContain('signing.distribution === "unsigned"');
     expect(builder).toContain("README.txt");
     expect(builder).toContain("npm install -g https://github.com/sgateway/s-gw/releases/download");
     expect(builder).toContain("Prefer not to use a macOS security override?");
@@ -117,7 +117,7 @@ describe("platform installers", () => {
     expect(verifier).toContain('path.join(runtimeRoot, "bin", "s-gw")');
     expect(verifier).toContain("runMcpSmoke");
     expect(verifier).toContain("SGW_TEST_HOME_ROOT");
-    expect(verifier).toContain("const npmInstall = packageVersion.includes");
+    expect(verifier).toContain("const releaseNpmInstall");
     expect(verifier).toContain("readme.includes(npmInstall)");
     expect(runtime.node.version).toMatch(/^24\./);
     expect(runtime.node.url).toContain(`v${runtime.node.version}/node-v${runtime.node.version}-darwin-arm64.tar.gz`);
@@ -184,7 +184,7 @@ describe("platform installers", () => {
     expect(workflow).toContain("release_tag:");
     expect(workflow).toContain("publish_release:");
     expect(workflow).toContain("macos_distribution:");
-    expect(workflow).toContain("unsigned-preview");
+    expect(workflow).toContain("- unsigned");
     expect(assetJob).toContain("ref: ${{ inputs.release_tag }}");
     expect(assetJob).toContain('SGW_REQUIRE_RUST_CORE: "1"');
     expect(assetJob).toContain("SGW_RUST_CORE_DIR: ${{ github.workspace }}/.private/sgw-core");
@@ -203,11 +203,12 @@ describe("platform installers", () => {
     expect(assetJob).toContain("SGW_MACOS_SIGN_IDENTITY=$identity");
     expect(assetJob).toContain("SGW_REQUIRE_NOTARIZATION=1");
     expect(assetJob).toContain("SGW_MACOS_DISTRIBUTION=notarized");
-    expect(assetJob).toContain("SGW_MACOS_DISTRIBUTION=unsigned-preview");
+    expect(assetJob).toContain("SGW_MACOS_DISTRIBUTION=unsigned");
     expect(assetJob).toContain("spctl --assess");
-    expect(assetJob).toContain("s-gw-${package_version}-macos-unsigned-preview.dmg");
-    expect(assetJob).toContain("--prerelease --latest=false");
-    expect(assetJob).toContain("unsigned-macos-preview-v${package_version}");
+    expect(assetJob).toContain('"dist/installers/s-gw.dmg"');
+    expect(assetJob).toContain('"dist/installers/s-gw-${package_version}-macos.dmg"');
+    expect(assetJob).not.toContain("--prerelease --latest=false");
+    expect(assetJob).not.toContain("unsigned-macos-preview-v${package_version}");
     expect(assetJob).toContain("npm install -g https://github.com/${GITHUB_REPOSITORY}");
     expect(assetJob).toContain("If you prefer not to override Gatekeeper");
     expect(assetJob).toContain("Create or verify a draft release");

--- a/tests/native-update.test.ts
+++ b/tests/native-update.test.ts
@@ -70,7 +70,7 @@ describe("native macOS update lifecycle", () => {
     expect(state).not.toContain("updateRetryInterval");
     expect(checker).toContain('"sha256sums.txt"');
     expect(checker).toContain("entry.fileName == assetName");
-    expect(checker).toContain('return "s-gw-\\(cleanVersion)-macos.dmg"');
+    expect(checker).toContain('return "s-gw.dmg"');
     expect(checker).toContain("static var usesSelfContainedRuntime");
     expect(checker).toContain('$0.state?.lowercased() == "uploaded"');
     expect(checker).toContain("for release in candidates");


### PR DESCRIPTION
Standard 0.1.18 release with the policy presentation improvements, demo data, resilient updater behavior, and a self-contained unsigned macOS installer.

- Primary download: `s-gw.dmg`
- Compatibility asset: `s-gw-0.1.18-macos.dmg`
- Existing clients continue to discover the stable release; the exact release tarball is the Gatekeeper-free fallback.

Verified locally: full isolated Vitest suite (373 tests), TypeScript/Rust/package checks, audit, and mounted DMG smoke test.