### PR TITLE
Fix approval policies and macOS window dragging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Notable changes to s-gw are documented here. The project follows [Semantic Versi
 ### Fixed
 
 - macOS update notices now carry verified installer metadata from the menu helper, enrich older partial notices automatically, and keep an enabled release-page fallback instead of showing a disabled Upgrade button.
+- Explicit Any command allow policies now authorize credential-permitted environment commands, while incomplete legacy rules remain fail-closed until they are deliberately converted. Policy previews identify the earlier winning rule and its priority.
+- The macOS approval helper can create a persistent request-scoped allow policy directly from the popup, alongside one-time and session-based grants.
+- The macOS app can be moved by dragging blank native title chrome without stealing clicks from buttons and other interactive controls.
 
 ## 0.1.20 - 2026-08-12
 
@@ -23,6 +26,7 @@ Notable changes to s-gw are documented here. The project follows [Semantic Versi
 
 ### Fixed
 
+- Timed and login-session approvals now stay bound to the requesting login session when the native helper approves them from a separate process.
 - The macOS app now restarts installed-but-unloaded local services when it opens, and LaunchAgent setup no longer issues a redundant blocking `kickstart` after loading a `RunAtLoad` job.
 - Windows agent integration updates now retry transient filesystem contention while another process releases the integration lock.
 - Windows desktop refreshes now hide packaged Node.js and credential-helper consoles instead of flashing command windows during background polling.

--- a/native/macos-app/Sources/SgwMac/App/AppState.swift
+++ b/native/macos-app/Sources/SgwMac/App/AppState.swift
@@ -453,6 +453,9 @@ final class AppState {
     if !draft.resolvedCommand.isEmpty {
       args += ["--resolved-command", draft.resolvedCommand]
     }
+    if draft.decision == .allow && draft.command.isEmpty && draft.resolvedCommand.isEmpty && draft.actionKind != "ssh_session" {
+      args.append("--any-command")
+    }
     if !draft.injectEnv.isEmpty {
       args += ["--inject-env", draft.injectEnv]
     }

--- a/native/macos-app/Sources/SgwMac/Models/Models.swift
+++ b/native/macos-app/Sources/SgwMac/Models/Models.swift
@@ -196,6 +196,10 @@ struct ApprovalPolicyConditions: Decodable, Hashable {
   var sshTargets: [String]?
   var sshPorts: [Int]?
 
+  var allowsAnyEnvironmentCommand: Bool {
+    commands?.isEmpty == true && resolvedCommands?.isEmpty == true
+  }
+
   var summary: String {
     var parts: [String] = []
     append("Handle", handles, to: &parts)

--- a/native/macos-app/Sources/SgwMac/Views/ConsoleWebAppView.swift
+++ b/native/macos-app/Sources/SgwMac/Views/ConsoleWebAppView.swift
@@ -12,7 +12,7 @@ struct ConsoleWebAppView: NSViewRepresentable {
   func makeNSView(context: Context) -> WKWebView {
     let configuration = WKWebViewConfiguration()
     configuration.websiteDataStore = .nonPersistent()
-    let webView = WKWebView(frame: .zero, configuration: configuration)
+    let webView = ConsoleWebView(frame: .zero, configuration: configuration)
     webView.navigationDelegate = context.coordinator
     webView.allowsBackForwardNavigationGestures = true
     webView.underPageBackgroundColor = NSColor(red: 0.02, green: 0.04, blue: 0.07, alpha: 1)
@@ -76,5 +76,55 @@ struct ConsoleWebAppView: NSViewRepresentable {
         webView.load(URLRequest(url: requestedURL))
       }
     }
+  }
+}
+
+final class ConsoleWebView: WKWebView {
+  static let dragSurfaceSelector = "[data-sgw-window-drag]"
+  static let interactiveSelector = "button, a, input, select, textarea, summary, [role='button'], [role='link'], [contenteditable='true'], [data-sgw-window-no-drag]"
+
+  override func mouseDown(with event: NSEvent) {
+    guard let window, shouldStartWindowDrag(at: convert(event.locationInWindow, from: nil)) else {
+      super.mouseDown(with: event)
+      return
+    }
+
+    window.performDrag(with: event)
+  }
+
+  func shouldStartWindowDrag(at point: NSPoint) -> Bool {
+    let clientY = isFlipped ? point.y : bounds.height - point.y
+    guard clientY >= 0, clientY <= 84 else {
+      return false
+    }
+
+    let script = """
+    (() => {
+      const hit = document.elementFromPoint(\(point.x), \(clientY));
+      if (!hit || hit.closest(\(Self.javaScriptString(Self.interactiveSelector)))) return false;
+      return Boolean(hit.closest(\(Self.javaScriptString(Self.dragSurfaceSelector))));
+    })()
+    """
+
+    var isDragSurface = false
+    let wait = DispatchSemaphore(value: 0)
+    evaluateJavaScript(script) { value, _ in
+      isDragSurface = value as? Bool ?? false
+      wait.signal()
+    }
+
+    let deadline = Date(timeIntervalSinceNow: 0.1)
+    while Date() < deadline {
+      if wait.wait(timeout: .now()) == .success {
+        return isDragSurface
+      }
+      RunLoop.current.run(mode: .default, before: Date(timeIntervalSinceNow: 0.001))
+    }
+    return false
+  }
+
+  private static func javaScriptString(_ value: String) -> String {
+    let data = try? JSONSerialization.data(withJSONObject: value, options: [.fragmentsAllowed])
+    return data.flatMap { String(data: $0, encoding: .utf8) } ?? "\"\""
   }
 }

--- a/native/macos-app/Sources/SgwMac/Views/PoliciesView.swift
+++ b/native/macos-app/Sources/SgwMac/Views/PoliciesView.swift
@@ -145,6 +145,10 @@ struct PoliciesView: View {
         EmptyPanel(title: "No requests to test", message: "Policy matching can be previewed after an agent creates a local authorization request.", systemImage: "target")
       } else {
         VStack(alignment: .leading, spacing: 12) {
+          Text("Rules evaluate from lowest priority to highest. Only the first matching rule applies.")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+
           Picker("Request", selection: Binding(
             get: { selectedPolicyRequestId },
             set: { selectedRequestId = $0 }
@@ -172,7 +176,7 @@ struct PoliciesView: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
             } else {
-              ForEach(matches) { rule in
+              ForEach(Array(matches.enumerated()), id: \.element.id) { index, rule in
                 HStack(spacing: 10) {
                   Image(systemName: icon(rule.decision))
                     .foregroundStyle(color(rule.decision))
@@ -185,9 +189,14 @@ struct PoliciesView: View {
                       .lineLimit(2)
                   }
                   Spacer()
-                  Text(rule.decision.label)
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(color(rule.decision))
+                  VStack(alignment: .trailing, spacing: 2) {
+                    Text(index == 0 ? "First match · wins" : "Not reached")
+                      .font(.caption2.weight(.semibold))
+                      .foregroundStyle(index == 0 ? color(rule.decision) : .secondary)
+                    Text(rule.decision.label)
+                      .font(.caption.weight(.semibold))
+                      .foregroundStyle(color(rule.decision))
+                  }
                 }
               }
             }
@@ -266,7 +275,7 @@ struct PoliciesView: View {
       PolicyTemplate(
         id: "allow-codex-selected",
         title: "Allow selected for Codex",
-        summary: "Let Codex use one selected handle without interrupting you.",
+        summary: "Let Codex run any command already permitted by one selected credential without interrupting you.",
         icon: "checkmark.shield",
         decision: .allow,
         requiresHandle: true
@@ -278,7 +287,7 @@ struct PoliciesView: View {
           decision: .allow,
           handle: handle,
           agent: "Codex",
-          actionKind: "",
+          actionKind: "env_command",
           command: "",
           injectEnv: "",
           sshTarget: "",
@@ -327,7 +336,11 @@ struct PoliciesView: View {
   private func matchingRules(for request: RequestRecord) -> [ApprovalPolicyRuleRecord] {
     appState.approvalPolicyRules
       .filter { $0.enabled && matches($0, request: request) }
-      .sorted { $0.priority < $1.priority }
+      .sorted {
+        if $0.priority != $1.priority { return $0.priority < $1.priority }
+        if $0.updatedAt != $1.updatedAt { return $0.updatedAt > $1.updatedAt }
+        return $0.id < $1.id
+      }
   }
 
   private func matches(_ rule: ApprovalPolicyRuleRecord, request: RequestRecord) -> Bool {
@@ -340,7 +353,9 @@ struct PoliciesView: View {
     if !matchesString(conditions.actionKinds, request.action.kind) { return false }
     if !matchesString(conditions.commands, request.action.command) { return false }
     if request.action.kind == "env_command" {
-      if rule.decision == .allow && (conditions.resolvedCommands?.isEmpty != false) { return false }
+      if rule.decision == .allow && (conditions.resolvedCommands?.isEmpty != false) && !conditions.allowsAnyEnvironmentCommand {
+        return false
+      }
       if let executables = conditions.resolvedCommands, !executables.isEmpty {
         guard let resolved = request.action.resolvedCommand, executables.contains(resolved) else { return false }
       }

--- a/native/macos-app/Sources/SgwMac/Views/SettingsView.swift
+++ b/native/macos-app/Sources/SgwMac/Views/SettingsView.swift
@@ -452,9 +452,14 @@ struct PolicyRuleEditor: View {
 
           TextField("Command", text: $draft.command)
           TextField("Resolved executable", text: $draft.resolvedCommand)
-          Text("Allow command policies require an exact executable path.")
+          Text("Leave both fields empty to match any command already permitted by the credential. If Command is set, Resolved executable must pin it to an exact path.")
             .font(.caption)
             .foregroundStyle(.secondary)
+          if draft.decision == .allow && !draft.command.isEmpty && draft.resolvedCommand.isEmpty {
+            Label("A named command without a pinned executable never runs automatically.", systemImage: "exclamationmark.triangle.fill")
+              .font(.caption)
+              .foregroundStyle(.orange)
+          }
           TextField("Environment name", text: $draft.injectEnv)
 
           HStack {
@@ -496,7 +501,8 @@ struct PolicyRuleEditor: View {
           save()
         }
         .keyboardShortcut(.defaultAction)
-        .disabled(draft.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        .disabled(draft.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ||
+          (draft.decision == .allow && !draft.command.isEmpty && draft.resolvedCommand.isEmpty))
       }
     }
     .padding(20)

--- a/native/macos-app/Tests/WindowDragTests.swift
+++ b/native/macos-app/Tests/WindowDragTests.swift
@@ -1,0 +1,86 @@
+import AppKit
+import Foundation
+import WebKit
+
+private func fail(_ message: String) -> Never {
+  FileHandle.standardError.write(Data(("FAIL: \(message)\n").utf8))
+  exit(1)
+}
+
+private func check(_ condition: Bool, _ message: String) {
+  if !condition { fail(message) }
+}
+
+@MainActor
+private func waitForDocument(_ webView: WKWebView) -> Bool {
+  let deadline = Date(timeIntervalSinceNow: 5)
+  while Date() < deadline {
+    var complete = false
+    var ready = false
+    webView.evaluateJavaScript("document.getElementById('blank') !== null") { value, _ in
+      ready = value as? Bool == true
+      complete = true
+    }
+    while !complete, Date() < deadline {
+      RunLoop.current.run(mode: .default, before: Date(timeIntervalSinceNow: 0.002))
+    }
+    if ready { return true }
+  }
+  return false
+}
+
+@MainActor
+private func evaluate(_ script: String, in webView: WKWebView) -> Any? {
+  let deadline = Date(timeIntervalSinceNow: 2)
+  var result: Any?
+  var complete = false
+  webView.evaluateJavaScript(script) { value, _ in
+    result = value
+    complete = true
+  }
+  while !complete, Date() < deadline {
+    RunLoop.current.run(mode: .default, before: Date(timeIntervalSinceNow: 0.002))
+  }
+  return result
+}
+
+@main
+struct WindowDragTests {
+  @MainActor
+  static func main() {
+    _ = NSApplication.shared
+    let configuration = WKWebViewConfiguration()
+    configuration.websiteDataStore = .nonPersistent()
+    let webView = ConsoleWebView(
+      frame: NSRect(x: 0, y: 0, width: 400, height: 200),
+      configuration: configuration
+    )
+    webView.loadHTMLString(
+      """
+      <!doctype html>
+      <style>
+        html, body { margin: 0; width: 400px; height: 200px; }
+        [data-sgw-window-drag] { position: fixed; inset: 0 0 auto 0; height: 52px; }
+        button { position: absolute; left: 10px; top: 10px; width: 80px; height: 30px; }
+        [role=button] { position: absolute; left: 100px; top: 10px; width: 80px; height: 30px; }
+      </style>
+      <div data-sgw-window-drag>
+        <button>Action</button>
+        <span role="button">Menu</span>
+        <span id="blank">Move</span>
+      </div>
+      """,
+      baseURL: nil
+    )
+
+    check(waitForDocument(webView), "test document did not load")
+    check(webView.isFlipped, "WKWebView should use top-left event coordinates")
+    let blank = evaluate("document.elementFromPoint(300, 20)?.outerHTML", in: webView) as? String ?? "none"
+    check(webView.shouldStartWindowDrag(at: NSPoint(x: 300, y: 20)), "blank title chrome should drag, found \(blank)")
+    check(!webView.shouldStartWindowDrag(at: NSPoint(x: 30, y: 25)), "button should stay clickable")
+    check(!webView.shouldStartWindowDrag(at: NSPoint(x: 130, y: 25)), "ARIA button should stay clickable")
+    check(!webView.shouldStartWindowDrag(at: NSPoint(x: 300, y: 100)), "page content should not drag")
+
+    print("WINDOW_DRAG_TESTS_OK")
+  }
+}

--- a/native/menu-bar-helper/Sources/AppDelegate.swift
+++ b/native/menu-bar-helper/Sources/AppDelegate.swift
@@ -372,6 +372,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
       openConsole: { [weak self] in self?.openConsoleAction() },
       testNotification: { [weak self] in self?.showTestNotificationAction() },
       approve: { [weak self] id, choice in self?.decisions.approve(id, choice: choice) },
+      approvePolicy: { [weak self] id in self?.decisions.approvePolicy(id) },
       deny: { [weak self] id in self?.decisions.deny(id) },
       setCountMode: { [weak self] mode in self?.setCountMode(mode) },
       quit: { NSApp.terminate(nil) }

--- a/native/menu-bar-helper/Sources/HelperDashboard.swift
+++ b/native/menu-bar-helper/Sources/HelperDashboard.swift
@@ -609,6 +609,12 @@ struct ApprovalPromptCard: View {
           }
         }
       }
+
+      Section("Policy") {
+        Button("Always allow this request scope") {
+          actions.approvePolicy(request.id)
+        }
+      }
     }
   }
 

--- a/native/menu-bar-helper/Sources/HelperViewModel.swift
+++ b/native/menu-bar-helper/Sources/HelperViewModel.swift
@@ -87,21 +87,47 @@ final class DecisionController {
   }
 
   func approve(_ id: String, choice: ApprovalChoice = .oneTime) {
-    decide(id, approving: true, choice: choice)
+    decide(
+      id,
+      args: ["approve", id] + choice.cliArgs,
+      successTitle: "s-gw approved",
+      successBody: "Approved request \(id).",
+      failureTitle: "Approve failed"
+    )
+  }
+
+  func approvePolicy(_ id: String) {
+    decide(
+      id,
+      args: ["approve-policy", id],
+      successTitle: "s-gw policy added",
+      successBody: "Allowed this request scope and approved request \(id).",
+      failureTitle: "Allow policy failed"
+    )
   }
 
   func deny(_ id: String) {
-    decide(id, approving: false, choice: nil)
+    decide(
+      id,
+      args: ["deny", id],
+      successTitle: "s-gw denied",
+      successBody: "Denied request \(id).",
+      failureTitle: "Deny failed"
+    )
   }
 
-  private func decide(_ id: String, approving: Bool, choice: ApprovalChoice?) {
+  private func decide(
+    _ id: String,
+    args: [String],
+    successTitle: String,
+    successBody: String,
+    failureTitle: String
+  ) {
     guard !decidingRequestIds.contains(id) else { return }
     decidingRequestIds.insert(id)
     onInFlightChange(decidingRequestIds)
 
-    let verb = approving ? "approve" : "deny"
     let run = runCli
-    let args = [verb, id] + (approving ? (choice?.cliArgs ?? ApprovalChoice.oneTime.cliArgs) : [])
 
     Task {
       let result = await Task.detached { run(args) }.value
@@ -109,15 +135,14 @@ final class DecisionController {
       self.onInFlightChange(self.decidingRequestIds)
 
       if result.ok {
-        let label = approving ? "approved" : "denied"
         self.notify(DecisionOutcome(
-          title: "s-gw \(label)",
-          body: "\(approving ? "Approved" : "Denied") request \(id).",
+          title: successTitle,
+          body: successBody,
           succeeded: true
         ))
       } else {
         self.notify(DecisionOutcome(
-          title: approving ? "Approve failed" : "Deny failed",
+          title: failureTitle,
           body: Self.failureReason(result.stderr ?? result.stdout, id: id),
           succeeded: false
         ))

--- a/native/menu-bar-helper/Sources/Models.swift
+++ b/native/menu-bar-helper/Sources/Models.swift
@@ -279,6 +279,7 @@ struct HelperMenuActions {
   let openConsole: () -> Void
   let testNotification: () -> Void
   let approve: (String, ApprovalChoice) -> Void
+  let approvePolicy: (String) -> Void
   let deny: (String) -> Void
   let setCountMode: (StatusCountMode) -> Void
   let quit: () -> Void

--- a/native/menu-bar-helper/Tests/DecisionGuardTests.swift
+++ b/native/menu-bar-helper/Tests/DecisionGuardTests.swift
@@ -69,14 +69,14 @@ fileprivate struct Scratch {
     gate = base.appendingPathComponent("gate.fifo")
     mkfifo(gate.path, 0o600)
 
-    // approve/deny block on the FIFO so the decision is genuinely in flight;
+    // approval actions block on the FIFO so the decision is genuinely in flight;
     // any other verb returns at once.
     let script = """
     #!/bin/zsh
     verb="$1"
     print -- "$verb" >> "\(invocationLog.path)"
     case "$verb" in
-      approve|deny)
+      approve|approve-policy|deny)
         read _line < "\(gate.path)"
         print -- '{"ok":true}'
         exit 0
@@ -157,6 +157,7 @@ struct DecisionGuardTests {
 
     await runInFlightGuardTest(scratch)
     await runGuardReleaseTest(scratch)
+    await runScopedPolicyApprovalTest(scratch)
     runFailureReasonTest()
     runRouteAndSizingTest()
     runApprovalFlowTest()
@@ -241,6 +242,36 @@ struct DecisionGuardTests {
     scratch.releaseOneInFlight()
     let done = await waitUntil(3.0) { !controller.isDeciding(id) }
     check(done, "second decision should clear its in-flight id too")
+  }
+
+  @MainActor
+  fileprivate static func runScopedPolicyApprovalTest(_ scratch: Scratch) async {
+    var outcomes: [DecisionOutcome] = []
+    let controller = DecisionController(
+      runCli: { args in runFakeCli(scratch.fakeCli.path, args) },
+      notify: { outcomes.append($0) },
+      afterDecision: {}
+    )
+    let id = "req-scoped-policy"
+    let before = scratch.verbs().filter { $0 == "approve-policy" }.count
+    let approveBefore = scratch.verbs().filter { $0 == "approve" }.count
+
+    controller.approvePolicy(id)
+    let started = await waitUntil(3.0) {
+      scratch.verbs().filter { $0 == "approve-policy" }.count == before + 1 && controller.isDeciding(id)
+    }
+    check(started, "scoped policy approval should invoke the approve-policy CLI command")
+
+    controller.approve(id)
+    try? await Task.sleep(for: .milliseconds(100))
+    check(scratch.verbs().filter { $0 == "approve" }.count == approveBefore,
+          "a second decision for the same request must be suppressed while approve-policy is running")
+
+    scratch.releaseOneInFlight()
+    let done = await waitUntil(3.0) { !controller.isDeciding(id) }
+    check(done, "scoped policy approval should release its in-flight request id")
+    check(outcomes.first?.title == "s-gw policy added" && outcomes.first?.succeeded == true,
+          "scoped policy approval should report an honest success")
   }
 
   // Test 3: the honest-failure parser pulls a clean reason out of the CLI's real

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -559,6 +559,15 @@ async function main(): Promise<void> {
     return;
   }
 
+  if (first === "approve-policy") {
+    if (!second) {
+      throw new Error("approve-policy requires a request id.");
+    }
+
+    printJson(await store.approveRequestWithScopedPolicy(second));
+    return;
+  }
+
   if (first === "deny") {
     if (!second) {
       throw new Error("deny requires a request id.");
@@ -2065,6 +2074,7 @@ async function handleApprovalPolicyCommand(
   }
 
   if (action === "add") {
+    assertAnyCommandFlag(flags);
     const duration = getFlag(flags, "duration") || getFlag(flags, "duration-ms");
     printJson(
       await store.addApprovalPolicyRule({
@@ -2084,6 +2094,7 @@ async function handleApprovalPolicyCommand(
     if (!approvalPolicyUpdateFlags.some((flag) => hasFlag(flags, flag))) {
       throw new Error("approval policy update needs at least one change.");
     }
+    assertAnyCommandFlag(flags);
 
     const duration = getFlag(flags, "duration") || getFlag(flags, "duration-ms");
     const conditions = approvalPolicyConditionPatchFromFlags(flags);
@@ -2139,6 +2150,7 @@ const approvalPolicyUpdateFlags = [
   "action-kind",
   "command",
   "resolved-command",
+  "any-command",
   "inject-env",
   "working-dir",
   "cwd",
@@ -2151,7 +2163,7 @@ const approvalPolicyUpdateFlags = [
 function approvalPolicyConditionsFromFlags(
   flags: Record<string, string | boolean | string[]>
 ): ApprovalPolicyConditions {
-  return {
+  const conditions: ApprovalPolicyConditions = {
     handles: getFlagList(flags, "handle"),
     envBindings: approvalPolicyEnvBindingsFromFlags(flags),
     secretTypes: getFlagList(flags, "type").map(approvalPolicySecretType),
@@ -2159,13 +2171,21 @@ function approvalPolicyConditionsFromFlags(
     minSeverity: optionalSecretSeverity(getFlag(flags, "min-severity")),
     agents: getFlagList(flags, "agent"),
     actionKinds: getFlagList(flags, "action-kind").map(approvalPolicyActionKind),
-    commands: getFlagList(flags, "command"),
-    resolvedCommands: getFlagList(flags, "resolved-command"),
     injectEnvs: getFlagList(flags, "inject-env"),
     workingDirs: getFlagList(flags, "working-dir").concat(getFlagList(flags, "cwd")),
     sshTargets: getFlagList(flags, "ssh-target").concat(getFlagList(flags, "target")),
     sshPorts: getFlagList(flags, "ssh-port").concat(getFlagList(flags, "port")).map((item) => Number(item))
   };
+
+  if (hasFlag(flags, "any-command")) {
+    conditions.commands = [];
+    conditions.resolvedCommands = [];
+  } else {
+    if (hasFlag(flags, "command")) conditions.commands = getFlagList(flags, "command");
+    if (hasFlag(flags, "resolved-command")) conditions.resolvedCommands = getFlagList(flags, "resolved-command");
+  }
+
+  return conditions;
 }
 
 function approvalPolicyConditionPatchFromFlags(
@@ -2181,6 +2201,7 @@ function approvalPolicyConditionPatchFromFlags(
     "action-kind",
     "command",
     "resolved-command",
+    "any-command",
     "inject-env",
     "working-dir",
     "cwd",
@@ -2201,8 +2222,13 @@ function approvalPolicyConditionPatchFromFlags(
   if (hasFlag(flags, "min-severity")) patch.minSeverity = optionalSecretSeverity(getFlag(flags, "min-severity"));
   if (hasFlag(flags, "agent")) patch.agents = getFlagList(flags, "agent");
   if (hasFlag(flags, "action-kind")) patch.actionKinds = getFlagList(flags, "action-kind").map(approvalPolicyActionKind);
-  if (hasFlag(flags, "command")) patch.commands = getFlagList(flags, "command");
-  if (hasFlag(flags, "resolved-command")) patch.resolvedCommands = getFlagList(flags, "resolved-command");
+  if (hasFlag(flags, "any-command")) {
+    patch.commands = [];
+    patch.resolvedCommands = [];
+  } else {
+    if (hasFlag(flags, "command")) patch.commands = getFlagList(flags, "command");
+    if (hasFlag(flags, "resolved-command")) patch.resolvedCommands = getFlagList(flags, "resolved-command");
+  }
   if (hasFlag(flags, "inject-env")) patch.injectEnvs = getFlagList(flags, "inject-env");
   if (hasFlag(flags, "working-dir") || hasFlag(flags, "cwd")) {
     patch.workingDirs = getFlagList(flags, "working-dir").concat(getFlagList(flags, "cwd"));
@@ -2214,6 +2240,15 @@ function approvalPolicyConditionPatchFromFlags(
     patch.sshPorts = getFlagList(flags, "ssh-port").concat(getFlagList(flags, "port")).map((item) => Number(item));
   }
   return patch;
+}
+
+function assertAnyCommandFlag(flags: Record<string, string | boolean | string[]>): void {
+  if (!hasFlag(flags, "any-command")) {
+    return;
+  }
+  if (hasFlag(flags, "command") || hasFlag(flags, "resolved-command")) {
+    throw new Error("--any-command cannot be combined with --command or --resolved-command.");
+  }
 }
 
 function approvalPolicyEnvBindingsFromFlags(
@@ -2540,8 +2575,8 @@ Commands:
   s-gw approval set --mode per-transaction|timed-session|login-session|always [--duration 15m]
   s-gw approval grants
   s-gw approval policy list
-  s-gw approval policy add --name NAME --decision allow|ask|deny [--handle HANDLE] [--binding ENV=HANDLE] [--agent Codex] [--command NAME] [--resolved-command /path/to/tool] [--action-kind env_command|ssh_session] [--duration 8h]
-  s-gw approval policy update --id POLICY_ID [--name NAME] [--decision allow|ask|deny] [--handle HANDLE] [--agent Codex] [--command NAME] [--resolved-command /path/to/tool] [--clear-expiry]
+  s-gw approval policy add --name NAME --decision allow|ask|deny [--handle HANDLE] [--binding ENV=HANDLE] [--agent Codex] [--command NAME] [--resolved-command /path/to/tool] [--any-command] [--action-kind env_command|ssh_session] [--duration 8h]
+  s-gw approval policy update --id POLICY_ID [--name NAME] [--decision allow|ask|deny] [--handle HANDLE] [--agent Codex] [--command NAME] [--resolved-command /path/to/tool] [--any-command] [--clear-expiry]
   s-gw approval policy arrange
   s-gw approval policy delete --id POLICY_ID
   s-gw approval policy enable|disable --id POLICY_ID
@@ -2562,6 +2597,7 @@ Commands:
   s-gw execute-next [--handle HANDLE] [--kind env_command|ssh_session] [--command CMD]
   s-gw store backups
   s-gw approve REQUEST_ID [--mode per-transaction|timed-session|login-session|always] [--duration 8h] [--agent-scope same-agent|any-agent]
+  s-gw approve-policy REQUEST_ID
   s-gw deny REQUEST_ID
   s-gw execute REQUEST_ID
 `);

--- a/src/command-suggest.ts
+++ b/src/command-suggest.ts
@@ -67,6 +67,7 @@ export const KNOWN_COMMANDS = [
   "requests cleanup",
   "store backups",
   "approve",
+  "approve-policy",
   "deny",
   "execute",
   "execute-next"

--- a/src/console-server.ts
+++ b/src/console-server.ts
@@ -1293,7 +1293,7 @@ function policyRuleUpdateInput(body: Record<string, unknown>): UpdateApprovalPol
 }
 
 function policyConditionsFromBody(body: Record<string, unknown>): ApprovalPolicyConditions {
-  return {
+  const conditions: ApprovalPolicyConditions = {
     handles: policyStringArray(body, "handles"),
     envBindings: policyEnvBindings(body.envBindings),
     secretTypes: policyStringArray(body, "secretTypes").map(policySecretType),
@@ -1301,13 +1301,14 @@ function policyConditionsFromBody(body: Record<string, unknown>): ApprovalPolicy
     minSeverity: optionalSecretSeverity(body.minSeverity),
     agents: policyStringArray(body, "agents"),
     actionKinds: policyStringArray(body, "actionKinds").map(approvalPolicyActionKind),
-    commands: policyStringArray(body, "commands"),
-    resolvedCommands: policyStringArray(body, "resolvedCommands"),
     injectEnvs: policyStringArray(body, "injectEnvs"),
     workingDirs: policyStringArray(body, "workingDirs"),
     sshTargets: policyStringArray(body, "sshTargets"),
     sshPorts: policyNumberArray(body, "sshPorts")
   };
+  if (hasBodyField(body, "commands")) conditions.commands = policyStringArray(body, "commands");
+  if (hasBodyField(body, "resolvedCommands")) conditions.resolvedCommands = policyStringArray(body, "resolvedCommands");
+  return conditions;
 }
 
 function policyConditionPatchFromBody(body: Record<string, unknown>): Partial<ApprovalPolicyConditions> | undefined {

--- a/src/console-ui/src/App.tsx
+++ b/src/console-ui/src/App.tsx
@@ -165,7 +165,7 @@ import {
 } from "@/lib/layout";
 import { credentialBackendLabel, credentialProviderPresentation } from "@/lib/credential-presentation";
 import { addDemoData, DEMO_DATA_STORAGE_KEY } from "@/lib/demo-data";
-import { findShadowingPolicyRule } from "../../policy-order";
+import { findShadowingPolicyRule, policyAllowsAnyEnvCommand } from "../../policy-order";
 import {
   commandName,
   durationLabel,
@@ -404,18 +404,21 @@ function ConsoleShell({ ctx, theme, setTheme }: { ctx: ConsoleContext; theme: st
 
       <SidebarInset className="sgw-console-main min-w-0 bg-transparent">
         {nativeShell ? (
-          <NativeWindowActions
-            ctx={displayCtx}
-            state={state}
-            theme={theme}
-            setTheme={setTheme}
-            setView={setView}
-            view={view}
-            onResetLayout={resetOverviewLayout}
-            setCommandOpen={setCommandOpen}
-            demoEnabled={demoEnabled}
-            onToggleDemoData={toggleDemoData}
-          />
+          <>
+            <div className="sgw-native-drag-surface" data-sgw-window-drag aria-hidden="true" />
+            <NativeWindowActions
+              ctx={displayCtx}
+              state={state}
+              theme={theme}
+              setTheme={setTheme}
+              setView={setView}
+              view={view}
+              onResetLayout={resetOverviewLayout}
+              setCommandOpen={setCommandOpen}
+              demoEnabled={demoEnabled}
+              onToggleDemoData={toggleDemoData}
+            />
+          </>
         ) : (
           <ConsoleTopbar
             ctx={displayCtx}
@@ -627,7 +630,7 @@ function ConsoleSidebar({
   return (
     <Sidebar collapsible="icon" className="border-r border-sidebar-border/80">
       <SidebarHeader className="sgw-sidebar-header h-14 justify-center px-3 group-data-[collapsible=icon]:px-2">
-        <div className="sgw-sidebar-titlebar flex w-full items-center justify-end gap-2 group-data-[collapsible=icon]:justify-center">
+        <div className="sgw-sidebar-titlebar flex w-full items-center justify-end gap-2 group-data-[collapsible=icon]:justify-center" data-sgw-window-drag>
           <Tooltip>
             <TooltipTrigger asChild>
               <SidebarTrigger className="sgw-sidebar-titlebar-trigger h-8 w-8 shrink-0 rounded-md text-sidebar-foreground hover:bg-sidebar-accent group-data-[collapsible=icon]:hidden" />
@@ -1453,6 +1456,9 @@ function PolicyConditionsCell({ conditions }: { conditions: ApprovalPolicyRuleRe
           {titleCase(agent)}
         </span>
       ))}
+      {policyAllowsAnyEnvCommand(conditions) ? (
+        <span className="rounded-md bg-muted px-1.5 py-0.5 text-xs">Any credential-permitted command</span>
+      ) : null}
       {hasRest ? <span className="truncate text-sm text-muted-foreground">{restSummary}</span> : null}
     </div>
   );
@@ -1679,7 +1685,7 @@ function PolicyDetailPanel({
 
   return (
     <div className="space-y-5 px-4 py-5 lg:px-6" data-policy-detail={rule.id}>
-      <PolicyFlowPreview form={policyFormFromRule(rule)} state={state} />
+      <PolicyFlowPreview form={policyFormFromRule(rule)} state={state} rule={rule} />
       {shadowedBy ? (
         <Alert variant={coveredBySameDecision ? "default" : "destructive"}>
           <EyeOff className="h-4 w-4" />
@@ -1704,7 +1710,7 @@ function PolicyDetailPanel({
           ["Agents", policyDetailValue(conditions.agents)],
           ["Credentials", bindings.length > 0 ? bindings.join(", ") : policyDetailValue(conditions.handles, (handle) => state.handles.find((item) => item.handle === handle)?.name || shortHandle(handle))],
           ["Action", policyDetailValue([...(conditions.actionKinds || []), ...(conditions.commands || [])])],
-          ["Executables", policyDetailValue(conditions.resolvedCommands)],
+          ["Executables", policyAllowsAnyEnvCommand(conditions) ? "Any executable permitted by the credential" : policyDetailValue(conditions.resolvedCommands)],
           ["Scope", policyDetailValue([...(conditions.providers || []), ...(conditions.secretTypes || []), conditions.minSeverity ? `${conditions.minSeverity} and above` : ""])],
           ["Environment", policyDetailValue([...(conditions.injectEnvs || []), ...(conditions.workingDirs || [])])],
           ["SSH", policyDetailValue([...(conditions.sshTargets || []), ...(conditions.sshPorts || []).map(String)])],
@@ -3439,14 +3445,24 @@ function PolicyEditorDialog({
   const [form, setForm] = React.useState<PolicyFormState>(emptyPolicyForm);
   const [advanced, setAdvanced] = React.useState(false);
   const [busy, setBusy] = React.useState(false);
+  const [confirmAnyCommandConversion, setConfirmAnyCommandConversion] = React.useState(false);
   const sources = React.useMemo(() => buildPolicyOptionSources(state), [state]);
   const editing = Boolean(rule);
   const bindingsLocked = Boolean(rule?.conditions.envBindings?.length);
+  const namedCommandNeedsExecutable = form.decision === "allow" && form.commands.length > 0 && form.resolvedCommands.length === 0;
+  const includesEnvCommand = form.actionKinds.length === 0 || form.actionKinds.includes("env_command");
+  const convertsLegacyCommandScope = Boolean(
+    rule && form.decision === "allow" && includesEnvCommand &&
+    form.commands.length === 0 && form.resolvedCommands.length === 0 &&
+    !policyAllowsAnyEnvCommand(rule.conditions)
+  );
+  const saveBlocked = namedCommandNeedsExecutable || (convertsLegacyCommandScope && !confirmAnyCommandConversion);
 
   React.useEffect(() => {
     if (!open) return;
     setForm(rule ? policyFormFromRule(rule) : emptyPolicyForm());
     setAdvanced(Boolean(rule));
+    setConfirmAnyCommandConversion(false);
   }, [open, rule]);
 
   const update = <K extends keyof PolicyFormState>(field: K, value: PolicyFormState[K]) => {
@@ -3454,7 +3470,7 @@ function PolicyEditorDialog({
   };
 
   async function save() {
-    if (busy || !form.name.trim()) return;
+    if (busy || !form.name.trim() || saveBlocked) return;
     setBusy(true);
     try {
       const body = policyFormToInput(form, rule?.enabled ?? true, bindingsLocked);
@@ -3480,7 +3496,7 @@ function PolicyEditorDialog({
         <DialogHeader>
           <DialogTitle>{editing ? "Edit policy rule" : "Add policy rule"}</DialogTitle>
           <DialogDescription>
-            Leave a condition empty to match anything. The preview shows the request shape this rule will affect.
+            Empty conditions are wildcards. In an allow rule, empty Commands and Resolved executables means any command already permitted by the credential. Lower priority numbers run first.
           </DialogDescription>
         </DialogHeader>
         <div className="space-y-5">
@@ -3500,7 +3516,32 @@ function PolicyEditorDialog({
               </AlertDescription>
             </Alert>
           ) : null}
-          <PolicyFlowPreview form={form} state={state} />
+          <PolicyFlowPreview form={form} state={state} rule={rule || undefined} />
+          {namedCommandNeedsExecutable ? (
+            <Alert variant="destructive" data-policy-command-pin-warning>
+              <AlertTriangle className="h-4 w-4" />
+              <AlertTitle>Pin the named command</AlertTitle>
+              <AlertDescription>Add at least one exact Resolved executable path. A named command without a pinned executable never runs automatically.</AlertDescription>
+            </Alert>
+          ) : null}
+          {convertsLegacyCommandScope ? (
+            <Alert data-policy-any-command-conversion>
+              <AlertTriangle className="h-4 w-4" />
+              <AlertTitle>This legacy rule is not an Any command rule yet</AlertTitle>
+              <AlertDescription>
+                <p>Its saved command scope is incomplete, so it does not currently auto-authorize environment commands. Saving both fields empty will deliberately convert it to Any credential-permitted command.</p>
+                <label className="mt-3 flex cursor-pointer items-start gap-2 text-foreground">
+                  <input
+                    type="checkbox"
+                    className="mt-0.5 h-4 w-4"
+                    checked={confirmAnyCommandConversion}
+                    onChange={(event) => setConfirmAnyCommandConversion(event.target.checked)}
+                  />
+                  <span>I understand this rule will allow any command already permitted by the selected credential.</span>
+                </label>
+              </AlertDescription>
+            </Alert>
+          ) : null}
           <PolicyFormFields
             form={form}
             update={update}
@@ -3512,7 +3553,7 @@ function PolicyEditorDialog({
         </div>
         <DialogFooter>
           <Button variant="outline" onClick={() => onOpenChange(false)} disabled={busy}>Cancel</Button>
-          <Button onClick={() => void save()} disabled={busy || !form.name.trim()}>
+          <Button onClick={() => void save()} disabled={busy || !form.name.trim() || saveBlocked}>
             {busy ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
             {editing ? "Save changes" : "Add rule"}
           </Button>
@@ -3558,10 +3599,10 @@ function PolicyFormFields({
       <PolicyField label={bindingsLocked ? "Credentials (fixed)" : "Credentials"} hint={bindingsLocked ? "Fixed by the exact binding set above." : undefined}>
         <MultiSelectField values={form.handles} onChange={(value) => update("handles", value)} options={sources.handles} disabled={bindingsLocked} aria-label="Policy credentials" />
       </PolicyField>
-      <PolicyField label="Commands">
+      <PolicyField label="Commands" hint="Leave this and Resolved executables empty to allow any command already permitted by the selected credential.">
         <MultiSelectField values={form.commands} onChange={(value) => update("commands", value)} options={sources.commands} aria-label="Policy commands" />
       </PolicyField>
-      <PolicyField label="Resolved executables" hint="Allow rules use exact executable paths; old unpinned allow rules do not authorize command execution.">
+      <PolicyField label="Resolved executables" hint="Pins named commands to exact executable paths. If Commands is not empty, an allow rule needs at least one path here.">
         <MultiSelectField values={form.resolvedCommands} onChange={(value) => update("resolvedCommands", value)} options={sources.resolvedCommands} aria-label="Policy resolved executables" />
       </PolicyField>
       <PolicyField label="Action kinds">
@@ -3624,18 +3665,92 @@ function PolicyField({ label, hint, className, children }: { label: string; hint
   );
 }
 
-function PolicyFlowPreview({ form, state }: { form: PolicyFormState; state: ConsoleState }) {
+function PolicyFlowPreview({
+  form,
+  state,
+  rule
+}: {
+  form: PolicyFormState;
+  state: ConsoleState;
+  rule?: ApprovalPolicyRuleRecord;
+}) {
   const handleLabels = form.handles.map((handle) => state.handles.find((item) => item.handle === handle)?.name || shortHandle(handle));
   const decisionCopy = form.decision === "allow" ? "Runs automatically" : form.decision === "deny" ? "Blocked automatically" : "Requires approval";
   const DecisionIcon = form.decision === "allow" ? ShieldCheck : form.decision === "deny" ? Ban : Clock3;
+  const candidate = policyPreviewCandidate(form, state, rule);
+  const rules = rule
+    ? state.approvalPolicyRules.map((item) => item.id === rule.id ? candidate : item)
+    : [...state.approvalPolicyRules, candidate];
+  const firstMatch = findShadowingPolicyRule(rules, candidate);
   return (
     <div className="grid gap-2 rounded-lg border bg-muted/30 p-3 text-sm sm:grid-cols-4" data-policy-flow-preview>
       <PolicyFlowCell label="Agent" value={summarizePolicyValues(form.agents, "Any agent")} icon={<UsersRound className="h-4 w-4" />} />
-      <PolicyFlowCell label="Action" value={summarizePolicyValues(form.commands, form.actionKinds.includes("ssh_session") ? "SSH session" : "Any command")} icon={<CommandIcon className="h-4 w-4" />} />
+      <PolicyFlowCell label="Action" value={policyActionPreview(form)} icon={<CommandIcon className="h-4 w-4" />} />
       <PolicyFlowCell label="Credential" value={summarizePolicyValues(handleLabels, "Any credential")} icon={<KeyRound className="h-4 w-4" />} />
       <PolicyFlowCell label="Decision" value={decisionCopy} icon={<DecisionIcon className="h-4 w-4" />} />
+      {firstMatch ? (
+        <div className="flex items-center gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 px-2.5 py-2 text-xs text-amber-700 sm:col-span-4 dark:text-amber-300" data-policy-first-match>
+          <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+          First matching rule: “{firstMatch.name}” at priority {firstMatch.priority} ({firstMatch.decision}). This rule is not reached for the full previewed scope.
+        </div>
+      ) : (
+        <div className="text-xs text-muted-foreground sm:col-span-4" data-policy-first-match>
+          No earlier rule covers this entire preview scope. A narrower earlier rule can still win for requests it matches.
+        </div>
+      )}
     </div>
   );
+}
+
+function policyPreviewCandidate(
+  form: PolicyFormState,
+  state: ConsoleState,
+  rule?: ApprovalPolicyRuleRecord
+): ApprovalPolicyRuleRecord {
+  const now = new Date().toISOString();
+  const fallbackPriority = state.approvalPolicyRules.length
+    ? Math.max(...state.approvalPolicyRules.map((item) => item.priority)) + 10
+    : 100;
+  return {
+    id: rule?.id || "policy_preview",
+    name: form.name.trim() || "This rule",
+    enabled: rule?.enabled ?? true,
+    priority: form.priority.trim() ? Number(form.priority) : fallbackPriority,
+    decision: form.decision,
+    conditions: {
+      handles: form.handles,
+      envBindings: rule?.conditions.envBindings,
+      providers: form.providers,
+      secretTypes: form.secretTypes,
+      minSeverity: form.minSeverity ? form.minSeverity as SecretSeverity : undefined,
+      agents: form.agents,
+      actionKinds: form.actionKinds,
+      commands: form.commands,
+      resolvedCommands: form.resolvedCommands,
+      injectEnvs: form.injectEnvs,
+      workingDirs: form.workingDirs,
+      sshTargets: form.sshTargets,
+      sshPorts: form.sshPorts.map(Number)
+    },
+    expiresAt: rule?.expiresAt,
+    createdAt: rule?.createdAt || now,
+    updatedAt: rule?.updatedAt || now
+  };
+}
+
+function policyActionPreview(form: PolicyFormState): string {
+  if (form.actionKinds.length === 1 && form.actionKinds[0] === "ssh_session") {
+    return "SSH session";
+  }
+  if (form.commands.length > 0) {
+    return summarizePolicyValues(form.commands, "Any command");
+  }
+  if (form.resolvedCommands.length > 0) {
+    return summarizePolicyValues(form.resolvedCommands, "Any executable");
+  }
+  return form.actionKinds.includes("ssh_session")
+    ? "Any permitted command or SSH"
+    : "Any credential-permitted command";
 }
 
 function PolicyFlowCell({ label, value, icon }: { label: string; value: string; icon: React.ReactNode }) {

--- a/src/console-ui/src/index.css
+++ b/src/console-ui/src/index.css
@@ -194,6 +194,19 @@
   backdrop-filter: none;
 }
 
+.sgw-native-drag-surface {
+  position: absolute;
+  top: 0;
+  right: 0;
+  left: 0;
+  z-index: 40;
+  height: 3.3rem;
+}
+
+.sgw-native-actions {
+  pointer-events: auto;
+}
+
 .sgw-native-actions [data-slot="button"],
 .sgw-native-actions [data-slot="badge"] {
   box-shadow: none;

--- a/src/policy-order.ts
+++ b/src/policy-order.ts
@@ -71,8 +71,8 @@ export function approvalPolicyRuleCovers<T extends PolicyRuleLike>(broader: T, n
   if (!bindingSetCovers(broader.conditions.envBindings, narrower.conditions.envBindings)) {
     return false;
   }
-  if (broader.decision === "allow" && !broader.conditions.resolvedCommands?.length &&
-      narrower.conditions.resolvedCommands?.length) {
+  if (broader.decision === "allow" && narrower.conditions.resolvedCommands?.length &&
+      !policyHasEffectiveEnvCommandScope(broader.conditions)) {
     return false;
   }
 
@@ -89,6 +89,17 @@ export function approvalPolicyRuleCovers<T extends PolicyRuleLike>(broader: T, n
   }
 
   return true;
+}
+
+export function policyAllowsAnyEnvCommand(conditions: PolicyConditionsLike): boolean {
+  return Object.prototype.hasOwnProperty.call(conditions, "commands") &&
+    Object.prototype.hasOwnProperty.call(conditions, "resolvedCommands") &&
+    Array.isArray(conditions.commands) && conditions.commands.length === 0 &&
+    Array.isArray(conditions.resolvedCommands) && conditions.resolvedCommands.length === 0;
+}
+
+function policyHasEffectiveEnvCommandScope(conditions: PolicyConditionsLike): boolean {
+  return Boolean(conditions.resolvedCommands?.length) || policyAllowsAnyEnvCommand(conditions);
 }
 
 export function approvalPolicyRulesEquivalent<T extends PolicyRuleLike>(left: T, right: T): boolean {

--- a/src/store.ts
+++ b/src/store.ts
@@ -6,7 +6,11 @@ import { decryptSecret, encryptSecret, fingerprintSecret, shortId } from "./cryp
 import { agentNameFromReason, requestAgentIdentity, requestAgentName, type AgentIdentity, type AgentIdentityContext } from "./agent-context.js";
 import { isAbsoluteCommand, resolveCommandExecutable, verifyPinnedCommand } from "./command-path.js";
 import { normalizeOnePasswordReference, readOnePasswordReference } from "./onepassword.js";
-import { arrangeApprovalPolicyRules as arrangePolicyRules, compareApprovalPolicyRules } from "./policy-order.js";
+import {
+  arrangeApprovalPolicyRules as arrangePolicyRules,
+  compareApprovalPolicyRules,
+  policyAllowsAnyEnvCommand
+} from "./policy-order.js";
 import { SGW_SSH_SESSION_COMMAND, normalizeSshPort, normalizeSshTarget, sshSessionIdentity } from "./ssh.js";
 import { ensureSgwHome, getSgwHome, getSgwLoginSessionId, getSgwRecoveryHome, getStorePath } from "./paths.js";
 import {
@@ -3503,7 +3507,8 @@ function approvalPolicyMatches(
   }
   if (action.kind === "env_command") {
     const resolved = action.resolvedCommand;
-    if (rule.decision === "allow" && !conditions.resolvedCommands?.length) {
+    if (rule.decision === "allow" && !conditions.resolvedCommands?.length &&
+        !policyAllowsAnyEnvCommand(rule.conditions)) {
       return false;
     }
     if (conditions.resolvedCommands?.length &&
@@ -3708,7 +3713,7 @@ function normalizeApprovalPolicyConditions(
   const resolvedCommands = policyStringValues(input?.resolvedCommands, "resolvedCommands", strict);
   const minSeverity = normalizePolicySeverity(input?.minSeverity, strict);
 
-  return {
+  const normalized: ApprovalPolicyConditions = {
     handles: policyStringValues(input?.handles, "handles", strict),
     envBindings: normalizePolicyEnvBindings(input?.envBindings, strict),
     secretTypes: normalizePolicySecretTypes(secretTypes, strict),
@@ -3716,17 +3721,24 @@ function normalizeApprovalPolicyConditions(
     minSeverity,
     agents: policyStringValues(input?.agents, "agents", strict).map((agent) => agent.toLowerCase()),
     actionKinds: normalizePolicyActionKinds(actionKinds, strict),
-    commands: strict
-      ? commands.map((command) => normalizeCommandGrant(command))
-      : commands.map((command) => safeNormalizeCommandGrant(command)).filter(Boolean) as string[],
-    resolvedCommands: strict
-      ? resolvedCommands.map(normalizeResolvedPolicyCommand)
-      : resolvedCommands.map(safeNormalizeResolvedPolicyCommand).filter(Boolean) as string[],
     injectEnvs: policyStringValues(input?.injectEnvs, "injectEnvs", strict),
     workingDirs: policyStringValues(input?.workingDirs, "workingDirs", strict).map((dir) => path.resolve(dir)),
     sshTargets: policyStringValues(input?.sshTargets, "sshTargets", strict).map((target) => normalizeSshTarget(target)),
     sshPorts: normalizePolicyPorts(input?.sshPorts, strict)
   };
+
+  if (input && hasOwn(input, "commands")) {
+    normalized.commands = strict
+      ? commands.map((command) => normalizeCommandGrant(command))
+      : commands.map((command) => safeNormalizeCommandGrant(command)).filter(Boolean) as string[];
+  }
+  if (input && hasOwn(input, "resolvedCommands")) {
+    normalized.resolvedCommands = strict
+      ? resolvedCommands.map(normalizeResolvedPolicyCommand)
+      : resolvedCommands.map(safeNormalizeResolvedPolicyCommand).filter(Boolean) as string[];
+  }
+
+  return normalized;
 }
 
 function mergeApprovalPolicyConditions(

--- a/tests/approval-requester-session.test.ts
+++ b/tests/approval-requester-session.test.ts
@@ -1,0 +1,127 @@
+import { execFileSync } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { buildEnvCommandAction } from "../src/gateway.js";
+import { SecretStore } from "../src/store.js";
+
+const repoRoot = process.cwd();
+const tsxCli = path.join(repoRoot, "node_modules", "tsx", "dist", "cli.mjs");
+const requesterSession = "requester-session-a";
+const approverSession = "approver-session-b";
+const eightHoursMs = 8 * 60 * 60 * 1000;
+
+let testHome = "";
+let recoveryHome = "";
+let previousEnv: Record<string, string | undefined> = {};
+
+beforeEach(async () => {
+  previousEnv = {
+    SGW_HOME: process.env.SGW_HOME,
+    SGW_RECOVERY_HOME: process.env.SGW_RECOVERY_HOME,
+    SGW_MASTER_PASSPHRASE: process.env.SGW_MASTER_PASSPHRASE,
+    SGW_LOGIN_SESSION_ID: process.env.SGW_LOGIN_SESSION_ID
+  };
+  testHome = await mkdtemp(path.join(os.tmpdir(), "sgw-requester-session-"));
+  recoveryHome = `${testHome}-recovery`;
+  process.env.SGW_HOME = testHome;
+  process.env.SGW_RECOVERY_HOME = recoveryHome;
+  process.env.SGW_MASTER_PASSPHRASE = "requester session test passphrase";
+  process.env.SGW_LOGIN_SESSION_ID = requesterSession;
+});
+
+afterEach(async () => {
+  await rm(testHome, { recursive: true, force: true });
+  await rm(recoveryHome, { recursive: true, force: true });
+  for (const [name, value] of Object.entries(previousEnv)) {
+    if (value === undefined) {
+      delete process.env[name];
+    } else {
+      process.env[name] = value;
+    }
+  }
+});
+
+describe("reusable approvals from a separate approval process", () => {
+  it.each([
+    {
+      label: "8-hour timed",
+      args: ["--mode", "timed-session", "--agent-scope", "same-agent", "--duration-ms", String(eightHoursMs)],
+      mode: "timed-session",
+      expires: true
+    },
+    {
+      label: "login-session",
+      args: ["--mode", "login-session", "--agent-scope", "same-agent"],
+      mode: "login-session",
+      expires: false
+    }
+  ])("binds an explicit $label CLI approval to requester session A, not approver session B", async ({ args, mode, expires }) => {
+    const store = new SecretStore();
+    const secret = await store.addSecret({
+      name: "requester session token",
+      type: "api-token",
+      value: "requester-session-secret-value-123456789",
+      policy: {
+        injectEnv: "SGW_REQUESTER_SESSION_TOKEN",
+        allowedCommands: [process.execPath]
+      }
+    });
+    const action = buildEnvCommandAction({
+      command: process.execPath,
+      args: ["-e", "process.stdout.write('ok')"],
+      injectEnv: "SGW_REQUESTER_SESSION_TOKEN"
+    });
+    const agentContext = { mcpClientName: "Codex", env: {} };
+
+    const first = await store.createRequest(secret.handle, action, "Codex requester session", agentContext);
+    expect(first.loginSessionId).toBe(requesterSession);
+    expect(first.state).toBe("pending");
+
+    const approved = approveThroughCli(first.id, args, approverSession);
+    expect(approved.state).toBe("approved");
+
+    const grant = (await store.listApprovalGrants()).find((item) => item.id === approved.approvalGrantId);
+    if (!grant) {
+      throw new Error("Expected the CLI approval to create a reusable grant.");
+    }
+    expect(grant).toMatchObject({
+      mode,
+      agentScope: "same-agent",
+      agentName: "Codex",
+      loginSessionId: requesterSession,
+      lastRequestId: first.id
+    });
+    if (expires) {
+      expect(Date.parse(grant.expiresAt!) - Date.parse(grant.updatedAt)).toBe(eightHoursMs);
+    } else {
+      expect(grant.expiresAt).toBeUndefined();
+    }
+
+    process.env.SGW_LOGIN_SESSION_ID = approverSession;
+    const fromApproverSession = await store.createRequest(secret.handle, action, "Codex approver session", agentContext);
+    expect(fromApproverSession.state).toBe("pending");
+    expect(fromApproverSession.approvalGrantId).toBeUndefined();
+
+    process.env.SGW_LOGIN_SESSION_ID = requesterSession;
+    const fromRequesterSession = await store.createRequest(secret.handle, action, "Codex requester retry", agentContext);
+    expect(fromRequesterSession.state).toBe("approved");
+    expect(fromRequesterSession.approvalSource).toBe("grant");
+    expect(fromRequesterSession.approvalGrantId).toBe(grant.id);
+  });
+});
+
+function approveThroughCli(requestId: string, choiceArgs: string[], loginSessionId: string) {
+  const output = execFileSync(process.execPath, [tsxCli, "src/cli.ts", "approve", requestId, ...choiceArgs], {
+    cwd: repoRoot,
+    env: { ...process.env, SGW_LOGIN_SESSION_ID: loginSessionId },
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"]
+  });
+  return JSON.parse(output) as {
+    id: string;
+    state: string;
+    approvalGrantId?: string;
+  };
+}

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -201,6 +201,7 @@ describe("CLI unknown-command behavior (end to end)", () => {
       SGW_HOME: home,
       SGW_RECOVERY_HOME: recoveryHome,
       CARGO_TARGET_DIR: cargoTarget,
+      SGW_AGENT_NAME: "Codex",
       SGW_MASTER_PASSPHRASE: "cli-policy-test-passphrase",
       SGW_DISABLE_KEYCHAIN: "1",
       SGW_DISABLE_ONEPASSWORD_BACKUP: "1"
@@ -281,6 +282,36 @@ describe("CLI unknown-command behavior (end to end)", () => {
       });
       expect(updated.expiresAt).toBeUndefined();
 
+      const anyCommand = JSON.parse(run([
+        "approval",
+        "policy",
+        "update",
+        "--id",
+        specific.id,
+        "--decision",
+        "allow",
+        "--any-command"
+      ]));
+      expect(anyCommand.conditions.commands).toEqual([]);
+      expect(anyCommand.conditions.resolvedCommands).toEqual([]);
+
+      let conflictingScopeError: { stderr?: string } | undefined;
+      try {
+        run([
+          "approval",
+          "policy",
+          "update",
+          "--id",
+          specific.id,
+          "--any-command",
+          "--command",
+          "aws"
+        ]);
+      } catch (error) {
+        conflictingScopeError = error as { stderr?: string };
+      }
+      expect(conflictingScopeError?.stderr).toContain("cannot be combined");
+
       const arranged = JSON.parse(run(["approval", "policy", "arrange"]));
       expect(arranged.reordered).toBeGreaterThan(0);
       expect(arranged.rules.map((rule: { id: string }) => rule.id)).toEqual([specific.id, broad.id]);
@@ -292,10 +323,152 @@ describe("CLI unknown-command behavior (end to end)", () => {
       expect(help).toContain("s-gw approval policy update --id POLICY_ID");
       expect(help).toContain("s-gw approval policy arrange");
       expect(help).toContain("--resolved-command /path/to/tool");
+      expect(help).toContain("--any-command");
+      expect(help).toContain("s-gw approve-policy REQUEST_ID");
+
+      const secret = JSON.parse(runCliSync([
+        "src/cli.ts",
+        "secret",
+        "add",
+        "--name",
+        "scoped CLI policy",
+        "--type",
+        "api-token",
+        "--value-stdin",
+        "--inject-env",
+        "SGW_CLI_SCOPED_POLICY",
+        "--allow-command",
+        process.execPath
+      ], {
+        cwd: repoRoot,
+        env,
+        input: "scoped-cli-policy-secret-value-123456789",
+        encoding: "utf8",
+        stdio: ["pipe", "pipe", "pipe"]
+      }));
+      const request = JSON.parse(run([
+        "request",
+        "env-command",
+        secret.handle,
+        "--command",
+        process.execPath,
+        "--inject-env",
+        "SGW_CLI_SCOPED_POLICY",
+        "--arg",
+        "--version"
+      ]));
+      expect(request.state).toBe("pending");
+
+      const policyApproval = JSON.parse(run(["approve-policy", request.id]));
+      expect(policyApproval.created).toBe(true);
+      expect(policyApproval.request).toMatchObject({
+        id: request.id,
+        state: "approved",
+        approvalSource: "policy"
+      });
+      expect(policyApproval.rule).toMatchObject({
+        decision: "allow",
+        conditions: {
+          handles: [secret.handle],
+          agents: ["codex"],
+          commands: [process.execPath],
+          resolvedCommands: [realpathSync.native(process.execPath)]
+        }
+      });
     } finally {
       await rm(home, { recursive: true, force: true });
       await rm(recoveryHome, { recursive: true, force: true });
       await rm(cargoTarget, { recursive: true, force: true });
+    }
+  }, 15_000);
+
+  it("keeps CLI add without --any-command fail-closed while explicit --any-command approves", async () => {
+    const home = await mkdtemp(path.join(os.tmpdir(), "sgw-cli-any-command-"));
+    const recoveryHome = `${home}-recovery`;
+    const env = {
+      ...process.env,
+      SGW_HOME: home,
+      SGW_RECOVERY_HOME: recoveryHome,
+      SGW_AGENT_NAME: "Codex",
+      SGW_MASTER_PASSPHRASE: "cli any-command test passphrase",
+      SGW_DISABLE_KEYCHAIN: "1",
+      SGW_DISABLE_ONEPASSWORD_BACKUP: "1"
+    };
+    const run = (args: string[], input?: string) => runCliSync(["src/cli.ts", ...args], {
+      cwd: repoRoot,
+      env,
+      input,
+      encoding: "utf8",
+      stdio: [input === undefined ? "ignore" : "pipe", "pipe", "pipe"]
+    });
+
+    try {
+      const secret = JSON.parse(run([
+        "secret",
+        "add",
+        "--name",
+        "CLI any-command scope",
+        "--type",
+        "api-token",
+        "--value-stdin",
+        "--inject-env",
+        "SGW_CLI_ANY_COMMAND",
+        "--allow-command",
+        process.execPath
+      ], "cli-any-command-secret-value-123456789"));
+      const policyArgs = [
+        "--decision",
+        "allow",
+        "--handle",
+        secret.handle,
+        "--agent",
+        "Codex",
+        "--action-kind",
+        "env_command"
+      ];
+      const incomplete = JSON.parse(run([
+        "approval",
+        "policy",
+        "add",
+        "--name",
+        "Incomplete command scope",
+        ...policyArgs
+      ]));
+      expect(incomplete.conditions).not.toHaveProperty("commands");
+      expect(incomplete.conditions).not.toHaveProperty("resolvedCommands");
+
+      const requestArgs = [
+        "request",
+        "env-command",
+        secret.handle,
+        "--command",
+        process.execPath,
+        "--inject-env",
+        "SGW_CLI_ANY_COMMAND",
+        "--arg",
+        "--version"
+      ];
+      expect(JSON.parse(run(requestArgs)).state).toBe("pending");
+
+      run(["approval", "policy", "disable", "--id", incomplete.id]);
+      const explicit = JSON.parse(run([
+        "approval",
+        "policy",
+        "add",
+        "--name",
+        "Explicit any command",
+        ...policyArgs,
+        "--any-command"
+      ]));
+      expect(explicit.conditions.commands).toEqual([]);
+      expect(explicit.conditions.resolvedCommands).toEqual([]);
+      expect(JSON.parse(run(requestArgs))).toMatchObject({
+        state: "approved",
+        approvalSource: "policy"
+      });
+    } finally {
+      await rm(home, { recursive: true, force: true });
+      await rm(recoveryHome, { recursive: true, force: true });
     }
   }, 15_000);
 

--- a/tests/console-server.test.ts
+++ b/tests/console-server.test.ts
@@ -540,6 +540,36 @@ describe("local console server", () => {
     expect(policies).toHaveLength(0);
   });
 
+  it("preserves omitted command scope and accepts an explicit Any command scope", async () => {
+    running = await startConsoleServer({ port: 0 });
+
+    const incomplete = await fetchJson("api/approval/policies", {
+      method: "POST",
+      body: {
+        name: "Legacy-style incomplete allow",
+        decision: "allow",
+        agents: ["Codex"],
+        actionKinds: ["env_command"]
+      }
+    });
+    expect(incomplete.conditions).not.toHaveProperty("commands");
+    expect(incomplete.conditions).not.toHaveProperty("resolvedCommands");
+
+    const anyCommand = await fetchJson("api/approval/policies", {
+      method: "POST",
+      body: {
+        name: "Codex Any command",
+        decision: "allow",
+        agents: ["Codex"],
+        actionKinds: ["env_command"],
+        commands: [],
+        resolvedCommands: []
+      }
+    });
+    expect(anyCommand.conditions.commands).toEqual([]);
+    expect(anyCommand.conditions.resolvedCommands).toEqual([]);
+  });
+
   it("rejects malformed policy constraints without widening an existing rule", async () => {
     running = await startConsoleServer({ port: 0 });
     const created = await fetchJson("api/approval/policies", {

--- a/tests/console-ui-source.test.ts
+++ b/tests/console-ui-source.test.ts
@@ -181,6 +181,20 @@ describe("React console source contracts", () => {
     expect(store).toContain("exactBindingsWouldConflict");
   });
 
+  it("makes Any command policy scope explicit and identifies earlier winning rules", async () => {
+    const app = await readFile(path.join(repoRoot, "src/console-ui/src/App.tsx"), "utf8");
+
+    expect(app).toContain("empty Commands and Resolved executables means any command already permitted by the credential");
+    expect(app).toContain("Any credential-permitted command");
+    expect(app).toContain("This legacy rule is not an Any command rule yet");
+    expect(app).toContain("confirmAnyCommandConversion");
+    expect(app).toContain("commands: form.commands");
+    expect(app).toContain("resolvedCommands: form.resolvedCommands");
+    expect(app).toContain("First matching rule:");
+    expect(app).toContain("data-policy-first-match");
+    expect(app).toContain("named command without a pinned executable never runs automatically");
+  });
+
   it("shows policy details without replacing hardened policy evaluation", async () => {
     const [app, policyOrder] = await Promise.all([
       readFile(path.join(repoRoot, "src/console-ui/src/App.tsx"), "utf8"),

--- a/tests/native-command-surface.test.ts
+++ b/tests/native-command-surface.test.ts
@@ -97,14 +97,27 @@ describe("native command and policy surface", () => {
   });
 
   it("keeps policy templates and request matching visible in the native app", async () => {
-    const policies = await source("Views/PoliciesView.swift");
+    const [policies, settings, models] = await Promise.all([
+      source("Views/PoliciesView.swift"),
+      source("Views/SettingsView.swift"),
+      source("Models/Models.swift")
+    ]);
 
     expect(policies).toContain("policyTemplatesPanel");
     expect(policies).toContain("policyTestPanel");
     expect(policies).toContain("Always ask for high-risk credentials");
     expect(policies).toContain("Always ask for SSH sessions");
     expect(policies).toContain("Allow Codex for selected credential");
+    expect(policies).toContain('actionKind: "env_command"');
+    expect(policies).toContain("any command already permitted by one selected credential");
     expect(policies).toContain("matchingRules(for request");
     expect(policies).toContain("matchesString");
+    expect(policies).toContain("First match · wins");
+    expect(policies).toContain("Only the first matching rule applies");
+    expect(policies).toContain("conditions.allowsAnyEnvironmentCommand");
+    expect(settings).toContain("Leave both fields empty to match any command already permitted by the credential");
+    expect(settings).toContain("A named command without a pinned executable never runs automatically");
+    expect(models).toContain("var allowsAnyEnvironmentCommand: Bool");
+    expect(await source("App/AppState.swift")).toContain('args.append("--any-command")');
   });
 });

--- a/tests/native-menubar.test.ts
+++ b/tests/native-menubar.test.ts
@@ -88,6 +88,9 @@ describe("menu-bar helper approval surface contract", () => {
     expect(source).not.toContain(".frame(width: 448, height: 510)");
     expect(source).toContain('Button("Allow 8 hours")');
     expect(source).toContain('Button("Once")');
+    expect(source).toContain('Button("Always allow this request scope")');
+    expect(source).toContain("actions.approvePolicy(request.id)");
+    expect(source).toContain("let approvePolicy: (String) -> Void");
     expect(source).toContain("confirmUnlimitedForAll = true");
     expect(source).toContain("Allow every agent without an expiry?");
   });

--- a/tests/native-window-drag-runtime.test.ts
+++ b/tests/native-window-drag-runtime.test.ts
@@ -1,0 +1,52 @@
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const root = process.cwd();
+const productionSource = path.join(root, "native/macos-app/Sources/SgwMac/Views/ConsoleWebAppView.swift");
+const testSource = path.join(root, "native/macos-app/Tests/WindowDragTests.swift");
+
+function hasSwift(): boolean {
+  if (process.platform !== "darwin") return false;
+  return spawnSync("swiftc", ["--version"], { stdio: "ignore" }).status === 0;
+}
+
+const describeNative = hasSwift() && existsSync(productionSource) && existsSync(testSource)
+  ? describe
+  : describe.skip;
+
+let workDir = "";
+let binary = "";
+
+describeNative("native macOS window dragging (real WebKit surface)", () => {
+  beforeAll(async () => {
+    workDir = await mkdtemp(path.join(os.tmpdir(), "sgw-window-drag-test-"));
+    binary = path.join(workDir, "window-drag-tests");
+    const compile = spawnSync(
+      "swiftc",
+      ["-O", "-parse-as-library", productionSource, testSource, "-o", binary],
+      { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }
+    );
+    if (compile.status !== 0) {
+      throw new Error(`swiftc failed:\n${compile.stderr || compile.stdout}`);
+    }
+  }, 180_000);
+
+  afterAll(async () => {
+    if (workDir) await rm(workDir, { recursive: true, force: true });
+  });
+
+  it("drags blank title chrome without stealing interactive clicks", () => {
+    const run = spawnSync(binary, [], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: 30_000
+    });
+    const output = `${run.stdout || ""}${run.stderr || ""}`;
+    expect(output, output).toContain("WINDOW_DRAG_TESTS_OK");
+    expect(run.status).toBe(0);
+  }, 30_000);
+});

--- a/tests/native-window-drag.test.ts
+++ b/tests/native-window-drag.test.ts
@@ -1,0 +1,46 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const root = process.cwd();
+
+describe("native macOS window drag surface", () => {
+  it("hands only marked web chrome to AppKit window dragging", async () => {
+    const [webView, app, css] = await Promise.all([
+      readFile(path.join(root, "native/macos-app/Sources/SgwMac/Views/ConsoleWebAppView.swift"), "utf8"),
+      readFile(path.join(root, "src/console-ui/src/App.tsx"), "utf8"),
+      readFile(path.join(root, "src/console-ui/src/index.css"), "utf8")
+    ]);
+
+    expect(webView).toContain("final class ConsoleWebView: WKWebView");
+    expect(webView).toContain("override func mouseDown(with event: NSEvent)");
+    expect(webView).toContain("window.performDrag(with: event)");
+    expect(webView).toContain("super.mouseDown(with: event)");
+    expect(webView).toContain('dragSurfaceSelector = "[data-sgw-window-drag]"');
+    expect(webView).toContain("interactiveSelector");
+    expect(webView).toContain("if (!hit || hit.closest(\\(Self.javaScriptString(Self.interactiveSelector)))) return false;");
+    expect(webView).toContain("return Boolean(hit.closest(\\(Self.javaScriptString(Self.dragSurfaceSelector))));");
+    expect(webView).toContain("[data-sgw-window-no-drag]");
+    for (const interactive of ["button", " a,", "input", "select", "textarea", "summary", "[role='button']", "[role='link']"]) {
+      expect(webView).toContain(interactive);
+    }
+    expect(webView).toContain("document.elementFromPoint");
+    expect(webView).toContain("let clientY = isFlipped ? point.y : bounds.height - point.y");
+    expect(webView).toContain("guard clientY >= 0, clientY <= 84");
+    expect(webView).toContain("document.elementFromPoint(\\(point.x), \\(clientY))");
+    expect(webView).toContain("Date(timeIntervalSinceNow: 0.1)");
+    expect(webView).toMatch(/while Date\(\) < deadline[\s\S]+return false/u);
+    expect(webView).toContain("return false");
+    expect(webView).toContain("options: [.fragmentsAllowed]");
+
+    expect(app).toContain('className="sgw-native-drag-surface" data-sgw-window-drag');
+    expect(app).toContain('className="sgw-sidebar-titlebar');
+    expect(app).toContain("data-sgw-window-drag>");
+    expect(app).not.toMatch(/<button[^>]*data-sgw-window-drag/u);
+    expect(css).toContain(".sgw-native-drag-surface {");
+    expect(css).toContain("position: absolute;");
+    expect(css).toContain("z-index: 40;");
+    expect(css).toContain(".sgw-native-actions {");
+    expect(css).toContain("z-index: 50;");
+  });
+});

--- a/tests/policy-order.test.ts
+++ b/tests/policy-order.test.ts
@@ -3,7 +3,8 @@ import {
   approvalPolicyRuleCovers,
   arrangeApprovalPolicyRules,
   compareApprovalPolicyRules,
-  findShadowingPolicyRule
+  findShadowingPolicyRule,
+  policyAllowsAnyEnvCommand
 } from "../src/policy-order.js";
 import type { ApprovalPolicyRule } from "../src/types.js";
 
@@ -27,7 +28,7 @@ function rule(
 
 describe("approval policy ordering", () => {
   it("recognizes semantic containment without treating case-sensitive commands as equivalent", () => {
-    const broad = rule("broad", 10, { agents: ["codex"], minSeverity: "low" });
+    const broad = rule("broad", 10, { agents: ["codex"], minSeverity: "low" }, "ask");
     const narrow = rule("narrow", 20, { agents: ["codex"], commands: ["/usr/bin/aws"], minSeverity: "high" });
     const differentCommand = rule("different-command", 20, { agents: ["codex"], commands: ["/usr/bin/AWS"], minSeverity: "high" });
 
@@ -75,6 +76,20 @@ describe("approval policy ordering", () => {
     expect(approvalPolicyRuleCovers(arm, intel)).toBe(false);
   });
 
+  it("distinguishes an explicit any-command allow from an unscoped legacy allow", () => {
+    const anyCommand = rule("any-command", 10, { commands: [], resolvedCommands: [] });
+    const legacy = rule("legacy", 20, {});
+    const pinned = rule("pinned", 30, {
+      commands: ["aws"],
+      resolvedCommands: ["/opt/homebrew/bin/aws"]
+    });
+
+    expect(policyAllowsAnyEnvCommand(anyCommand.conditions)).toBe(true);
+    expect(policyAllowsAnyEnvCommand(legacy.conditions)).toBe(false);
+    expect(approvalPolicyRuleCovers(anyCommand, pinned)).toBe(true);
+    expect(approvalPolicyRuleCovers(legacy, pinned)).toBe(false);
+  });
+
   it("preserves the established last-updated-first order for equal priorities", () => {
     const older = { ...rule("older", 100, {}), updatedAt: "2026-07-16T00:00:00Z" };
     const newer = { ...rule("newer", 100, {}), updatedAt: "2026-07-16T00:01:00Z" };
@@ -113,7 +128,7 @@ describe("approval policy ordering", () => {
   });
 
   it("reports only an earlier live covering rule as shadowing", () => {
-    const broad = rule("broad", 10, { agents: ["codex"] });
+    const broad = rule("broad", 10, { agents: ["codex"] }, "ask");
     const narrow = rule("narrow", 20, { agents: ["codex"], commands: ["/usr/bin/aws"] });
     const expired = { ...broad, id: "expired", priority: 5, expiresAt: "2026-07-15T00:00:00Z" };
 

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -217,6 +217,75 @@ describe("SecretStore", () => {
     expect(request.state).toBe("pending");
   });
 
+  it("treats explicit empty command conditions as an allow wildcard", async () => {
+    const store = new SecretStore();
+    const record = await store.addSecret({
+      name: "any command policy token",
+      type: "api-token",
+      value: fakeOpenAiToken("any_command_policy"),
+      policy: {
+        injectEnv: "ANY_COMMAND_POLICY_TOKEN",
+        allowedCommands: [process.execPath]
+      }
+    });
+    const rule = await store.addApprovalPolicyRule({
+      name: "Allow Codex any credential-permitted command",
+      decision: "allow",
+      conditions: {
+        handles: [record.handle],
+        agents: ["Codex"],
+        actionKinds: ["env_command"],
+        commands: [],
+        resolvedCommands: []
+      }
+    });
+
+    const request = await store.createRequest(record.handle, buildEnvCommandAction({
+      command: process.execPath,
+      args: ["-e", "0"],
+      injectEnv: "ANY_COMMAND_POLICY_TOKEN"
+    }), "Codex any command policy request");
+
+    expect(rule.conditions.commands).toEqual([]);
+    expect(rule.conditions.resolvedCommands).toEqual([]);
+    expect(request.state).toBe("approved");
+    expect(request.approvalPolicyRuleId).toBe(rule.id);
+  });
+
+  it("does not broaden an allow rule that omits its command scope", async () => {
+    const store = new SecretStore();
+    const record = await store.addSecret({
+      name: "omitted command scope token",
+      type: "api-token",
+      value: fakeOpenAiToken("omitted_command_scope"),
+      policy: {
+        injectEnv: "OMITTED_COMMAND_SCOPE_TOKEN",
+        allowedCommands: [process.execPath]
+      }
+    });
+    const rule = await store.addApprovalPolicyRule({
+      name: "Legacy allow without a command scope",
+      decision: "allow",
+      conditions: {
+        handles: [record.handle],
+        agents: ["Codex"],
+        actionKinds: ["env_command"]
+      }
+    });
+    await store.updateApprovalPolicyRule(rule.id, { name: "Renamed legacy allow" });
+
+    const saved = (await store.listApprovalPolicyRules()).find((item) => item.id === rule.id);
+    expect(saved?.conditions).not.toHaveProperty("commands");
+    expect(saved?.conditions).not.toHaveProperty("resolvedCommands");
+
+    const request = await store.createRequest(record.handle, buildEnvCommandAction({
+      command: process.execPath,
+      args: ["-e", "0"],
+      injectEnv: "OMITTED_COMMAND_SCOPE_TOKEN"
+    }), "Codex omitted command scope request");
+    expect(request.state).toBe("pending");
+  });
+
   it("does not reuse a pinned allow policy after a bare command resolves elsewhere", async () => {
     const firstBin = path.join(tmpHome, "first-bin");
     const secondBin = path.join(tmpHome, "second-bin");


### PR DESCRIPTION
## Summary

- make Any command an explicit policy choice while legacy or incomplete command scopes remain fail-closed
- show first-match policy precedence and add durable request-scoped approval from the CLI and macOS prompt
- bind timed and login approvals to the requesting session
- restore dragging from blank macOS title chrome without consuming clicks on controls

## Verification

- npm run verify (51 test files passed, 510 tests passed, 31 skipped)
- targeted CLI regression proves add without --any-command stays pending and explicit --any-command approves
- native WebKit drag runtime tests and installer validation included in the full suite
- git diff --check

This is intended for the v0.1.21 release.