### PR TITLE
Pin npm for release builds

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,6 +66,8 @@ jobs:
           registry-url: https://registry.npmjs.org
           package-manager-cache: false
 
+      - name: Pin release build npm
+        run: npm install --global npm@10.9.8
       - run: rustup toolchain install 1.96.1 --profile minimal --component rustfmt,clippy
       - run: npm ci --ignore-scripts
 
@@ -280,6 +282,8 @@ jobs:
           registry-url: https://registry.npmjs.org
           package-manager-cache: false
 
+      - name: Pin release build npm
+        run: npm install --global npm@10.9.8
       - run: rustup toolchain install 1.96.1 --profile minimal --component rustfmt,clippy
       - run: npm ci --ignore-scripts
       - name: Verify release source
@@ -311,6 +315,9 @@ jobs:
             "dist/s-gw Menu Bar.app/Contents/MacOS/s-gw-menu-bar-helper"; do
             lipo "$binary" -verify_arch arm64
           done
+
+      - name: Enable npm trusted publishing
+        run: npm install --global npm@11.16.0
 
       - name: Record local npm package integrity
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,10 +68,9 @@ jobs:
 
       - name: Pin release build npm
         run: |
-          npm install --global npm@10.9.8
-          test "$(npm --version)" = 10.9.8
+          test "$(npx --yes --package npm@10.9.8 npm --version)" = 10.9.8
       - run: rustup toolchain install 1.96.1 --profile minimal --component rustfmt,clippy
-      - run: npm ci --ignore-scripts
+      - run: npx --yes --package npm@10.9.8 npm ci --ignore-scripts
 
       - name: Configure macOS distribution signing
         if: inputs.macos_distribution == 'notarized'
@@ -286,10 +285,9 @@ jobs:
 
       - name: Pin release build npm
         run: |
-          npm install --global npm@10.9.8
-          test "$(npm --version)" = 10.9.8
+          test "$(npx --yes --package npm@10.9.8 npm --version)" = 10.9.8
       - run: rustup toolchain install 1.96.1 --profile minimal --component rustfmt,clippy
-      - run: npm ci --ignore-scripts
+      - run: npx --yes --package npm@10.9.8 npm ci --ignore-scripts
       - name: Verify release source
         if: ${{ !inputs.publish_npm_only }}
         run: npm run verify
@@ -319,11 +317,6 @@ jobs:
             "dist/s-gw Menu Bar.app/Contents/MacOS/s-gw-menu-bar-helper"; do
             lipo "$binary" -verify_arch arm64
           done
-
-      - name: Enable npm trusted publishing
-        run: |
-          npm install --global npm@11.16.0
-          test "$(npm --version)" = 11.16.0
 
       - name: Record local npm package integrity
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -67,7 +67,9 @@ jobs:
           package-manager-cache: false
 
       - name: Pin release build npm
-        run: npm install --global npm@10.9.8
+        run: |
+          npm install --global npm@10.9.8
+          test "$(npm --version)" = 10.9.8
       - run: rustup toolchain install 1.96.1 --profile minimal --component rustfmt,clippy
       - run: npm ci --ignore-scripts
 
@@ -283,7 +285,9 @@ jobs:
           package-manager-cache: false
 
       - name: Pin release build npm
-        run: npm install --global npm@10.9.8
+        run: |
+          npm install --global npm@10.9.8
+          test "$(npm --version)" = 10.9.8
       - run: rustup toolchain install 1.96.1 --profile minimal --component rustfmt,clippy
       - run: npm ci --ignore-scripts
       - name: Verify release source
@@ -317,7 +321,9 @@ jobs:
           done
 
       - name: Enable npm trusted publishing
-        run: npm install --global npm@11.16.0
+        run: |
+          npm install --global npm@11.16.0
+          test "$(npm --version)" = 11.16.0
 
       - name: Record local npm package integrity
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,9 +68,10 @@ jobs:
 
       - name: Pin release build npm
         run: |
-          test "$(npx --yes --package npm@10.9.8 npm --version)" = 10.9.8
+          npm install --global npm@10.9.8
+          test "$(npm --version)" = 10.9.8
       - run: rustup toolchain install 1.96.1 --profile minimal --component rustfmt,clippy
-      - run: npx --yes --package npm@10.9.8 npm ci --ignore-scripts
+      - run: npm ci --ignore-scripts
 
       - name: Configure macOS distribution signing
         if: inputs.macos_distribution == 'notarized'

--- a/tests/installers.test.ts
+++ b/tests/installers.test.ts
@@ -205,6 +205,8 @@ describe("platform installers", () => {
     expect(assetJob).toContain("SGW_RUST_CORE_DIR: ${{ github.workspace }}/.private/sgw-core");
     expect(assetJob).toContain("repository: barryqy/s-gw-rust-core");
     expect(assetJob).toContain("path: .private/sgw-core");
+    expect(assetJob).toContain("name: Pin release build npm");
+    expect(assetJob).toContain("npm install --global npm@10.9.8");
     expect(assetJob).toContain("npm run build");
     expect(assetJob).toContain("npm run check:rust");
     expect(assetJob).toContain("npx vitest run --testTimeout 15000");
@@ -270,6 +272,14 @@ describe("platform installers", () => {
     expect(npmJob).toContain("repository: barryqy/s-gw-rust-core");
     expect(npmJob).toContain("ref: ${{ inputs.release_tag }}");
     expect(npmJob).not.toContain("github.event.release");
+    expect(npmJob).toContain("name: Pin release build npm");
+    expect(npmJob).toContain("npm install --global npm@10.9.8");
+    expect(npmJob).toContain("name: Enable npm trusted publishing");
+    expect(npmJob).toContain("npm install --global npm@11.16.0");
+    expect(npmJob.indexOf("npm install --global npm@10.9.8"))
+      .toBeLessThan(npmJob.indexOf("npm ci --ignore-scripts"));
+    expect(npmJob.indexOf("npm install --global npm@11.16.0"))
+      .toBeLessThan(npmJob.indexOf("name: Record local npm package integrity"));
     expect(npmJob).toContain("npm run validate:npm-package");
     expect(npmJob).toContain("Record local npm package integrity");
     expect(npmJob).toContain("SGW_NPM_PACKAGE_INTEGRITY");

--- a/tests/installers.test.ts
+++ b/tests/installers.test.ts
@@ -207,6 +207,7 @@ describe("platform installers", () => {
     expect(assetJob).toContain("path: .private/sgw-core");
     expect(assetJob).toContain("name: Pin release build npm");
     expect(assetJob).toContain("npm install --global npm@10.9.8");
+    expect(assetJob).toContain('test "$(npm --version)" = 10.9.8');
     expect(assetJob).toContain("npm run build");
     expect(assetJob).toContain("npm run check:rust");
     expect(assetJob).toContain("npx vitest run --testTimeout 15000");
@@ -274,8 +275,10 @@ describe("platform installers", () => {
     expect(npmJob).not.toContain("github.event.release");
     expect(npmJob).toContain("name: Pin release build npm");
     expect(npmJob).toContain("npm install --global npm@10.9.8");
+    expect(npmJob).toContain('test "$(npm --version)" = 10.9.8');
     expect(npmJob).toContain("name: Enable npm trusted publishing");
     expect(npmJob).toContain("npm install --global npm@11.16.0");
+    expect(npmJob).toContain('test "$(npm --version)" = 11.16.0');
     expect(npmJob.indexOf("npm install --global npm@10.9.8"))
       .toBeLessThan(npmJob.indexOf("npm ci --ignore-scripts"));
     expect(npmJob.indexOf("npm install --global npm@11.16.0"))

--- a/tests/installers.test.ts
+++ b/tests/installers.test.ts
@@ -206,8 +206,9 @@ describe("platform installers", () => {
     expect(assetJob).toContain("repository: barryqy/s-gw-rust-core");
     expect(assetJob).toContain("path: .private/sgw-core");
     expect(assetJob).toContain("name: Pin release build npm");
-    expect(assetJob).toContain("npx --yes --package npm@10.9.8 npm ci --ignore-scripts");
-    expect(assetJob).toContain('test "$(npx --yes --package npm@10.9.8 npm --version)" = 10.9.8');
+    expect(assetJob).toContain("npm install --global npm@10.9.8");
+    expect(assetJob).toContain('test "$(npm --version)" = 10.9.8');
+    expect(assetJob).toContain("npm ci --ignore-scripts");
     expect(assetJob).toContain("npm run build");
     expect(assetJob).toContain("npm run check:rust");
     expect(assetJob).toContain("npx vitest run --testTimeout 15000");

--- a/tests/installers.test.ts
+++ b/tests/installers.test.ts
@@ -206,8 +206,8 @@ describe("platform installers", () => {
     expect(assetJob).toContain("repository: barryqy/s-gw-rust-core");
     expect(assetJob).toContain("path: .private/sgw-core");
     expect(assetJob).toContain("name: Pin release build npm");
-    expect(assetJob).toContain("npm install --global npm@10.9.8");
-    expect(assetJob).toContain('test "$(npm --version)" = 10.9.8');
+    expect(assetJob).toContain("npx --yes --package npm@10.9.8 npm ci --ignore-scripts");
+    expect(assetJob).toContain('test "$(npx --yes --package npm@10.9.8 npm --version)" = 10.9.8');
     expect(assetJob).toContain("npm run build");
     expect(assetJob).toContain("npm run check:rust");
     expect(assetJob).toContain("npx vitest run --testTimeout 15000");
@@ -274,15 +274,9 @@ describe("platform installers", () => {
     expect(npmJob).toContain("ref: ${{ inputs.release_tag }}");
     expect(npmJob).not.toContain("github.event.release");
     expect(npmJob).toContain("name: Pin release build npm");
-    expect(npmJob).toContain("npm install --global npm@10.9.8");
-    expect(npmJob).toContain('test "$(npm --version)" = 10.9.8');
-    expect(npmJob).toContain("name: Enable npm trusted publishing");
-    expect(npmJob).toContain("npm install --global npm@11.16.0");
-    expect(npmJob).toContain('test "$(npm --version)" = 11.16.0');
-    expect(npmJob.indexOf("npm install --global npm@10.9.8"))
-      .toBeLessThan(npmJob.indexOf("npm ci --ignore-scripts"));
-    expect(npmJob.indexOf("npm install --global npm@11.16.0"))
-      .toBeLessThan(npmJob.indexOf("name: Record local npm package integrity"));
+    expect(npmJob).toContain("npx --yes --package npm@10.9.8 npm ci --ignore-scripts");
+    expect(npmJob).toContain('test "$(npx --yes --package npm@10.9.8 npm --version)" = 10.9.8');
+    expect(npmJob).not.toContain("npm install --global npm@10.9.8");
     expect(npmJob).toContain("npm run validate:npm-package");
     expect(npmJob).toContain("Record local npm package integrity");
     expect(npmJob).toContain("SGW_NPM_PACKAGE_INTEGRITY");


### PR DESCRIPTION
The v0.1.20 draft publish exposed an npm 11 lockfile regression around an unpublished optional packager binary. The asset job now uses the same npm 10.9.8 pin already proven in desktop CI, covering both its top-level and nested clean installs. The npm publication job scopes npm 10 to dependency installation only, preserving npm 11 for OIDC trusted publishing. The corrected draft build completed successfully and uploaded all twelve validated release assets. Focused workflow tests, TypeScript checks, actionlint, the dependency audit, and a local npm 10 clean install pass.