### PR TITLE
Prepare 0.1.19 release

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "s-gw",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "Local s-gw plugin that lets coding agents use typed secret handles without receiving raw credentials.",
   "author": {
     "name": "Barry Yuan"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,19 @@ Notable changes to s-gw are documented here. The project follows [Semantic Versi
 
 ## Unreleased
 
+## 0.1.19 - 2026-07-21
+
 ### Changed
 
 - `npm install -g @s-gw/s-gw` is now the primary documented installation path on macOS, Windows, and Linux. The self-contained Apple Silicon DMG remains a desktop alternative.
 - Release automation publishes and verifies the npm package before it makes the GitHub release public, regardless of whether the macOS DMG is notarized. A recovery-only npm publish mode can repair a previously released version without changing its GitHub release.
+- Runtime dependencies and pinned GitHub Actions were refreshed, while Dependabot ignores unsupported TypeScript and Node type-definition major updates.
+
+### Fixed
+
+- The macOS app loads runtime status before first-launch migration and refreshes services separately from bounded agent configuration rewrites, preventing healthy installations from appearing incomplete or blocking the UI.
+- Agent integration and store-lock reads stay pinned to verified regular-file descriptors, EC2 update hosts require an exact AWS domain suffix, and XML update metadata is decoded only once.
+- Installed-app discovery is isolated in tests, and high-contention integration updates no longer fail because an open file's metadata changed during a concurrent operation.
 
 ## 0.1.18 - 2026-07-17
 

--- a/native/macos-app/Sources/SgwMac/Services/UpdateChecker.swift
+++ b/native/macos-app/Sources/SgwMac/Services/UpdateChecker.swift
@@ -73,7 +73,7 @@ actor UpdateChecker: UpdateChecking {
     private let cli = CLIRunner()
 
     static var currentVersion: String {
-        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.1.18"
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.1.19"
     }
 
     static var usesSelfContainedRuntime: Bool {

--- a/native/macos-app/Tests/AppStateGuardTests.swift
+++ b/native/macos-app/Tests/AppStateGuardTests.swift
@@ -151,7 +151,7 @@ fileprivate struct Scratch {
         exit 0
         ;;
       status)
-        print -- '{"version":"0.1.18","packageRoot":"/tmp/sgw","ready":true,"readiness":{"ok":true,"summary":"ready","blockers":[]},"cliPath":{"path":"/tmp/cli.js","exists":true},"mcpPath":{"path":"/tmp/mcp.js","exists":true},"keychainHelperPath":{"path":"/tmp/helper","exists":true},"menuBarAppPath":{"path":"/tmp/mb.app","exists":true},"menuBarBinaryPath":{"path":"/tmp/mb","exists":true},"storePath":"/tmp/store.json","consoleUrl":"http://127.0.0.1:8718/","unlock":{"activeSource":"env"},"launchAgents":{"console":{"label":"c","plistPath":"/tmp/c.plist","installed":true,"loaded":true},"menuBar":{"label":"m","plistPath":"/tmp/m.plist","installed":true,"loaded":true}}}'
+        print -- '{"version":"0.1.19","packageRoot":"/tmp/sgw","ready":true,"readiness":{"ok":true,"summary":"ready","blockers":[]},"cliPath":{"path":"/tmp/cli.js","exists":true},"mcpPath":{"path":"/tmp/mcp.js","exists":true},"keychainHelperPath":{"path":"/tmp/helper","exists":true},"menuBarAppPath":{"path":"/tmp/mb.app","exists":true},"menuBarBinaryPath":{"path":"/tmp/mb","exists":true},"storePath":"/tmp/store.json","consoleUrl":"http://127.0.0.1:8718/","unlock":{"activeSource":"env"},"launchAgents":{"console":{"label":"c","plistPath":"/tmp/c.plist","installed":true,"loaded":true},"menuBar":{"label":"m","plistPath":"/tmp/m.plist","installed":true,"loaded":true}}}'
         exit 0
         ;;
       app)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@s-gw/s-gw",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@s-gw/s-gw",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "license": "Apache-2.0",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-gw/s-gw",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "mcpName": "io.github.sgateway/s-gw",
   "description": "Local credential control for AI coding agents.",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -15,13 +15,13 @@
     "url": "https://github.com/sgateway/s-gw",
     "source": "github"
   },
-  "version": "0.1.18",
+  "version": "0.1.19",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@s-gw/s-gw",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "runtimeHint": "npx",
       "runtimeArguments": [
         {

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const CURRENT_VERSION = "0.1.18";
+export const CURRENT_VERSION = "0.1.19";


### PR DESCRIPTION
## Summary

Prepare the public 0.1.19 release after the startup, migration, repository-maintenance, and security hardening changes merged in #59. This aligns the npm package, lockfile, Codex plugin, MCP Registry metadata, TypeScript runtime, macOS fallback version, native test fixture, and changelog.

The release includes the npm-primary installation and recovery workflow improvements from #55, the runtime dependency refresh from #57, and the first-launch, file-safety, update-validation, and repository-maintenance fixes from #59.

## Verification

- Private core: `cargo fmt --check`
- Private core: `cargo clippy --all-targets --all-features -- -D warnings`
- Private core: `cargo test --all-targets --all-features`
- `SGW_REQUIRE_RUST_CORE=1 npm run verify` — 36 files and 377 tests passed; audit reported zero vulnerabilities
- Unsigned `npm run build:installers`
- Release asset validation for the scoped package, legacy bridge, checksums, and self-contained macOS DMG
- Version alignment test across all shipped product surfaces
