### PR TITLE
Recover stopped macOS services on launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Notable changes to s-gw are documented here. The project follows [Semantic Versi
 ### Fixed
 
 - The macOS app now restarts installed-but-unloaded local services when it opens, and LaunchAgent setup no longer issues a redundant blocking `kickstart` after loading a `RunAtLoad` job.
+- Windows agent integration updates now retry transient filesystem contention while another process releases the integration lock.
 
 ## 0.1.19 - 2026-07-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Notable changes to s-gw are documented here. The project follows [Semantic Versi
 
 ## Unreleased
 
+### Fixed
+
+- The macOS app now restarts installed-but-unloaded local services when it opens, and LaunchAgent setup no longer issues a redundant blocking `kickstart` after loading a `RunAtLoad` job.
+
 ## 0.1.19 - 2026-07-21
 
 ### Changed

--- a/native/macos-app/Sources/SgwMac/App/AppState.swift
+++ b/native/macos-app/Sources/SgwMac/App/AppState.swift
@@ -48,6 +48,7 @@ final class AppState {
   @ObservationIgnored private let now: () -> Date
   @ObservationIgnored private let updateCheckInterval: TimeInterval
   @ObservationIgnored private var seenPendingRequestIds = Set<String>()
+  @ObservationIgnored private var didAttemptServiceRecovery = false
 
   init(
     updater: any UpdateChecking = UpdateChecker(),
@@ -151,6 +152,7 @@ final class AppState {
     Task {
       await refreshInitialStatus()
       await refreshBundledRuntimeAfterReplacement(enabled: refreshBundledRuntime)
+      await recoverInstalledServices()
       await refresh()
     }
     Task {
@@ -182,6 +184,25 @@ final class AppState {
     } catch {
       lastError = error.localizedDescription
     }
+  }
+
+  func recoverInstalledServices() async {
+    guard !didAttemptServiceRecovery else { return }
+    guard
+      status?.ready == true,
+      status?.launchAgents.console.installed == true,
+      status?.launchAgents.console.loaded == false
+    else {
+      return
+    }
+
+    didAttemptServiceRecovery = true
+    let result = await cli.run(arguments: ["start", "--no-open-app"])
+    if !result.succeeded {
+      lastError = result.output.trimmingCharacters(in: .whitespacesAndNewlines)
+      return
+    }
+    await refreshInitialStatus()
   }
 
   func refresh(showSpinner: Bool = true) async {

--- a/native/macos-app/Tests/AppStateGuardTests.swift
+++ b/native/macos-app/Tests/AppStateGuardTests.swift
@@ -263,6 +263,7 @@ struct AppStateGuardTests {
     UserDefaults.standard.set(scratch.fakeCli.path, forKey: CLIRunner.binaryOverrideKey)
 
     await runStartupOrderingTest(scratch)
+    await runStoppedServiceRecoveryTest(scratch)
     await runInFlightGuardTest(scratch)
     await runGuardReleaseTest(scratch)
     await runReadinessDerivationTest()
@@ -280,6 +281,27 @@ struct AppStateGuardTests {
     runChecksumManifestTest()
 
     print("ALL_NATIVE_TESTS_OK")
+  }
+
+  @MainActor
+  fileprivate static func runStoppedServiceRecoveryTest(_ scratch: Scratch) async {
+    let app = AppState()
+    app.status = statusPayload(ready: true,
+                               summary: "ready",
+                               blockers: [],
+                               activeSource: "env",
+                               consoleLoaded: false,
+                               consoleInstalled: true)
+    let before = scratch.commands().filter { $0 == "start --no-open-app" }.count
+
+    await app.recoverInstalledServices()
+    let after = scratch.commands().filter { $0 == "start --no-open-app" }.count
+    check(after == before + 1, "opening the app should recover an installed stopped console")
+    check(app.daemonRunning, "service recovery should refresh the running status")
+
+    await app.recoverInstalledServices()
+    let repeated = scratch.commands().filter { $0 == "start --no-open-app" }.count
+    check(repeated == after, "service recovery should run at most once per app launch")
   }
 
   @MainActor
@@ -763,6 +785,7 @@ struct AppStateGuardTests {
 
   static func statusPayload(ready: Bool, summary: String, blockers: [String],
                             activeSource: String, consoleLoaded: Bool,
+                            consoleInstalled: Bool? = nil,
                             version: String? = nil) -> StatusPayload {
     let blockerJson = blockers.map { "\"\($0)\"" }.joined(separator: ",")
     let versionJson = version.map { "\"version\":\"\($0)\"," } ?? ""
@@ -781,7 +804,7 @@ struct AppStateGuardTests {
       "consoleUrl": "http://127.0.0.1:8718/",
       "unlock": {"activeSource":"\(activeSource)"},
       "launchAgents": {
-        "console": {"label":"c","plistPath":"/tmp/c.plist","installed":\(consoleLoaded),"loaded":\(consoleLoaded)},
+        "console": {"label":"c","plistPath":"/tmp/c.plist","installed":\(consoleInstalled ?? consoleLoaded),"loaded":\(consoleLoaded)},
         "menuBar": {"label":"m","plistPath":"/tmp/m.plist","installed":false,"loaded":false}
       }
     }

--- a/src/agent-install.ts
+++ b/src/agent-install.ts
@@ -549,6 +549,9 @@ function removeAbandonedAgentLock(lockPath: string): boolean {
     state = inspectAgentIntegrationLock(lockPath);
   } catch (error) {
     if (isNodeError(error) && error.code === "ENOENT") return true;
+    if (process.platform === "win32" && isNodeError(error) && (error.code === "EPERM" || error.code === "EACCES")) {
+      return false;
+    }
     throw error;
   }
 

--- a/src/install.ts
+++ b/src/install.ts
@@ -1008,7 +1008,6 @@ ${aqua}  <key>StandardOutPath</key>
 function startLaunchAgent(label: string, plistPath: string): void {
   stopLaunchAgent(label);
   runLaunchctl(["bootstrap", launchdDomain(), plistPath]);
-  runLaunchctl(["kickstart", "-k", `${launchdDomain()}/${label}`]);
 }
 
 function stopLaunchAgent(label: string): void {

--- a/tests/install.test.ts
+++ b/tests/install.test.ts
@@ -219,6 +219,17 @@ describe("launch-agent packaging", () => {
     expect(plist).not.toContain("<string>--notify-on-launch</string>");
   });
 
+  it("does not restart a newly bootstrapped LaunchAgent", async () => {
+    const source = await readFile(path.join(repoRoot, "src/install.ts"), "utf8");
+    const start = source.slice(
+      source.indexOf("function startLaunchAgent"),
+      source.indexOf("function stopLaunchAgent")
+    );
+
+    expect(start).toContain('runLaunchctl(["bootstrap"');
+    expect(start).not.toContain("kickstart");
+  });
+
   it("preserves the existing ledger namespace while rebinding a migrated runtime", () => {
     const oldHelper = process.env.SGW_KEYCHAIN_HELPER;
     delete process.env.SGW_KEYCHAIN_HELPER;


### PR DESCRIPTION
## What changed

- restart installed-but-unloaded local services once when the macOS app opens
- remove the redundant blocking `launchctl kickstart -k` after bootstrapping a `RunAtLoad` LaunchAgent
- add native and TypeScript regression coverage
- record the fix under `CHANGELOG.md` → `Unreleased` so it is carried into the next release

## Root cause

Both LaunchAgent plists could remain installed but unloaded. The native app then stayed on its Setup surface. Recovery could also hang because setup bootstrapped each `RunAtLoad` job and immediately issued a second blocking kickstart.

## Impact

Opening the installed app recovers the stopped console automatically. Setup relies on launchd's `RunAtLoad` behavior and no longer stalls on the redundant kickstart.

## Verification

- `npm run build`
- `npm test` — 36 files, 376 passed, 2 skipped
- focused `tests/install.test.ts` and `tests/native-appstate.test.ts` — 13 passed
- reproduced and repaired the local 0.1.18 Setup-state failure, then verified the upgraded 0.1.19 console and menu helper are loaded and healthy
