### PR TITLE
Prepare 0.1.21 release

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "s-gw",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "description": "Local s-gw plugin that lets coding agents use typed secret handles without receiving raw credentials.",
   "author": {
     "name": "Barry Yuan"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,14 @@ Notable changes to s-gw are documented here. The project follows [Semantic Versi
 
 ## Unreleased
 
+## 0.1.21 - 2026-08-12
+
 ### Fixed
 
 - macOS update notices now carry verified installer metadata from the menu helper, enrich older partial notices automatically, and keep an enabled release-page fallback instead of showing a disabled Upgrade button.
 - Explicit Any command allow policies now authorize credential-permitted environment commands, while incomplete legacy rules remain fail-closed until they are deliberately converted. Policy previews identify the earlier winning rule and its priority.
 - The macOS approval helper can create a persistent request-scoped allow policy directly from the popup, alongside one-time and session-based grants.
+- Timed and login-session approvals now stay bound to the requesting login session when the native helper approves them from a separate process.
 - The macOS app can be moved by dragging blank native title chrome without stealing clicks from buttons and other interactive controls.
 
 ## 0.1.20 - 2026-08-12
@@ -26,7 +29,6 @@ Notable changes to s-gw are documented here. The project follows [Semantic Versi
 
 ### Fixed
 
-- Timed and login-session approvals now stay bound to the requesting login session when the native helper approves them from a separate process.
 - The macOS app now restarts installed-but-unloaded local services when it opens, and LaunchAgent setup no longer issues a redundant blocking `kickstart` after loading a `RunAtLoad` job.
 - Windows agent integration updates now retry transient filesystem contention while another process releases the integration lock.
 - Windows desktop refreshes now hide packaged Node.js and credential-helper consoles instead of flashing command windows during background polling.

--- a/native/desktop-app/Cargo.lock
+++ b/native/desktop-app/Cargo.lock
@@ -3251,7 +3251,7 @@ checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "s-gw-desktop"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "eframe",
  "egui",

--- a/native/desktop-app/Cargo.toml
+++ b/native/desktop-app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s-gw-desktop"
-version = "0.1.20"
+version = "0.1.21"
 description = "Native Windows and Linux desktop application for s-gw"
 authors = ["Barry Yuan"]
 edition = "2021"

--- a/native/desktop-app/src/app.rs
+++ b/native/desktop-app/src/app.rs
@@ -1866,7 +1866,7 @@ mod tests {
     fn fixture() -> DesktopSnapshot {
         DesktopSnapshot {
             status: StatusSnapshot {
-                version: Some("0.1.20".into()),
+                version: Some("0.1.21".into()),
                 ready: Some(true),
                 readiness: Readiness {
                     summary: "Ready for local credential requests.".into(),

--- a/native/macos-app/Sources/SgwMac/Services/UpdateChecker.swift
+++ b/native/macos-app/Sources/SgwMac/Services/UpdateChecker.swift
@@ -73,7 +73,7 @@ actor UpdateChecker: UpdateChecking {
     private let cli = CLIRunner()
 
     static var currentVersion: String {
-        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.1.20"
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.1.21"
     }
 
     static var usesSelfContainedRuntime: Bool {

--- a/native/macos-app/Tests/AppStateGuardTests.swift
+++ b/native/macos-app/Tests/AppStateGuardTests.swift
@@ -151,7 +151,7 @@ fileprivate struct Scratch {
         exit 0
         ;;
       status)
-        print -- '{"version":"0.1.20","packageRoot":"/tmp/sgw","ready":true,"readiness":{"ok":true,"summary":"ready","blockers":[]},"cliPath":{"path":"/tmp/cli.js","exists":true},"mcpPath":{"path":"/tmp/mcp.js","exists":true},"keychainHelperPath":{"path":"/tmp/helper","exists":true},"menuBarAppPath":{"path":"/tmp/mb.app","exists":true},"menuBarBinaryPath":{"path":"/tmp/mb","exists":true},"storePath":"/tmp/store.json","consoleUrl":"http://127.0.0.1:8718/","unlock":{"activeSource":"env"},"launchAgents":{"console":{"label":"c","plistPath":"/tmp/c.plist","installed":true,"loaded":true},"menuBar":{"label":"m","plistPath":"/tmp/m.plist","installed":true,"loaded":true}}}'
+        print -- '{"version":"0.1.21","packageRoot":"/tmp/sgw","ready":true,"readiness":{"ok":true,"summary":"ready","blockers":[]},"cliPath":{"path":"/tmp/cli.js","exists":true},"mcpPath":{"path":"/tmp/mcp.js","exists":true},"keychainHelperPath":{"path":"/tmp/helper","exists":true},"menuBarAppPath":{"path":"/tmp/mb.app","exists":true},"menuBarBinaryPath":{"path":"/tmp/mb","exists":true},"storePath":"/tmp/store.json","consoleUrl":"http://127.0.0.1:8718/","unlock":{"activeSource":"env"},"launchAgents":{"console":{"label":"c","plistPath":"/tmp/c.plist","installed":true,"loaded":true},"menuBar":{"label":"m","plistPath":"/tmp/m.plist","installed":true,"loaded":true}}}'
         exit 0
         ;;
       app)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@s-gw/s-gw",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@s-gw/s-gw",
-      "version": "0.1.20",
+      "version": "0.1.21",
       "license": "Apache-2.0",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-gw/s-gw",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "mcpName": "io.github.sgateway/s-gw",
   "description": "Local credential control for AI coding agents.",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -15,13 +15,13 @@
     "url": "https://github.com/sgateway/s-gw",
     "source": "github"
   },
-  "version": "0.1.20",
+  "version": "0.1.21",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@s-gw/s-gw",
-      "version": "0.1.20",
+      "version": "0.1.21",
       "runtimeHint": "npx",
       "runtimeArguments": [
         {

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const CURRENT_VERSION = "0.1.20";
+export const CURRENT_VERSION = "0.1.21";


### PR DESCRIPTION
## Summary

- bump every public package, plugin, native app, and registry version surface to 0.1.21
- publish the updater, approval-policy, requester-session, and macOS window-dragging fixes in the changelog
- align with the already merged and tagged private core v0.1.21

## Verification

- SGW_RUST_CORE_DIR=<private 0.1.21 checkout> SGW_REQUIRE_RUST_CORE=1 npm run verify (51 files passed; 512 tests passed, 29 skipped)
- SGW_RUST_CORE_DIR=<private 0.1.21 checkout> SGW_REQUIRE_RUST_CORE=1 npm run build:installers
- installer validation verified the self-contained DMG, current/legacy npm tarballs, and checksums
- Swift build, Cargo metadata, version alignment, and git diff --check

Release target: immutable v0.1.21, unsigned macOS distribution.