### PR TITLE
Make npm the primary install path

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,11 @@ on:
         required: true
         default: true
         type: boolean
+      publish_npm_only:
+        description: Publish the tagged npm package without rebuilding or changing an existing GitHub release
+        required: true
+        default: false
+        type: boolean
       macos_distribution:
         description: macOS distribution. Unsigned releases remain discoverable but require a Gatekeeper override.
         required: true
@@ -30,7 +35,7 @@ permissions:
 
 jobs:
   release-assets:
-    if: github.repository == 'sgateway/s-gw'
+    if: github.repository == 'sgateway/s-gw' && !inputs.publish_npm_only
     runs-on: macos-15
     permissions:
       contents: write
@@ -149,26 +154,25 @@ jobs:
       - name: Prepare release notes
         run: |
           set -euo pipefail
-          package_version="$(node -p "require('./package.json').version")"
           notes="$RUNNER_TEMP/release-notes.md"
-          if [ "$MACOS_DISTRIBUTION" = "unsigned" ]; then
-            cat > "$notes" <<EOF
-          ## macOS installation
+          cat > "$notes" <<EOF
+          ## Install
 
-          The Apple Silicon DMG in this release is not Developer ID signed or notarized, so macOS will require an explicit Gatekeeper override to open it. Drag \`s-gw.app\` from \`s-gw.dmg\` to Applications, then open it to complete setup.
-
-          If you prefer not to override Gatekeeper, install this exact release through npm instead (Node.js 20+):
+          The recommended installation path on macOS, Windows, and Linux is the public npm package (Node.js 20+):
 
           \`\`\`bash
-          npm install -g https://github.com/${GITHUB_REPOSITORY}/releases/download/${RELEASE_TAG}/s-gw-${package_version}.tgz
+          npm install -g @s-gw/s-gw
           s-gw setup
           \`\`\`
-          EOF
-          else
-            cat > "$notes" <<EOF
-          ## macOS installation
 
-          Drag \`s-gw.app\` from the Apple Silicon DMG to Applications, then open it to complete setup.
+          ## macOS desktop alternative
+
+          The Apple Silicon DMG is self-contained. Drag \`s-gw.app\` from \`s-gw.dmg\` to Applications, then open it to complete setup.
+          EOF
+          if [ "$MACOS_DISTRIBUTION" = "unsigned" ]; then
+            cat >> "$notes" <<EOF
+
+          This DMG is not Developer ID signed or notarized, so macOS requires an explicit Gatekeeper override to open it. Use the npm installation above if you do not want to use that override.
           EOF
           fi
           echo "SGW_RELEASE_NOTES=$notes" >> "$GITHUB_ENV"
@@ -224,8 +228,8 @@ jobs:
           done
 
   publish-release:
-    needs: release-assets
-    if: github.repository == 'sgateway/s-gw' && inputs.publish_release
+    needs: [release-assets, publish-npm]
+    if: always() && github.repository == 'sgateway/s-gw' && !inputs.publish_npm_only && inputs.publish_release && needs.release-assets.result == 'success' && needs.publish-npm.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -244,8 +248,8 @@ jobs:
           test "$(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json isDraft --jq '.isDraft')" = "false"
 
   publish-npm:
-    needs: publish-release
-    if: github.repository == 'sgateway/s-gw' && needs.publish-release.result == 'success' && inputs.macos_distribution == 'notarized'
+    needs: release-assets
+    if: always() && github.repository == 'sgateway/s-gw' && (inputs.publish_npm_only || (inputs.publish_release && needs.release-assets.result == 'success'))
     runs-on: macos-15
     environment: npm
     permissions:
@@ -297,23 +301,45 @@ jobs:
             lipo "$binary" -verify_arch arm64
           done
 
+      - name: Record local npm package integrity
+        run: |
+          set -euo pipefail
+          pack_dir="$RUNNER_TEMP/s-gw-npm-pack"
+          mkdir -p "$pack_dir"
+          npm pack --json --ignore-scripts --pack-destination "$pack_dir" > "$pack_dir/pack.json"
+          package_integrity="$(node -e 'const fs = require("node:fs"); const [{ integrity }] = JSON.parse(fs.readFileSync(process.argv[1], "utf8")); process.stdout.write(integrity || "");' "$pack_dir/pack.json")"
+          test -n "$package_integrity"
+          echo "SGW_NPM_PACKAGE_INTEGRITY=$package_integrity" >> "$GITHUB_ENV"
+
       - name: Publish to npm
-        run: npm publish --access public --ignore-scripts
+        run: |
+          set -euo pipefail
+          package_version="$(node -p "require('./package.json').version")"
+          published_integrity="$(npm view "@s-gw/s-gw@${package_version}" dist.integrity 2>/dev/null || true)"
+          if [ -n "$published_integrity" ]; then
+            test "$published_integrity" = "$SGW_NPM_PACKAGE_INTEGRITY"
+            echo "@s-gw/s-gw@${package_version} is already published with the verified package integrity."
+            exit 0
+          fi
+          npm publish --access public --ignore-scripts
 
       - name: Verify published npm package
         run: |
           package_version="$(node -p "require('./package.json').version")"
           prefix="${RUNNER_TEMP}/s-gw-npm-${package_version}"
+          published_integrity=""
           installed=0
           for _ in 1 2 3 4 5 6; do
             rm -rf "$prefix"
-            if npm install --global --prefix "$prefix" --ignore-scripts --no-audit --no-fund --prefer-online "@s-gw/s-gw@${package_version}"; then
+            published_integrity="$(npm view "@s-gw/s-gw@${package_version}" dist.integrity 2>/dev/null || true)"
+            if [ "$published_integrity" = "$SGW_NPM_PACKAGE_INTEGRITY" ] && npm install --global --prefix "$prefix" --ignore-scripts --no-audit --no-fund --prefer-online "@s-gw/s-gw@${package_version}"; then
               installed=1
               break
             fi
             sleep 10
           done
           test "$installed" = 1
+          test "$published_integrity" = "$SGW_NPM_PACKAGE_INTEGRITY"
 
           package_root="$prefix/lib/node_modules/@s-gw/s-gw"
           test -x "$prefix/bin/s-gw"
@@ -331,7 +357,7 @@ jobs:
 
   publish-registry:
     needs: publish-npm
-    if: always() && github.repository == 'sgateway/s-gw' && inputs.macos_distribution == 'notarized' && needs.publish-npm.result == 'success'
+    if: always() && github.repository == 'sgateway/s-gw' && !inputs.publish_npm_only && inputs.publish_release && needs.publish-npm.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Notable changes to s-gw are documented here. The project follows [Semantic Versioning](https://semver.org/) once public releases begin.
 
+## Unreleased
+
+### Changed
+
+- `npm install -g @s-gw/s-gw` is now the primary documented installation path on macOS, Windows, and Linux. The self-contained Apple Silicon DMG remains a desktop alternative.
+- Release automation publishes and verifies the npm package before it makes the GitHub release public, regardless of whether the macOS DMG is notarized. A recovery-only npm publish mode can repair a previously released version without changing its GitHub release.
+
 ## 0.1.18 - 2026-07-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -96,18 +96,7 @@ The agent never needs the unlock passphrase or raw credential. Approval is scope
 
 ## Quick Start
 
-On an Apple Silicon Mac, download the macOS DMG from [GitHub Releases](https://github.com/sgateway/s-gw/releases), drag `s-gw.app` to **Applications**, then open it and complete setup. The app includes its own Node runtime, CLI, MCP server, native helpers, and menu-bar helper; it does not require Node.js or npm on the host. Setup is intentionally blocked until the app is in `/Applications` or `~/Applications`.
-
-macOS releases provide `s-gw.dmg` and a versioned compatibility copy for existing update clients. A release built without an Apple Developer ID is clearly documented as unsigned and requires a Gatekeeper override. If you prefer not to override Gatekeeper, install the matching release package with Node.js 20 or newer instead:
-
-```bash
-npm install -g https://github.com/sgateway/s-gw/releases/download/vVERSION/s-gw-VERSION.tgz
-s-gw setup
-```
-
-Replace `VERSION` with the release version, or copy the exact command from the release notes or DMG README.
-
-For terminal-first, Linux, Windows, or source installs, use Node.js 20 or newer:
+The public npm package is the recommended installation path on macOS, Windows 10/11, and Linux. Install Node.js 20 or newer, then run:
 
 ```bash
 npm install -g @s-gw/s-gw
@@ -115,9 +104,15 @@ s-gw setup
 s-gw status
 ```
 
+On Windows, run the same commands in PowerShell. Windows support is preview software: it uses the TypeScript execution path and includes the PowerShell client, tray helper, and local web console.
+
+For an Apple Silicon Mac desktop bundle, [GitHub Releases](https://github.com/sgateway/s-gw/releases) also provides a self-contained `s-gw.dmg`. Drag `s-gw.app` to **Applications**, then open it and complete setup. The app includes its own Node runtime, CLI, MCP server, native helpers, and menu-bar helper; it does not require Node.js or npm on the host. Setup is intentionally blocked until the app is in `/Applications` or `~/Applications`.
+
+An unsigned DMG requires a Gatekeeper override. Use the npm installation above instead if you do not want to use that override.
+
 The public source builds the TypeScript compatibility path. Building the native macOS surfaces also requires a Swift toolchain. Maintainer release builds additionally require access to the private Rust core checkout.
 
-The Apple Silicon Mac DMG is the preferred desktop path. Published macOS DMGs are either Developer ID signed and notarized or explicitly documented as unsigned; unsigned builds require a Gatekeeper override but retain the standard release tag and update path. Local `npm run build:installers` output is ad-hoc signed for local verification. The npm package remains the terminal-first path and includes the native app, menu helper, Keychain helper, metadata-only Keychain inspector, and Rust core for Apple Silicon Macs. Linux and Windows use the TypeScript execution path when a matching native core is not packaged. Intel Macs must build the native Keychain and desktop surfaces from source for now; packaged arm64-only helpers are rejected before launch.
+The Apple Silicon Mac DMG is a self-contained desktop alternative. Published macOS DMGs are either Developer ID signed and notarized or explicitly documented as unsigned; unsigned builds require a Gatekeeper override but retain the standard release tag and update path. Local `npm run build:installers` output is ad-hoc signed for local verification. The npm package is the primary install and includes the native app, menu helper, Keychain helper, metadata-only Keychain inspector, and Rust core for Apple Silicon Macs. Linux and Windows use the TypeScript execution path when a matching native core is not packaged. Intel Macs must build the native Keychain and desktop surfaces from source for now; packaged arm64-only helpers are rejected before launch.
 
 ```bash
 git clone https://github.com/sgateway/s-gw.git

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -45,17 +45,20 @@ The macOS DMG is a self-contained `s-gw.app` plus an Applications shortcut. The 
 - `APPLE_NOTARY_KEY_ID`
 - `APPLE_NOTARY_ISSUER_ID`
 
-`unsigned` is the Apple-ID-free macOS mode. It produces the primary `s-gw.dmg` plus a versioned compatibility copy, uses the ordinary `vVERSION` tag, omits npm and MCP Registry publication, and remains discoverable by current and older clients. Its release notes and DMG README explain the required Gatekeeper override and include the exact `.tgz` npm command for users who prefer not to override it. Local builds use ad-hoc signatures only. Do not describe the Windows package as a production download until it is signed and validated on supported Windows versions.
+`unsigned` is the Apple-ID-free macOS mode. It produces the primary `s-gw.dmg` plus a versioned compatibility copy and uses the ordinary `vVERSION` tag, while the normal npm package remains the primary installation path. Its release notes and DMG README lead with `npm install -g @s-gw/s-gw` and explain the required Gatekeeper override for the desktop alternative. Local builds use ad-hoc signatures only. Do not describe the Windows package as a production download until it is signed and validated on supported Windows versions.
 
 ## Publish
 
 1. Create an annotated `vX.Y.Z` tag from a green `main` commit.
 2. Ensure private `barryqy/s-gw-rust-core` has the same immutable tag.
-3. Run **Publish release** with `release_tag=vX.Y.Z`, `publish_release=true`, and `macos_distribution=notarized` for a signed release or `macos_distribution=unsigned` when an Apple Developer ID is unavailable.
+3. Run **Publish release** with `release_tag=vX.Y.Z`, `publish_release=true`, `publish_npm_only=false`, and `macos_distribution=notarized` for a signed release or `macos_distribution=unsigned` when an Apple Developer ID is unavailable.
 4. The normal workflow verifies the tag/version pair, builds, signs, notarizes, staples, and Gatekeeper-assesses the DMG before it creates or updates a **draft** GitHub release.
-5. It uploads every installer and checksum, confirms their GitHub asset state is `uploaded`, then publishes the draft. Only a notarized release publishes npm and the MCP Registry.
-6. To inspect assets without notifying users, run the workflow with `publish_release=false`; the release remains a draft. Re-run with `true` only after review.
-7. Verify checksums from a clean download and install the release on clean macOS and Windows test accounts.
-8. Confirm the update checker sees the release and opens the correct notes.
+5. It uploads every installer and checksum, confirms their GitHub asset state is `uploaded`, then verifies and publishes the scoped npm package from the immutable tag. This protected OIDC step is independent of macOS notarization.
+6. After npm verification succeeds, it publishes the draft. MCP Registry publication follows the successful npm publication and does not hold the GitHub release open.
+7. To inspect assets without notifying users, run the workflow with `publish_release=false` and `publish_npm_only=false`; the release remains a draft and npm is not changed. Re-run with `true` only after review.
+8. Verify checksums from a clean download and install the release on clean macOS and Windows test accounts.
+9. Confirm the update checker sees the release and opens the correct notes.
 
-When signing is unavailable, use `unsigned`. It creates a normal SemVer release so installed clients can discover it, but it intentionally does not publish to npm or the MCP Registry. The release notes must state the Gatekeeper override and exact tarball alternative. The Windows package may still be labeled as a preview artifact with its limitations stated in the release notes.
+When signing is unavailable, use `unsigned`. It creates a normal SemVer release so installed clients can discover it, and it still publishes the normal npm package before the GitHub release. The release notes must lead with the npm command and state the Gatekeeper override for the DMG. The Windows package may still be labeled as a preview artifact with its limitations stated in the release notes.
+
+If an existing public GitHub release missed npm publication, run **Publish release** with `release_tag=vX.Y.Z` and `publish_npm_only=true`. This verifies the immutable tag and matching private core, publishes (or verifies) the scoped npm version through the existing OIDC environment, and does not rebuild assets, alter the GitHub release, or publish to the MCP Registry.

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,8 +2,8 @@
 
 ## Start Here
 
-- [macOS app install](deployment.md#macos-app-apple-silicon): drag the self-contained Apple Silicon app to Applications.
-- [Quick start](quickstart.md): npm/source installation and the disposable trust-loop demo.
+- [Quick start](quickstart.md): the recommended npm installation for macOS, Windows, and Linux, plus the disposable trust-loop demo.
+- [macOS app install](deployment.md#macos-app-apple-silicon): self-contained Apple Silicon desktop alternative.
 - [Architecture](architecture.md): components, data flow, and local process boundaries.
 - [Threat model](threat-model.md): intended guarantees, attacker assumptions, and non-goals.
 - [Deployment](deployment.md): platform support, setup, packaging, upgrade, and uninstall.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -18,9 +18,22 @@ Raw credentials stay in the local encrypted ledger and are decrypted only inside
 
 ## Distribution Options
 
+### npm Registry (Recommended)
+
+The public npm package is the recommended installation path on macOS, Windows, and Linux. It installs the `s-gw`, `sgw`, `s-gw-mcp`, and `secret-gateway-mcp` commands. Releases are built on macOS arm64 so Apple Silicon users also receive the native app, menu helper, Keychain helper, and matching Rust core. Linux and Windows use the TypeScript execution path when the package has no matching native core. Intel Macs must build the native Keychain and desktop surfaces from source; packaged arm64-only helpers are rejected before launch.
+
+```bash
+npm install -g @s-gw/s-gw
+s-gw setup
+```
+
+On Windows, run the same commands in PowerShell. Windows 10/11 support is preview software, but npm is the expected install path for the PowerShell client, tray helper, and local web console.
+
+For an npm-based Apple Silicon Mac installation, `s-gw setup` generates a strong local unlock secret, stores it in macOS Keychain, initializes the encrypted ledger, installs `s-gw.app` in `/Applications` (or `~/Applications` when required), installs and starts the console LaunchAgent, installs and starts the menu-bar helper, and opens the native macOS app. The browser console remains installed as a fallback local UI. Do not use npm setup to manage a machine that already has the self-contained app installed.
+
 ### macOS App (Apple Silicon)
 
-The preferred Mac installation is the self-contained DMG from [GitHub Releases](https://github.com/sgateway/s-gw/releases):
+The self-contained DMG from [GitHub Releases](https://github.com/sgateway/s-gw/releases) is a desktop alternative for users who prefer an app bundle instead of an npm installation:
 
 1. Open `s-gw.dmg`.
 2. Drag `s-gw.app` onto the **Applications** shortcut.
@@ -35,17 +48,6 @@ For an external configuration that needs an executable path, such as a Kubernete
 ```
 
 The equivalent bundled MCP command is `.../bin/s-gw-mcp`; setup writes the absolute bundled Node and MCP paths into supported agent configurations automatically.
-
-### npm Registry
-
-The public npm package is the terminal-first installation path. It installs the `s-gw`, `sgw`, `s-gw-mcp`, and `secret-gateway-mcp` commands. Releases are built on macOS arm64 so Apple Silicon users also receive the native app, menu helper, Keychain helper, and matching Rust core. Linux and Windows use the TypeScript execution path when the package has no matching native core. Intel Macs must build the native Keychain and desktop surfaces from source; packaged arm64-only helpers are rejected before launch.
-
-```bash
-npm install -g @s-gw/s-gw
-s-gw setup
-```
-
-For an npm-based Apple Silicon Mac installation, `s-gw setup` generates a strong local unlock secret, stores it in macOS Keychain, initializes the encrypted ledger, installs `s-gw.app` in `/Applications` (or `~/Applications` when required), installs and starts the console LaunchAgent, installs and starts the menu-bar helper, and opens the native macOS app. The browser console remains installed as a fallback local UI. Do not use npm setup to manage a machine that already has the self-contained app installed.
 
 ### Local Tarball Or Source
 
@@ -71,16 +73,14 @@ npm link
 
 ### macOS Installer
 
-The macOS DMG contains `s-gw.app`, an `Applications` shortcut, and a short README with the npm installation alternative. The app includes the runtime and all macOS components, so users drag one bundle into Applications instead of double-clicking a shell installer. The default release mode signs every executable with a Developer ID Application certificate, enables the hardened runtime, applies the Node JIT entitlement required by V8, submits the DMG to Apple notarization, staples the result, and assesses it with Gatekeeper before upload.
+The macOS DMG contains `s-gw.app`, an `Applications` shortcut, and a short README that identifies npm as the recommended installation and the DMG as a self-contained desktop alternative. The app includes the runtime and all macOS components, so users drag one bundle into Applications instead of double-clicking a shell installer. The default release mode signs every executable with a Developer ID Application certificate, enables the hardened runtime, applies the Node JIT entitlement required by V8, submits the DMG to Apple notarization, staples the result, and assesses it with Gatekeeper before upload.
 
-When Developer ID signing is unavailable, the `unsigned` mode produces the primary `s-gw.dmg` plus a versioned compatibility copy under the ordinary `vVERSION` release tag. It is not notarized, requires a Gatekeeper override, remains visible to automatic updaters, and does not publish npm or the MCP Registry. Users who prefer not to override Gatekeeper can install the matching `.tgz` release asset with Node.js 20 or newer:
+When Developer ID signing is unavailable, the `unsigned` mode still publishes `@s-gw/s-gw` before its GitHub release. The DMG is not notarized and requires a Gatekeeper override; use the normal npm installation instead when that override is not appropriate:
 
 ```bash
-npm install -g https://github.com/sgateway/s-gw/releases/download/vVERSION/s-gw-VERSION.tgz
+npm install -g @s-gw/s-gw
 s-gw setup
 ```
-
-Replace `VERSION` with the release version, or copy the exact command from the release notes or DMG README.
 
 The installer never pre-seeds passphrases, credentials, `SGW_HOME`, or policy templates.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,6 +1,6 @@
 # Quick Start
 
-This guide covers the npm/source path and exercises its approval boundary with disposable data. It does not require a real credential. For the self-contained Apple Silicon macOS app, see the [macOS app installation](deployment.md#macos-app-apple-silicon) first.
+This guide covers the recommended npm installation and exercises its approval boundary with disposable data. It does not require a real credential. For the self-contained Apple Silicon macOS desktop alternative, see the [macOS app installation](deployment.md#macos-app-apple-silicon).
 
 The supported npm installation requires Node.js 20 or newer.
 

--- a/scripts/build-installers.mjs
+++ b/scripts/build-installers.mjs
@@ -102,10 +102,6 @@ function buildMacInstaller(packed) {
 }
 
 function macInstallReadme(signing) {
-  const releaseTag = releaseTagFor(signing);
-  const npmInstall = signing.distribution === "unsigned"
-    ? `npm install -g https://github.com/sgateway/s-gw/releases/download/${releaseTag}/s-gw-${version}.tgz`
-    : "npm install -g @s-gw/s-gw";
   const trustNotice = signing.distribution === "unsigned"
     ? [
       "This macOS release is not signed with an Apple Developer ID or notarized.",
@@ -118,14 +114,18 @@ function macInstallReadme(signing) {
   return `${[
     `s-gw ${version} for Apple silicon`,
     "",
+    "Recommended installation (Node.js 20+):",
+    "npm install -g @s-gw/s-gw",
+    "s-gw setup",
+    "",
+    "Self-contained desktop alternative:",
     "1. Drag s-gw.app to Applications.",
     "2. Open s-gw from Applications and complete setup.",
     "",
     ...trustNotice,
-    "",
-    "Prefer not to use a macOS security override? Install the CLI package instead (Node.js 20+ required):",
-    npmInstall,
-    "s-gw setup"
+    signing.distribution === "unsigned"
+      ? "Use the npm installation above if you do not want to use a macOS security override."
+      : ""
   ].join("\n")}\n`;
 }
 

--- a/scripts/verify-macos-dmg.mjs
+++ b/scripts/verify-macos-dmg.mjs
@@ -57,11 +57,9 @@ try {
     throw new Error("The DMG must include installation guidance.");
   }
   const readme = readFileSync(readmePath, "utf8");
-  const packageVersion = JSON.parse(readFileSync(path.join(packageRoot, "package.json"), "utf8")).version;
-  const releaseNpmInstall = `npm install -g https://github.com/sgateway/s-gw/releases/download/v${packageVersion}/s-gw-${packageVersion}.tgz`;
-  const npmInstall = readme.includes(releaseNpmInstall) ? releaseNpmInstall : "npm install -g @s-gw/s-gw";
+  const npmInstall = "npm install -g @s-gw/s-gw";
   if (!readme.includes(npmInstall) || !readme.includes("s-gw setup")) {
-    throw new Error("The DMG installation guidance must include the matching npm alternative.");
+    throw new Error("The DMG installation guidance must include the primary npm installation.");
   }
 
   run("codesign", ["--verify", "--deep", "--strict", "--verbose=2", appPath]);

--- a/tests/installers.test.ts
+++ b/tests/installers.test.ts
@@ -105,8 +105,10 @@ describe("platform installers", () => {
     expect(builder).toContain("SGW_MACOS_DISTRIBUTION");
     expect(builder).toContain('signing.distribution === "unsigned"');
     expect(builder).toContain("README.txt");
-    expect(builder).toContain("npm install -g https://github.com/sgateway/s-gw/releases/download");
-    expect(builder).toContain("Prefer not to use a macOS security override?");
+    expect(builder).toContain("Recommended installation (Node.js 20+):");
+    expect(builder).toContain("npm install -g @s-gw/s-gw");
+    expect(builder).toContain("Self-contained desktop alternative:");
+    expect(builder).not.toContain("github.com/sgateway/s-gw/releases/download");
     expect(builder).toContain("notarytool");
     expect(builder).toContain("NodeRuntime.entitlements");
     expect(builder).toContain("com.apple.security.cs.allow-jit");
@@ -117,7 +119,7 @@ describe("platform installers", () => {
     expect(verifier).toContain('path.join(runtimeRoot, "bin", "s-gw")');
     expect(verifier).toContain("runMcpSmoke");
     expect(verifier).toContain("SGW_TEST_HOME_ROOT");
-    expect(verifier).toContain("const releaseNpmInstall");
+    expect(verifier).toContain('const npmInstall = "npm install -g @s-gw/s-gw"');
     expect(verifier).toContain("readme.includes(npmInstall)");
     expect(runtime.node.version).toMatch(/^24\./);
     expect(runtime.node.url).toContain(`v${runtime.node.version}/node-v${runtime.node.version}-darwin-arm64.tar.gz`);
@@ -183,6 +185,7 @@ describe("platform installers", () => {
     expect(workflow).not.toContain("  release:");
     expect(workflow).toContain("release_tag:");
     expect(workflow).toContain("publish_release:");
+    expect(workflow).toContain("publish_npm_only:");
     expect(workflow).toContain("macos_distribution:");
     expect(workflow).toContain("- unsigned");
     expect(assetJob).toContain("ref: ${{ inputs.release_tag }}");
@@ -209,8 +212,10 @@ describe("platform installers", () => {
     expect(assetJob).toContain('"dist/installers/s-gw-${package_version}-macos.dmg"');
     expect(assetJob).not.toContain("--prerelease --latest=false");
     expect(assetJob).not.toContain("unsigned-macos-preview-v${package_version}");
-    expect(assetJob).toContain("npm install -g https://github.com/${GITHUB_REPOSITORY}");
-    expect(assetJob).toContain("If you prefer not to override Gatekeeper");
+    expect(assetJob).toContain("npm install -g @s-gw/s-gw");
+    expect(assetJob).toContain("The recommended installation path on macOS, Windows, and Linux");
+    expect(assetJob).toContain("Use the npm installation above if you do not want to use that override");
+    expect(assetJob).not.toContain("releases/download/${RELEASE_TAG}");
     expect(assetJob).toContain("Create or verify a draft release");
     expect(assetJob).toContain("gh release create \"$RELEASE_TAG\" --draft --verify-tag --generate-notes");
     expect(assetJob).toContain('select(.state == "uploaded")');
@@ -225,7 +230,7 @@ describe("platform installers", () => {
     expect(validator).toContain("macosDistribution");
   });
 
-  it("publishes the native npm package on Apple Silicon and keeps Registry publishing on Linux", async () => {
+  it("publishes the native npm package before the GitHub release and keeps Registry publishing on Linux", async () => {
     const workflow = await readFile(path.join(root, ".github/workflows/publish.yml"), "utf8");
     const npmJob = workflow.slice(
       workflow.indexOf("  publish-npm:"),
@@ -240,17 +245,23 @@ describe("platform installers", () => {
       workflow.indexOf("  publish-npm:")
     );
 
-    expect(releaseJob).toContain("needs: release-assets");
+    expect(releaseJob).toContain("needs: [release-assets, publish-npm]");
+    expect(releaseJob).toContain("needs.publish-npm.result == 'success'");
     expect(releaseJob).toContain('gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY"');
     expect(releaseJob).toContain("gh release edit \"$RELEASE_TAG\" --repo \"$GITHUB_REPOSITORY\" --draft=false");
     expect(npmJob).toContain("runs-on: macos-15");
-    expect(npmJob).toContain("needs: publish-release");
-    expect(npmJob).toContain("inputs.macos_distribution == 'notarized'");
+    expect(npmJob).toContain("needs: release-assets");
+    expect(npmJob).toContain("inputs.publish_npm_only");
+    expect(npmJob).toContain("inputs.publish_release");
+    expect(npmJob).not.toContain("inputs.macos_distribution");
     expect(npmJob).toContain('SGW_REQUIRE_RUST_CORE: "1"');
     expect(npmJob).toContain("repository: barryqy/s-gw-rust-core");
     expect(npmJob).toContain("ref: ${{ inputs.release_tag }}");
     expect(npmJob).not.toContain("github.event.release");
     expect(npmJob).toContain("npm run validate:npm-package");
+    expect(npmJob).toContain("Record local npm package integrity");
+    expect(npmJob).toContain("SGW_NPM_PACKAGE_INTEGRITY");
+    expect(npmJob).toContain('npm view "@s-gw/s-gw@${package_version}" dist.integrity');
     expect(npmJob).toContain("npm publish --access public --ignore-scripts");
     expect(npmJob).toContain("-verify_arch arm64");
     expect(npmJob).toContain('npm install --global --prefix "$prefix"');
@@ -258,10 +269,54 @@ describe("platform installers", () => {
     expect(npmJob).toContain('s-gw-core" --version');
     expect(npmJob).toContain('test ! -e "$package_root/dist/native/s-gw-core"');
     expect(registryJob).toContain("needs: publish-npm");
-    expect(registryJob).toContain("inputs.macos_distribution == 'notarized'");
+    expect(registryJob).toContain("inputs.publish_release");
+    expect(registryJob).toContain("!inputs.publish_npm_only");
+    expect(registryJob).not.toContain("inputs.macos_distribution");
     expect(registryJob).toContain("runs-on: ubuntu-latest");
     expect(registryJob).toContain("mcp-publisher_linux_amd64.tar.gz");
     expect(registryJob).not.toContain("npm publish --access public");
+  });
+
+  it("supports an npm-only recovery without rebuilding or changing a GitHub release", async () => {
+    const workflow = await readFile(path.join(root, ".github/workflows/publish.yml"), "utf8");
+    const assetJob = workflow.slice(
+      workflow.indexOf("  release-assets:"),
+      workflow.indexOf("  publish-release:")
+    );
+    const releaseJob = workflow.slice(
+      workflow.indexOf("  publish-release:"),
+      workflow.indexOf("  publish-npm:")
+    );
+    const npmJob = workflow.slice(
+      workflow.indexOf("  publish-npm:"),
+      workflow.indexOf("  publish-registry:")
+    );
+    const registryJob = workflow.slice(
+      workflow.indexOf("  publish-registry:"),
+      workflow.length
+    );
+
+    expect(workflow).toContain("publish_npm_only:");
+    expect(assetJob).toContain("!inputs.publish_npm_only");
+    expect(npmJob).toContain("always()");
+    expect(npmJob).toContain("inputs.publish_npm_only ||");
+    expect(releaseJob).toContain("!inputs.publish_npm_only");
+    expect(registryJob).toContain("!inputs.publish_npm_only");
+  });
+
+  it("makes the registry package the primary public installation", async () => {
+    const [readme, deployment, releaseGuide] = await Promise.all([
+      readFile(path.join(root, "README.md"), "utf8"),
+      readFile(path.join(root, "docs/deployment.md"), "utf8"),
+      readFile(path.join(root, "RELEASING.md"), "utf8")
+    ]);
+
+    expect(readme.indexOf("npm install -g @s-gw/s-gw")).toBeLessThan(readme.indexOf("For an Apple Silicon Mac desktop bundle"));
+    expect(readme).not.toContain("releases/download/vVERSION/s-gw-VERSION.tgz");
+    expect(deployment.indexOf("### npm Registry (Recommended)")).toBeLessThan(deployment.indexOf("### macOS App (Apple Silicon)"));
+    expect(deployment).not.toContain("releases/download/vVERSION/s-gw-VERSION.tgz");
+    expect(releaseGuide).toContain("publish_npm_only=true");
+    expect(releaseGuide).toContain("npm install -g @s-gw/s-gw");
   });
 });
 


### PR DESCRIPTION
Promotes the public npm package to the default install path, keeps desktop downloads as fallbacks, and makes unsigned releases publish npm before GitHub release visibility.